### PR TITLE
v0.9.0-beta.20: Metadata Embedding (Beta)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ ENV/
 # IDE
 .idea/
 .vscode/
+.cursor/
 *.swp
 *.swo
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.20] - 2025-12-14
+
+### Added
+- **Metadata Embedding (Beta)** - Write verified metadata directly into audio file tags
+  - New "Metadata Embedding" toggle in Settings > Behavior
+  - Supported formats: MP3 (ID3v2), M4B/M4A/AAC (MP4 atoms), FLAC/Ogg/Opus (Vorbis comments), WMA (ASF)
+  - Tags written: title, album (book title), artist/albumartist (author), year
+  - Custom tags: SERIES, SERIESNUMBER, NARRATOR, EDITION, VARIANT
+  - Optional sidecar backup: `.library-manager.tags.json` stores original tags before modification
+  - Runs automatically when fixes are applied (auto-fix or manual Apply Fix)
+  - New `audio_tagging.py` module with format-specific tagging functions
+  - Test suite: `test-env/test-audio-tagging.py`
+
+### Changed
+- **History table expanded** - Now stores series/narrator/year/edition/variant metadata
+  - Enables metadata embedding when applying pending fixes
+  - Tracks embedding status (ok/error) and error messages
+
+---
+
 ## [0.9.0-beta.19] - 2025-12-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,261 @@
+# CLAUDE.md
+
+This file is guidance for AI assistants (Claude Code, Cursor agents, etc.) contributing to **Library Manager**.
+
+## Project overview
+
+- **What this is**: A single-process web app that scans audiobook/ebook libraries, proposes safe renames, and tracks history.
+- **Tech**: Python + Flask (Jinja templates in `templates/`, static assets in `static/`), SQLite for persistence.
+- **Main entrypoint**: `app.py` (monolithic by design; avoid “framework-izing” unless explicitly asked).
+
+## Repository layout (high-signal)
+
+- `app.py`: main Flask app, worker thread, scanning/AI logic, API routes.
+- `abs_client.py`: Audiobookshelf API client.
+- `templates/`: server-rendered UI.
+- `static/`: UI assets.
+- `docs/`: user-facing documentation.
+- `test-env/`: integration tests (container-based) + test library generators.
+- `Dockerfile`, `docker-compose.yml`: container setup.
+
+## Using Context7 for up-to-date library docs (MCP)
+
+When you’re touching code that depends on an external library/API (Python packages, vendor APIs, SDKs), **do not rely on memory** if version-specific behavior matters. Use the Context7 MCP server to pull current docs/snippets.
+
+Workflow:
+
+- **Resolve the library ID**: use Context7 `resolve-library-id` for the package/framework name.
+- **Fetch docs**: use Context7 `get-library-docs` with the resolved ID.
+  - Use `mode='code'` for API references/examples.
+  - Use `mode='info'` for conceptual/architecture pages.
+
+Typical times to use this:
+
+- Updating/adding integration with a third-party API or SDK
+- Fixing subtle behavior differences across versions
+- Writing new code that uses unfamiliar library APIs
+  
+If the change is fully internal (pure refactor, local logic), skip Context7.
+
+## How to run
+
+### Local (Python)
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python app.py
+```
+
+- App listens on **`http://localhost:5757`** by default.
+- Override port with `PORT=XXXX`.
+
+### Docker
+
+- Persistent data is stored in the container at **`/data`** (see `DATA_DIR` below).
+- Your audiobook library must be mounted into the container (commonly `/audiobooks`).
+
+```bash
+docker run -d \
+  --name library-manager \
+  -p 5757:5757 \
+  -v /path/to/audiobooks:/audiobooks \
+  -v library-manager-data:/data \
+  ghcr.io/deucebucket/library-manager:latest
+```
+
+Or use `docker-compose.yml` (edit the host audiobook mount).
+
+## Data / config model (do not guess)
+
+`app.py` uses these paths:
+
+- **`DATA_DIR`**: `Path(os.environ.get('DATA_DIR', BASE_DIR))`
+  - In Docker, `DATA_DIR` is set to `/data` (see `Dockerfile`).
+- **SQLite**: `${DATA_DIR}/library.db`
+- **Config**: `${DATA_DIR}/config.json`
+- **Secrets**: `${DATA_DIR}/secrets.json` (API keys)
+
+On startup (`__main__`):
+
+- `init_config()` creates default `config.json` and `secrets.json` if missing.
+- `init_db()` creates/migrates tables.
+- A background worker starts via `start_worker()`.
+
+### Security rules
+
+- `secrets.json` is gitignored; **never commit secrets**.
+- Don’t log or echo API keys.
+- Avoid introducing any new hardcoded paths or personal machine references.
+
+## Testing
+
+There’s no unit test framework wired in; the project relies on an **integration test harness**.
+
+### Integration tests (container-based)
+
+```bash
+./test-env/run-integration-tests.sh
+# or rebuild the ~2GB test library
+./test-env/run-integration-tests.sh --rebuild
+```
+
+Notes:
+
+- The harness uses **`podman`** by default. If you don’t have podman, adapt locally to docker (don’t commit that change unless requested).
+- Tests validate the container can boot, UI returns 200, and core API endpoints respond.
+
+### Minimal local sanity checks
+
+When you change Python code, at least ensure it still parses:
+
+```bash
+python -m py_compile app.py abs_client.py
+```
+
+## Coding conventions (match existing patterns)
+
+- Prefer **small, surgical edits**. `app.py` is large; keep changes localized.
+- Use **4-space indentation**, straightforward imperative style.
+- Type hints are used in some modules (e.g., `abs_client.py`) but not everywhere; follow local style.
+- Keep dependencies minimal (current `requirements.txt` is intentionally small).
+- For UI, modify Jinja templates in `templates/` and keep changes backwards-compatible.
+
+## Behavior & safety conventions (core project intent)
+
+This project is “safety-first” about renames:
+
+- Avoid auto-applying anything that could be wrong.
+- Be very cautious about changing the AI prompts/rules that protect against false author swaps.
+- Don’t weaken heuristics that prevent destructive renames.
+
+If you touch any rename logic, ensure:
+
+- We don’t overwrite existing folders/files.
+- We can undo operations (history/undo flow stays intact).
+- Docker-mounted paths continue to work (container only sees mounted paths).
+
+## Best-practice extensions (match existing patterns)
+
+These are “logical extensions” of the patterns already in `app.py`. Follow them to avoid subtle regressions.
+
+### File/rename safety invariants (never break these)
+
+- **Library boundary**: any filesystem operation must remain inside one of the configured `library_paths`.
+  - Use the existing pattern: `Path(...).resolve().relative_to(lib_path)` to prove it’s inside.
+- **Path construction**: build destinations through `build_new_path()` and its sanitizers.
+  - Don’t hand-roll new paths; it already blocks traversal (`..`), strips invalid chars, enforces minimum depth, and prevents escaping the library root.
+- **No merges**: if a destination folder exists and contains files, treat it as a conflict (often a different narrator/variant).
+  - Prefer blocking with a clear error message rather than “helpfully” merging.
+- **Depth checks**: avoid “too shallow” destinations (e.g., dumping at author level or library root).
+- **File vs folder moves**: preserve the existing distinction:
+  - Loose files/ebooks move into a folder + keep original filename.
+  - Folder fixes move the folder.
+- **History-first mindset**: for anything not obviously safe, record `pending_fix` and require manual approval.
+
+### Queue/worker patterns (keep it predictable)
+
+- **Config is live**: the worker reloads config each batch so changes take effect immediately—don’t cache config globally.
+- **Rate limits are real**: keep API calls bounded via `max_requests_per_hour` and batch delays; don’t add loops that multiply calls silently.
+- **Batching**: prefer processing in small batches (`batch_size`) and keeping DB transactions short.
+- **Safety gates before processing**: preserve the existing “series folder / multi-book” detection that blocks dangerous auto-processing.
+
+### SQLite + migrations (do the simple thing consistently)
+
+- Use `get_db()` (WAL + timeout) for all DB access; keep connections short-lived.
+- Close connections on all paths (success/early return/error).
+- For lightweight migrations, follow the existing pattern:
+  - `try: ALTER TABLE ... except: pass`
+- Handle duplicates explicitly (`sqlite3.IntegrityError`) rather than letting the app crash.
+
+### Adding/changing settings (end-to-end, not half-done)
+
+When introducing a new setting or changing defaults, update all the “touch points”:
+
+- `DEFAULT_CONFIG` (and `DEFAULT_SECRETS` if it’s a secret)
+- Settings UI (`templates/settings.html`) so it’s user-configurable
+- `load_config()` / `save_config()` semantics (secrets must stay out of `config.json`)
+- Docs framework: update `CHANGELOG.md` and `README.md` when user-facing (see the framework below)
+
+### API endpoints (keep responses boring and safe)
+
+- Prefer returning JSON shaped like:
+  - `{ "success": true, ... }` or `{ "success": false, "error": "..." }`
+- Never return secrets (API keys) or host-specific paths in API responses.
+- If an endpoint can trigger heavy work, keep it asynchronous or bounded (use queue + worker patterns).
+
+### Prompt / AI guardrails (don’t degrade safety)
+
+- Treat prompt edits as “high-risk changes”.
+- Keep the existing “trust the input author” and garbage-match filtering philosophy intact.
+- If you must adjust prompts/thresholds, add/extend test library cases or integration checks that cover the failure mode you’re addressing.
+
+## Versioning + changelog (required for user-facing fixes)
+
+The project uses a beta version string in `app.py`:
+
+- `APP_VERSION = "0.9.0-beta.N"`
+
+### Documentation + release notes framework (follow this every time)
+
+When you change behavior, **treat docs as part of the feature**. Use this framework:
+
+#### 1) Decide the “impact level”
+
+- **User-facing**: Anything a user can notice (UI/UX, rename behavior, scanners, AI/provider behavior, new endpoints, settings, Docker behavior, installation/config).
+- **Developer-facing**: Dev scripts, tests, CI, refactors that change how contributors work.
+- **Internal-only**: Pure refactor with no observable behavior change.
+
+#### 2) Update the right files
+
+**Always update `CHANGELOG.md` for:**
+- Any **user-facing** change (fix/improvement/feature/breaking change).
+- Any **developer-facing** change that impacts running/testing/releasing.
+
+**Update `README.md` when:**
+- You changed **how to install/run** (Python/Docker/compose/env vars/ports/volumes).
+- You added/changed a **headline feature** or a key workflow users rely on.
+- You added/changed **core config knobs** (new settings, renamed settings, defaults that matter).
+- You added/changed **API endpoints** documented in the README’s API table.
+
+**Optional docs (`docs/`)**:
+- If a change is too detailed for the README, update/add the appropriate file in `docs/` and link it from the README if needed.
+
+#### 3) What to write (don’t be vague)
+
+- **Changelog entries** should answer: what changed, who it affects, and any migration steps.
+  - Prefer bullets under `Added / Changed / Improved / Fixed`.
+  - Call out **breaking changes** explicitly and how to recover.
+- **README updates** should be “front door” accurate:
+  - Commands should be copy/pasteable.
+  - Examples should use generic paths and never include secrets.
+  - If you add a setting, mention what it does and where users configure it (web UI Settings).
+
+#### 4) Order of operations for releases
+
+When you ship a user-facing fix/feature:
+
+- Bump `APP_VERSION` (increment the beta number).
+- Add an entry to `CHANGELOG.md` for the new version.
+- Ensure `README.md` is accurate for any new/changed user workflow (see rules above).
+
+## GitHub automation (issue-bot)
+
+There’s an automation script in `scripts/auto-fix-issues.sh` that can launch Claude Code with repo-specific guidance (`scripts/issue-bot-prompt.md`).
+
+If you’re running it locally:
+
+- Requires `gh`, `jq`, and `claude` on PATH (optionally `tmux`).
+- It is designed to act like the maintainer and may push to `main`.
+
+**Do not run automated issue workflows unless explicitly asked.**
+
+## CI/CD
+
+- GitHub Actions builds and publishes a multi-arch image to GHCR (see `.github/workflows/docker-publish.yml`).
+
+## When in doubt
+
+- Prefer aligning with existing user docs in `docs/` and the behavior implied by `README.md`.
+- If you can’t prove a change is safe, make it opt-in or require manual approval.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.19-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.20-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE)
 
@@ -258,7 +258,7 @@ python app.py  # Runs on http://localhost:5757
 Pull requests welcome! Ideas:
 - [ ] Ollama/local LLM support
 - [ ] Cover art fetching
-- [ ] Metadata embedding
+- [x] Metadata embedding (added in v0.9.0-beta.20)
 - [ ] Movie/music library support
 
 ---

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.19"
+APP_VERSION = "0.9.0-beta.20"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:
@@ -36,6 +36,7 @@ import re
 from pathlib import Path
 from datetime import datetime, timedelta
 from flask import Flask, render_template, request, jsonify, redirect, url_for, send_file
+from audio_tagging import embed_tags_for_path, build_metadata_for_embedding
 
 
 # ============== SEARCH QUEUE / PROGRESS TRACKING ==============
@@ -390,7 +391,11 @@ DEFAULT_CONFIG = {
     "ebook_library_mode": "merge",  # "merge" = same folder as audiobooks, "separate" = own library
     "update_channel": "beta",  # "stable", "beta", or "nightly"
     "naming_format": "author/title",  # "author/title", "author - title", "custom"
-    "custom_naming_template": "{author}/{title}"  # Custom template with {author}, {title}, {series}, etc.
+    "custom_naming_template": "{author}/{title}",  # Custom template with {author}, {title}, {series}, etc.
+    # Metadata embedding settings
+    "metadata_embedding_enabled": False,  # Embed tags into audio files when fixes are applied
+    "metadata_embedding_overwrite_managed": True,  # Overwrite managed fields (title/author/series/etc)
+    "metadata_embedding_backup_sidecar": True  # Create .library-manager.tags.json backup before modifying
 }
 
 DEFAULT_SECRETS = {
@@ -471,6 +476,23 @@ def init_db():
         c.execute('ALTER TABLE history ADD COLUMN error_message TEXT')
     except:
         pass
+
+    # Add metadata columns for embedding (migration)
+    metadata_columns = [
+        'new_narrator TEXT',
+        'new_series TEXT',
+        'new_series_num TEXT',
+        'new_year TEXT',
+        'new_edition TEXT',
+        'new_variant TEXT',
+        'embed_status TEXT',
+        'embed_error TEXT'
+    ]
+    for col_def in metadata_columns:
+        try:
+            c.execute(f'ALTER TABLE history ADD COLUMN {col_def}')
+        except:
+            pass  # Column already exists
 
     # Stats table - daily stats
     c.execute('''CREATE TABLE IF NOT EXISTS stats (
@@ -3807,11 +3829,14 @@ def process_queue(config, limit=None):
                         # AI is uncertain - block the change
                         logger.warning(f"BLOCKED (uncertain): {row['current_author']} -> {new_author}")
                         # Record as pending_fix for manual review
-                        c.execute('''INSERT INTO history (book_id, old_author, old_title, new_author, new_title, old_path, new_path, status, error_message)
-                                     VALUES (?, ?, ?, ?, ?, ?, ?, 'pending_fix', ?)''',
+                        c.execute('''INSERT INTO history (book_id, old_author, old_title, new_author, new_title, old_path, new_path, status, error_message,
+                                                          new_narrator, new_series, new_series_num, new_year, new_edition, new_variant)
+                                     VALUES (?, ?, ?, ?, ?, ?, ?, 'pending_fix', ?, ?, ?, ?, ?, ?, ?)''',
                                  (row['book_id'], row['current_author'], row['current_title'],
                                   new_author, new_title, str(old_path), str(new_path),
-                                  f"Uncertain: {verification.get('reasoning', 'needs review')}"))
+                                  f"Uncertain: {verification.get('reasoning', 'needs review')}",
+                                  new_narrator, new_series, str(new_series_num) if new_series_num else None,
+                                  str(new_year) if new_year else None, new_edition, new_variant))
                         c.execute('UPDATE books SET status = ? WHERE id = ?', ('pending_fix', row['book_id']))
                         c.execute('DELETE FROM queue WHERE id = ?', (row['queue_id'],))
                         processed += 1
@@ -3888,10 +3913,13 @@ def process_queue(config, limit=None):
                             else:
                                 # Couldn't resolve - mark as conflict
                                 logger.warning(f"CONFLICT: {new_path} exists - no unique distinguisher found")
-                                c.execute('''INSERT INTO history (book_id, old_author, old_title, new_author, new_title, old_path, new_path, status, error_message)
-                                             VALUES (?, ?, ?, ?, ?, ?, ?, 'error', 'Destination exists - could not resolve version conflict')''',
+                                c.execute('''INSERT INTO history (book_id, old_author, old_title, new_author, new_title, old_path, new_path, status, error_message,
+                                                                  new_narrator, new_series, new_series_num, new_year, new_edition, new_variant)
+                                             VALUES (?, ?, ?, ?, ?, ?, ?, 'error', 'Destination exists - could not resolve version conflict', ?, ?, ?, ?, ?, ?)''',
                                          (row['book_id'], row['current_author'], row['current_title'],
-                                          new_author, new_title, str(old_path), str(new_path)))
+                                          new_author, new_title, str(old_path), str(new_path),
+                                          new_narrator, new_series, str(new_series_num) if new_series_num else None,
+                                          str(new_year) if new_year else None, new_edition, new_variant))
                                 c.execute('UPDATE books SET status = ?, error_message = ? WHERE id = ?',
                                          ('conflict', 'Destination folder exists - multiple versions detected', row['book_id']))
                                 c.execute('DELETE FROM queue WHERE id = ?', (row['queue_id'],))
@@ -3928,10 +3956,14 @@ def process_queue(config, limit=None):
                     c.execute("DELETE FROM history WHERE book_id = ? AND status = 'pending_fix'", (row['book_id'],))
 
                     # Record in history
-                    c.execute('''INSERT INTO history (book_id, old_author, old_title, new_author, new_title, old_path, new_path, status)
-                                 VALUES (?, ?, ?, ?, ?, ?, ?, 'fixed')''',
+                    c.execute('''INSERT INTO history (book_id, old_author, old_title, new_author, new_title, old_path, new_path, status,
+                                                      new_narrator, new_series, new_series_num, new_year, new_edition, new_variant)
+                                 VALUES (?, ?, ?, ?, ?, ?, ?, 'fixed', ?, ?, ?, ?, ?, ?)''',
                              (row['book_id'], row['current_author'], row['current_title'],
-                              new_author, new_title, str(old_path), str(new_path)))
+                              new_author, new_title, str(old_path), str(new_path),
+                              new_narrator, new_series, str(new_series_num) if new_series_num else None,
+                              str(new_year) if new_year else None, new_edition, new_variant))
+                    history_id = c.lastrowid  # Capture the newly inserted history record ID
 
                     # Update book record - handle case where another book already has this path
                     try:
@@ -3944,6 +3976,42 @@ def process_queue(config, limit=None):
                         c.execute('DELETE FROM books WHERE id = ?', (row['book_id'],))
 
                     fixed += 1
+
+                    # Embed metadata tags if enabled
+                    if config.get('metadata_embedding_enabled', False):
+                        try:
+                            embed_metadata = build_metadata_for_embedding(
+                                author=new_author,
+                                title=new_title,
+                                series=new_series,
+                                series_num=str(new_series_num) if new_series_num else None,
+                                narrator=new_narrator,
+                                year=str(new_year) if new_year else None,
+                                edition=new_edition,
+                                variant=new_variant
+                            )
+                            embed_result = embed_tags_for_path(
+                                new_path,
+                                embed_metadata,
+                                create_backup=config.get('metadata_embedding_backup_sidecar', True),
+                                overwrite=config.get('metadata_embedding_overwrite_managed', True)
+                            )
+                            if embed_result['success']:
+                                embed_status = 'ok'
+                                embed_error = None
+                                logger.info(f"Embedded tags in {embed_result['files_processed']} files at {new_path}")
+                            else:
+                                embed_status = 'error'
+                                embed_error = embed_result.get('error') or '; '.join(embed_result.get('errors', []))[:500]
+                                logger.warning(f"Tag embedding failed for {new_path}: {embed_error}")
+                            # Update history with embed status using the captured history ID
+                            c.execute('UPDATE history SET embed_status = ?, embed_error = ? WHERE id = ?',
+                                     (embed_status, embed_error, history_id))
+                        except Exception as embed_e:
+                            logger.error(f"Tag embedding exception for {new_path}: {embed_e}")
+                            c.execute('UPDATE history SET embed_status = ?, embed_error = ? WHERE id = ?',
+                                     ('error', str(embed_e)[:500], history_id))
+
                 except Exception as e:
                     error_msg = str(e)
                     logger.error(f"Error fixing {row['path']}: {error_msg}")
@@ -3952,10 +4020,13 @@ def process_queue(config, limit=None):
             else:
                 # Drastic change or auto_fix disabled - record as pending for manual review
                 logger.info(f"PENDING APPROVAL: {row['current_author']} -> {new_author} (drastic={drastic_change})")
-                c.execute('''INSERT INTO history (book_id, old_author, old_title, new_author, new_title, old_path, new_path, status)
-                             VALUES (?, ?, ?, ?, ?, ?, ?, 'pending_fix')''',
+                c.execute('''INSERT INTO history (book_id, old_author, old_title, new_author, new_title, old_path, new_path, status,
+                                                  new_narrator, new_series, new_series_num, new_year, new_edition, new_variant)
+                             VALUES (?, ?, ?, ?, ?, ?, ?, 'pending_fix', ?, ?, ?, ?, ?, ?)''',
                          (row['book_id'], row['current_author'], row['current_title'],
-                          new_author, new_title, str(old_path), str(new_path)))
+                          new_author, new_title, str(old_path), str(new_path),
+                          new_narrator, new_series, str(new_series_num) if new_series_num else None,
+                          str(new_year) if new_year else None, new_edition, new_variant))
                 c.execute('UPDATE books SET status = ? WHERE id = ?', ('pending_fix', row['book_id']))
                 fixed += 1
         else:
@@ -4099,6 +4170,43 @@ def apply_fix(history_id):
 
         # Update history status
         c.execute('UPDATE history SET status = ? WHERE id = ?', ('fixed', history_id))
+
+        # Embed metadata tags if enabled
+        embed_status = None
+        embed_error = None
+        if config.get('metadata_embedding_enabled', False):
+            try:
+                embed_metadata = build_metadata_for_embedding(
+                    author=fix['new_author'],
+                    title=fix['new_title'],
+                    series=fix['new_series'] if fix['new_series'] else None,
+                    series_num=fix['new_series_num'] if fix['new_series_num'] else None,
+                    narrator=fix['new_narrator'] if fix['new_narrator'] else None,
+                    year=fix['new_year'] if fix['new_year'] else None,
+                    edition=fix['new_edition'] if fix['new_edition'] else None,
+                    variant=fix['new_variant'] if fix['new_variant'] else None
+                )
+                embed_result = embed_tags_for_path(
+                    new_path,
+                    embed_metadata,
+                    create_backup=config.get('metadata_embedding_backup_sidecar', True),
+                    overwrite=config.get('metadata_embedding_overwrite_managed', True)
+                )
+                if embed_result['success']:
+                    embed_status = 'ok'
+                    logger.info(f"Embedded tags in {embed_result['files_processed']} files at {new_path}")
+                else:
+                    embed_status = 'error'
+                    embed_error = embed_result.get('error') or '; '.join(embed_result.get('errors', []))[:500]
+                    logger.warning(f"Tag embedding failed for {new_path}: {embed_error}")
+            except Exception as embed_e:
+                embed_status = 'error'
+                embed_error = str(embed_e)[:500]
+                logger.error(f"Tag embedding exception for {new_path}: {embed_e}")
+
+            # Update history with embed status
+            c.execute('UPDATE history SET embed_status = ?, embed_error = ? WHERE id = ?',
+                     (embed_status, embed_error, history_id))
 
         conn.commit()
         conn.close()
@@ -4395,6 +4503,9 @@ def settings_page():
         config['series_grouping'] = 'series_grouping' in request.form
         config['ebook_management'] = 'ebook_management' in request.form
         config['ebook_library_mode'] = request.form.get('ebook_library_mode', 'merge')
+        config['metadata_embedding_enabled'] = 'metadata_embedding_enabled' in request.form
+        config['metadata_embedding_overwrite_managed'] = 'metadata_embedding_overwrite_managed' in request.form
+        config['metadata_embedding_backup_sidecar'] = 'metadata_embedding_backup_sidecar' in request.form
         config['google_books_api_key'] = request.form.get('google_books_api_key', '').strip() or None
         config['update_channel'] = request.form.get('update_channel', 'stable')
         config['naming_format'] = request.form.get('naming_format', 'author/title')

--- a/audio_tagging.py
+++ b/audio_tagging.py
@@ -1,0 +1,526 @@
+"""
+Audio Tagging Module for Library Manager
+
+Handles embedding audiobook metadata into audio files using mutagen.
+Supports MP3, M4B/M4A/AAC, FLAC, Ogg/Opus, and WMA formats.
+Creates sidecar JSON backups of original tags before modification.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Any
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+# Audio extensions we can potentially tag
+TAGGABLE_EXTENSIONS = {'.m4b', '.mp3', '.m4a', '.flac', '.ogg', '.opus', '.wma', '.aac'}
+
+# Sidecar backup filename
+SIDECAR_FILENAME = '.library-manager.tags.json'
+
+
+def collect_audio_files(target_path: Path) -> List[Path]:
+    """
+    Collect all taggable audio files from a path.
+    If target_path is a file, returns [target_path] if it's audio.
+    If target_path is a directory, walks it recursively.
+    """
+    target = Path(target_path)
+    audio_files = []
+
+    if target.is_file():
+        if target.suffix.lower() in TAGGABLE_EXTENSIONS:
+            audio_files.append(target)
+    elif target.is_dir():
+        for ext in TAGGABLE_EXTENSIONS:
+            audio_files.extend(target.rglob(f'*{ext}'))
+            # Also check uppercase
+            audio_files.extend(target.rglob(f'*{ext.upper()}'))
+    
+    # Deduplicate (in case of case-insensitive filesystem)
+    seen = set()
+    unique_files = []
+    for f in audio_files:
+        resolved = f.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            unique_files.append(f)
+    
+    return sorted(unique_files)
+
+
+def snapshot_tags(file_path: Path) -> Optional[Dict[str, Any]]:
+    """
+    Read existing tags from an audio file and return a JSON-safe representation.
+    Skips binary data like cover art.
+    Returns None if file cannot be read.
+    """
+    try:
+        from mutagen import File
+        from mutagen.mp3 import MP3
+        from mutagen.mp4 import MP4
+        from mutagen.flac import FLAC
+        from mutagen.oggvorbis import OggVorbis
+        from mutagen.oggopus import OggOpus
+        from mutagen.asf import ASF
+
+        audio = File(str(file_path))
+        if audio is None:
+            return None
+
+        snapshot = {
+            'file': str(file_path.name),
+            'format': type(audio).__name__,
+            'timestamp': datetime.now().isoformat(),
+            'tags': {}
+        }
+
+        if isinstance(audio, MP3) and audio.tags:
+            # ID3 tags - extract text values only
+            for key, value in audio.tags.items():
+                if hasattr(value, 'text'):
+                    # Text frames (TIT2, TPE1, etc.)
+                    snapshot['tags'][key] = [str(t) for t in value.text]
+                elif key.startswith('TXXX:'):
+                    # User-defined text frames
+                    snapshot['tags'][key] = [str(t) for t in value.text] if hasattr(value, 'text') else str(value)
+                # Skip binary frames like APIC (cover art)
+
+        elif isinstance(audio, MP4) and audio.tags:
+            # MP4/M4B/M4A tags
+            for key, value in audio.tags.items():
+                if key.startswith('covr'):
+                    continue  # Skip cover art
+                if isinstance(value, list):
+                    snapshot['tags'][key] = [str(v) if not isinstance(v, bytes) else None for v in value]
+                    snapshot['tags'][key] = [v for v in snapshot['tags'][key] if v is not None]
+                else:
+                    if not isinstance(value, bytes):
+                        snapshot['tags'][key] = str(value)
+
+        elif isinstance(audio, (FLAC, OggVorbis, OggOpus)) and audio.tags:
+            # Vorbis comments
+            for key, value in audio.tags.items():
+                if key.lower() in ('metadata_block_picture', 'coverart'):
+                    continue  # Skip cover art
+                snapshot['tags'][key] = list(value) if isinstance(value, list) else [str(value)]
+
+        elif isinstance(audio, ASF) and audio.tags:
+            # WMA/ASF tags
+            for key, value in audio.tags.items():
+                if 'picture' in key.lower():
+                    continue  # Skip pictures
+                if hasattr(value, 'value'):
+                    snapshot['tags'][key] = str(value.value)
+                else:
+                    snapshot['tags'][key] = str(value)
+
+        return snapshot
+
+    except Exception as e:
+        logger.debug(f"Could not snapshot tags from {file_path}: {e}")
+        return None
+
+
+def write_sidecar_backup(folder: Path, snapshots: List[Dict[str, Any]]) -> bool:
+    """
+    Write/update a sidecar JSON backup file with tag snapshots.
+    If the sidecar already exists, merge new snapshots (update by filename).
+    Returns True on success.
+    """
+    sidecar_path = Path(folder) / SIDECAR_FILENAME
+
+    existing_data = {'version': 1, 'created': datetime.now().isoformat(), 'files': {}}
+
+    # Load existing sidecar if present
+    if sidecar_path.exists():
+        try:
+            with open(sidecar_path, 'r', encoding='utf-8') as f:
+                existing_data = json.load(f)
+        except Exception as e:
+            logger.warning(f"Could not read existing sidecar {sidecar_path}: {e}")
+
+    # Update with new snapshots
+    for snap in snapshots:
+        if snap and 'file' in snap:
+            filename = snap['file']
+            # Keep the first backup (original), don't overwrite
+            if filename not in existing_data.get('files', {}):
+                existing_data.setdefault('files', {})[filename] = snap
+
+    # Ensure updated timestamp
+    existing_data['updated'] = datetime.now().isoformat()
+
+    try:
+        with open(sidecar_path, 'w', encoding='utf-8') as f:
+            json.dump(existing_data, f, indent=2, ensure_ascii=False)
+        logger.debug(f"Wrote sidecar backup to {sidecar_path}")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to write sidecar backup {sidecar_path}: {e}")
+        return False
+
+
+def embed_tags_mp3(file_path: Path, metadata: Dict[str, Any], overwrite: bool = True) -> bool:
+    """Embed tags into MP3 file using ID3v2."""
+    try:
+        from mutagen.mp3 import MP3
+        from mutagen.id3 import ID3, TIT2, TALB, TPE1, TPE2, TDRC, TXXX
+
+        audio = MP3(str(file_path))
+
+        # Create ID3 tag if none exists
+        if audio.tags is None:
+            audio.add_tags()
+
+        tags = audio.tags
+
+        # Standard tags
+        tag_mapping = [
+            ('title', TIT2, 'TIT2'),       # Track/chapter title -> book title for albums
+            ('album', TALB, 'TALB'),       # Album -> book title
+            ('artist', TPE1, 'TPE1'),      # Artist -> author
+            ('albumartist', TPE2, 'TPE2'), # Album artist -> author
+        ]
+
+        for meta_key, frame_class, frame_id in tag_mapping:
+            value = metadata.get(meta_key)
+            if value:
+                if overwrite or frame_id not in tags:
+                    tags[frame_id] = frame_class(encoding=3, text=[str(value)])
+
+        # Year
+        year = metadata.get('year')
+        if year:
+            if overwrite or 'TDRC' not in tags:
+                tags['TDRC'] = TDRC(encoding=3, text=[str(year)])
+
+        # Custom tags via TXXX frames
+        custom_tags = [
+            ('series', 'SERIES'),
+            ('series_num', 'SERIESNUMBER'),
+            ('narrator', 'NARRATOR'),
+            ('edition', 'EDITION'),
+            ('variant', 'VARIANT'),
+        ]
+
+        for meta_key, txxx_desc in custom_tags:
+            value = metadata.get(meta_key)
+            if value:
+                txxx_key = f'TXXX:{txxx_desc}'
+                if overwrite or txxx_key not in tags:
+                    tags[txxx_key] = TXXX(encoding=3, desc=txxx_desc, text=[str(value)])
+
+        audio.save()
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to embed MP3 tags in {file_path}: {e}")
+        return False
+
+
+def embed_tags_mp4(file_path: Path, metadata: Dict[str, Any], overwrite: bool = True) -> bool:
+    """Embed tags into MP4/M4B/M4A/AAC file."""
+    try:
+        from mutagen.mp4 import MP4
+
+        audio = MP4(str(file_path))
+
+        if audio.tags is None:
+            audio.add_tags()
+
+        tags = audio.tags
+
+        # Standard MP4 tags
+        standard_tags = [
+            ('title', '\xa9nam'),      # Title
+            ('album', '\xa9alb'),      # Album
+            ('artist', '\xa9ART'),     # Artist
+            ('albumartist', 'aART'),   # Album artist
+        ]
+
+        for meta_key, mp4_key in standard_tags:
+            value = metadata.get(meta_key)
+            if value:
+                if overwrite or mp4_key not in tags:
+                    tags[mp4_key] = [str(value)]
+
+        # Year
+        year = metadata.get('year')
+        if year:
+            if overwrite or '\xa9day' not in tags:
+                tags['\xa9day'] = [str(year)]
+
+        # Custom tags via freeform atoms (iTunes style)
+        custom_tags = [
+            ('series', 'SERIES'),
+            ('series_num', 'SERIESNUMBER'),
+            ('narrator', 'NARRATOR'),
+            ('edition', 'EDITION'),
+            ('variant', 'VARIANT'),
+        ]
+
+        for meta_key, tag_name in custom_tags:
+            value = metadata.get(meta_key)
+            if value:
+                # Use ----:com.apple.iTunes:TAGNAME format
+                freeform_key = f'----:com.apple.iTunes:{tag_name}'
+                if overwrite or freeform_key not in tags:
+                    # MP4FreeForm expects bytes
+                    tags[freeform_key] = [str(value).encode('utf-8')]
+
+        audio.save()
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to embed MP4 tags in {file_path}: {e}")
+        return False
+
+
+def embed_tags_vorbis(file_path: Path, metadata: Dict[str, Any], overwrite: bool = True) -> bool:
+    """Embed tags into FLAC/Ogg/Opus files using Vorbis comments."""
+    try:
+        from mutagen import File
+
+        audio = File(str(file_path))
+        if audio is None:
+            return False
+
+        if audio.tags is None:
+            # Different file types have different ways to add tags
+            if hasattr(audio, 'add_tags'):
+                audio.add_tags()
+            else:
+                return False
+
+        tags = audio.tags
+
+        # Standard Vorbis comments (uppercase by convention)
+        standard_tags = [
+            ('title', 'TITLE'),
+            ('album', 'ALBUM'),
+            ('artist', 'ARTIST'),
+            ('albumartist', 'ALBUMARTIST'),
+            ('year', 'DATE'),
+        ]
+
+        for meta_key, vorbis_key in standard_tags:
+            value = metadata.get(meta_key)
+            if value:
+                if overwrite or vorbis_key not in tags:
+                    tags[vorbis_key] = [str(value)]
+
+        # Custom tags (Vorbis comments are flexible)
+        custom_tags = [
+            ('series', 'SERIES'),
+            ('series_num', 'SERIESNUMBER'),
+            ('narrator', 'NARRATOR'),
+            ('edition', 'EDITION'),
+            ('variant', 'VARIANT'),
+        ]
+
+        for meta_key, vorbis_key in custom_tags:
+            value = metadata.get(meta_key)
+            if value:
+                if overwrite or vorbis_key not in tags:
+                    tags[vorbis_key] = [str(value)]
+
+        audio.save()
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to embed Vorbis tags in {file_path}: {e}")
+        return False
+
+
+def embed_tags_asf(file_path: Path, metadata: Dict[str, Any], overwrite: bool = True) -> bool:
+    """Embed tags into WMA/ASF files."""
+    try:
+        from mutagen.asf import ASF
+
+        audio = ASF(str(file_path))
+
+        if audio.tags is None:
+            audio.add_tags()
+
+        tags = audio.tags
+
+        # Standard ASF tags
+        standard_tags = [
+            ('title', 'Title'),
+            ('album', 'WM/AlbumTitle'),
+            ('artist', 'Author'),
+            ('albumartist', 'WM/AlbumArtist'),
+            ('year', 'WM/Year'),
+        ]
+
+        for meta_key, asf_key in standard_tags:
+            value = metadata.get(meta_key)
+            if value:
+                if overwrite or asf_key not in tags:
+                    tags[asf_key] = [str(value)]
+
+        # Custom tags
+        custom_tags = [
+            ('series', 'WM/Series'),
+            ('series_num', 'WM/SeriesNumber'),
+            ('narrator', 'WM/Narrator'),
+            ('edition', 'WM/Edition'),
+            ('variant', 'WM/Variant'),
+        ]
+
+        for meta_key, asf_key in custom_tags:
+            value = metadata.get(meta_key)
+            if value:
+                if overwrite or asf_key not in tags:
+                    tags[asf_key] = [str(value)]
+
+        audio.save()
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to embed ASF tags in {file_path}: {e}")
+        return False
+
+
+def embed_tags(file_path: Path, metadata: Dict[str, Any], overwrite: bool = True) -> bool:
+    """
+    Embed metadata tags into an audio file.
+    Dispatches to format-specific handler based on file extension.
+    
+    Args:
+        file_path: Path to the audio file
+        metadata: Dict with keys: title, album, artist, albumartist, year, 
+                  series, series_num, narrator, edition, variant
+        overwrite: If True, overwrite existing managed fields. If False, only fill missing.
+    
+    Returns:
+        True if successful, False otherwise.
+    """
+    file_path = Path(file_path)
+    ext = file_path.suffix.lower()
+
+    if ext == '.mp3':
+        return embed_tags_mp3(file_path, metadata, overwrite)
+    elif ext in ('.m4b', '.m4a', '.aac'):
+        return embed_tags_mp4(file_path, metadata, overwrite)
+    elif ext in ('.flac', '.ogg', '.opus'):
+        return embed_tags_vorbis(file_path, metadata, overwrite)
+    elif ext == '.wma':
+        return embed_tags_asf(file_path, metadata, overwrite)
+    else:
+        logger.debug(f"Unsupported format for tagging: {ext}")
+        return False
+
+
+def build_metadata_for_embedding(
+    author: str,
+    title: str,
+    series: Optional[str] = None,
+    series_num: Optional[str] = None,
+    narrator: Optional[str] = None,
+    year: Optional[str] = None,
+    edition: Optional[str] = None,
+    variant: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Build a metadata dict suitable for embed_tags() from book info.
+    Maps audiobook concepts to standard audio tag fields.
+    """
+    metadata = {
+        'title': title,          # Track title (for single-file books) / Album title
+        'album': title,          # Album = book title
+        'artist': author,        # Artist = author (for compatibility)
+        'albumartist': author,   # Album artist = author (more accurate for audiobooks)
+    }
+
+    if year:
+        metadata['year'] = str(year)
+    if series:
+        metadata['series'] = series
+    if series_num:
+        metadata['series_num'] = str(series_num)
+    if narrator:
+        metadata['narrator'] = narrator
+    if edition:
+        metadata['edition'] = edition
+    if variant:
+        metadata['variant'] = variant
+
+    return metadata
+
+
+def embed_tags_for_path(
+    target_path: Path,
+    metadata: Dict[str, Any],
+    create_backup: bool = True,
+    overwrite: bool = True
+) -> Dict[str, Any]:
+    """
+    High-level function to embed tags into all audio files at a path.
+    Creates sidecar backup before modifying if requested.
+    
+    Args:
+        target_path: File or folder path
+        metadata: Dict with book metadata (author, title, series, etc.)
+        create_backup: Whether to create/update sidecar backup
+        overwrite: Whether to overwrite existing managed fields
+    
+    Returns:
+        Dict with 'success': bool, 'files_processed': int, 'files_failed': int, 
+        'error': str (if any critical error)
+    """
+    target = Path(target_path)
+    result = {
+        'success': True,
+        'files_processed': 0,
+        'files_failed': 0,
+        'errors': []
+    }
+
+    try:
+        # Collect audio files
+        audio_files = collect_audio_files(target)
+        if not audio_files:
+            logger.debug(f"No audio files found at {target}")
+            return result
+
+        # Determine backup folder (parent of file, or the folder itself)
+        backup_folder = target if target.is_dir() else target.parent
+
+        # Create backups before modifying
+        if create_backup:
+            snapshots = []
+            for f in audio_files:
+                snap = snapshot_tags(f)
+                if snap:
+                    snapshots.append(snap)
+            
+            if snapshots:
+                write_sidecar_backup(backup_folder, snapshots)
+
+        # Embed tags
+        for audio_file in audio_files:
+            try:
+                success = embed_tags(audio_file, metadata, overwrite)
+                if success:
+                    result['files_processed'] += 1
+                else:
+                    result['files_failed'] += 1
+                    result['errors'].append(f"Failed to tag: {audio_file.name}")
+            except Exception as e:
+                result['files_failed'] += 1
+                result['errors'].append(f"{audio_file.name}: {str(e)}")
+
+        # Overall success if any files were processed
+        result['success'] = result['files_processed'] > 0 or (len(audio_files) == 0)
+
+    except Exception as e:
+        result['success'] = False
+        result['error'] = str(e)
+        logger.error(f"Error embedding tags at {target_path}: {e}")
+
+    return result
+

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -13,6 +13,8 @@ All settings are configured through the web UI at **Settings**.
 | Series Grouping | `false` | Enable `Author/Series/# - Title` format |
 | Auto-Fix | `false` | Automatically apply safe fixes |
 | Protect Author Changes | `true` | Require approval for drastic author changes |
+| Ebook Management | `false` | Organize ebooks alongside audiobooks |
+| Metadata Embedding | `false` | Write tags into audio files on fix |
 | Scan Interval | `6 hours` | How often to auto-scan |
 
 ### AI Setup Tab
@@ -46,6 +48,40 @@ Author/Series Name/2 - Book Title/
 ```
 
 Standalone books stay as `Author/Title/`.
+
+## Metadata Embedding (Beta)
+
+When enabled, the app will write verified metadata directly into audio file tags when fixes are applied.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Enable Embedding | `false` | Write tags when fixes are applied |
+| Overwrite Tags | `true` | Overwrite existing managed fields |
+| Backup Tags | `true` | Save original tags before modifying |
+
+### Supported Formats
+
+- **MP3** - ID3v2 tags (TIT2, TALB, TPE1, etc.)
+- **M4B/M4A/AAC** - MP4 atoms with iTunes freeform tags
+- **FLAC/Ogg/Opus** - Vorbis comments
+- **WMA** - ASF tags
+
+### Tags Written
+
+| Field | Standard Tag | Custom Tag |
+|-------|-------------|------------|
+| Title | ALBUM (book title) | - |
+| Author | ARTIST, ALBUMARTIST | - |
+| Year | DATE/TDRC | - |
+| Series | - | SERIES |
+| Series # | - | SERIESNUMBER |
+| Narrator | - | NARRATOR |
+| Edition | - | EDITION |
+| Variant | - | VARIANT |
+
+### Backup Files
+
+When "Backup Tags" is enabled, original tags are saved to `.library-manager.tags.json` in each book folder before any modifications. This allows manual recovery if needed.
 
 ## Rate Limits
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -236,6 +236,37 @@
                                 </select>
                                 <small class="text-muted d-block mt-1">Merge: puts ebook in same Author/Title/ folder as audiobook</small>
                             </div>
+                            <hr class="my-2">
+                            <div class="form-check form-switch mb-2">
+                                <input class="form-check-input" type="checkbox" name="metadata_embedding_enabled" id="metadata_embedding_enabled"
+                                       {% if config.metadata_embedding_enabled %}checked{% endif %} onchange="toggleEmbeddingOptions()">
+                                <label class="form-check-label" for="metadata_embedding_enabled">
+                                    <strong>Metadata Embedding</strong>
+                                    <span class="badge bg-info">BETA</span>
+                                    <br><small class="text-muted">Write metadata tags into audio files when fixes are applied</small>
+                                </label>
+                            </div>
+                            <div id="embedding-options" class="ms-4 mb-2" style="display: {% if config.metadata_embedding_enabled %}block{% else %}none{% endif %};">
+                                <div class="form-check form-switch mb-2">
+                                    <input class="form-check-input" type="checkbox" name="metadata_embedding_overwrite_managed" id="metadata_embedding_overwrite_managed"
+                                           {% if config.metadata_embedding_overwrite_managed %}checked{% endif %}>
+                                    <label class="form-check-label small" for="metadata_embedding_overwrite_managed">
+                                        Overwrite existing tags (title/author/series/narrator/year)
+                                    </label>
+                                </div>
+                                <div class="form-check form-switch mb-2">
+                                    <input class="form-check-input" type="checkbox" name="metadata_embedding_backup_sidecar" id="metadata_embedding_backup_sidecar"
+                                           {% if config.metadata_embedding_backup_sidecar %}checked{% endif %}>
+                                    <label class="form-check-label small" for="metadata_embedding_backup_sidecar">
+                                        Create backup before modifying tags
+                                        <br><small class="text-muted">Saves original tags to <code>.library-manager.tags.json</code></small>
+                                    </label>
+                                </div>
+                                <small class="text-muted">
+                                    <i class="bi bi-info-circle"></i>
+                                    Supports MP3, M4B/M4A, FLAC, Ogg/Opus, and WMA formats.
+                                </small>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -528,6 +559,11 @@ function toggleProviderFields() {
 function toggleEbookOptions() {
     const enabled = document.getElementById('ebook_management').checked;
     document.getElementById('ebook-options').style.display = enabled ? 'block' : 'none';
+}
+
+function toggleEmbeddingOptions() {
+    const enabled = document.getElementById('metadata_embedding_enabled').checked;
+    document.getElementById('embedding-options').style.display = enabled ? 'block' : 'none';
 }
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/test-env/test-audio-tagging.py
+++ b/test-env/test-audio-tagging.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""
+Test script for the audio tagging/metadata embedding feature.
+Creates sample audio files, runs embedding, and verifies results.
+
+Requires: ffmpeg (for creating test audio files), mutagen
+
+Usage:
+    python test-env/test-audio-tagging.py
+"""
+
+import os
+import sys
+import json
+import tempfile
+import subprocess
+from pathlib import Path
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from audio_tagging import (
+    collect_audio_files,
+    snapshot_tags,
+    write_sidecar_backup,
+    embed_tags,
+    embed_tags_for_path,
+    build_metadata_for_embedding,
+    SIDECAR_FILENAME
+)
+
+
+def create_silent_mp3(filepath, duration_seconds=1):
+    """Create a silent MP3 file using ffmpeg."""
+    try:
+        subprocess.run([
+            'ffmpeg', '-y', '-f', 'lavfi', '-i', f'anullsrc=r=44100:cl=mono',
+            '-t', str(duration_seconds), '-q:a', '9', str(filepath)
+        ], capture_output=True, check=True)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(f"  Warning: Could not create MP3 (ffmpeg required): {e}")
+        return False
+
+
+def add_existing_tags_mp3(filepath, title=None, artist=None, album=None):
+    """Add some existing tags to an MP3 file."""
+    from mutagen.mp3 import MP3
+    from mutagen.id3 import ID3, TIT2, TPE1, TALB
+
+    audio = MP3(str(filepath))
+    if audio.tags is None:
+        audio.add_tags()
+    if title:
+        audio.tags['TIT2'] = TIT2(encoding=3, text=[title])
+    if artist:
+        audio.tags['TPE1'] = TPE1(encoding=3, text=[artist])
+    if album:
+        audio.tags['TALB'] = TALB(encoding=3, text=[album])
+    audio.save()
+
+
+def verify_tags_mp3(filepath, expected):
+    """Verify MP3 tags match expected values."""
+    from mutagen.mp3 import MP3
+
+    audio = MP3(str(filepath))
+    if audio.tags is None:
+        return False, "No tags found"
+
+    errors = []
+    
+    # Check standard tags
+    tag_mapping = {
+        'album': 'TALB',
+        'artist': 'TPE1',
+        'albumartist': 'TPE2',
+        'year': 'TDRC',
+    }
+    
+    for key, frame_id in tag_mapping.items():
+        if key in expected:
+            if frame_id not in audio.tags:
+                errors.append(f"Missing {frame_id}")
+            else:
+                actual = str(audio.tags[frame_id].text[0])
+                if actual != str(expected[key]):
+                    errors.append(f"{frame_id}: expected '{expected[key]}', got '{actual}'")
+    
+    # Check custom TXXX tags
+    custom_mapping = {
+        'series': 'SERIES',
+        'series_num': 'SERIESNUMBER',
+        'narrator': 'NARRATOR',
+    }
+    
+    for key, desc in custom_mapping.items():
+        if key in expected:
+            txxx_key = f'TXXX:{desc}'
+            if txxx_key not in audio.tags:
+                errors.append(f"Missing {txxx_key}")
+            else:
+                actual = str(audio.tags[txxx_key].text[0])
+                if actual != str(expected[key]):
+                    errors.append(f"{txxx_key}: expected '{expected[key]}', got '{actual}'")
+    
+    if errors:
+        return False, "; ".join(errors)
+    return True, "OK"
+
+
+def test_collect_audio_files(test_dir):
+    """Test collect_audio_files function."""
+    print("\n=== Test: collect_audio_files ===")
+    
+    # Create test files
+    (test_dir / "test1.mp3").touch()
+    (test_dir / "test2.MP3").touch()  # uppercase
+    (test_dir / "subdir").mkdir(exist_ok=True)
+    (test_dir / "subdir" / "nested.mp3").touch()
+    (test_dir / "not_audio.txt").touch()
+    
+    files = collect_audio_files(test_dir)
+    mp3_count = len([f for f in files if f.suffix.lower() == '.mp3'])
+    
+    if mp3_count >= 2:  # At least test1.mp3 and nested.mp3 (uppercase might be same on case-insensitive FS)
+        print(f"  PASS: Found {mp3_count} MP3 files")
+        return True
+    else:
+        print(f"  FAIL: Expected at least 2 MP3 files, found {mp3_count}")
+        return False
+
+
+def test_snapshot_and_backup(test_dir):
+    """Test snapshot_tags and write_sidecar_backup functions."""
+    print("\n=== Test: snapshot_tags + write_sidecar_backup ===")
+    
+    test_file = test_dir / "snapshot_test.mp3"
+    if not create_silent_mp3(test_file):
+        print("  SKIP: ffmpeg not available")
+        return None
+    
+    # Add some tags
+    add_existing_tags_mp3(test_file, title="Test Title", artist="Test Artist", album="Test Album")
+    
+    # Snapshot
+    snapshot = snapshot_tags(test_file)
+    if not snapshot:
+        print("  FAIL: snapshot_tags returned None")
+        return False
+    
+    if 'tags' not in snapshot or 'file' not in snapshot:
+        print(f"  FAIL: Invalid snapshot structure: {snapshot.keys()}")
+        return False
+    
+    print(f"  Snapshot: {snapshot['tags']}")
+    
+    # Write sidecar
+    success = write_sidecar_backup(test_dir, [snapshot])
+    if not success:
+        print("  FAIL: write_sidecar_backup returned False")
+        return False
+    
+    sidecar_path = test_dir / SIDECAR_FILENAME
+    if not sidecar_path.exists():
+        print(f"  FAIL: Sidecar file not created at {sidecar_path}")
+        return False
+    
+    # Verify sidecar content
+    with open(sidecar_path) as f:
+        sidecar_data = json.load(f)
+    
+    if 'files' not in sidecar_data or 'snapshot_test.mp3' not in sidecar_data['files']:
+        print(f"  FAIL: Sidecar missing expected file entry")
+        return False
+    
+    print(f"  PASS: Sidecar created with {len(sidecar_data['files'])} file(s)")
+    return True
+
+
+def test_embed_tags_mp3(test_dir):
+    """Test embedding tags into MP3 file."""
+    print("\n=== Test: embed_tags (MP3) ===")
+    
+    test_file = test_dir / "embed_test.mp3"
+    if not create_silent_mp3(test_file):
+        print("  SKIP: ffmpeg not available")
+        return None
+    
+    # Build metadata
+    metadata = build_metadata_for_embedding(
+        author="Brandon Sanderson",
+        title="The Final Empire",
+        series="Mistborn",
+        series_num="1",
+        narrator="Michael Kramer",
+        year="2006"
+    )
+    
+    # Embed
+    success = embed_tags(test_file, metadata, overwrite=True)
+    if not success:
+        print("  FAIL: embed_tags returned False")
+        return False
+    
+    # Verify
+    expected = {
+        'album': "The Final Empire",
+        'artist': "Brandon Sanderson",
+        'albumartist': "Brandon Sanderson",
+        'year': "2006",
+        'series': "Mistborn",
+        'series_num': "1",
+        'narrator': "Michael Kramer"
+    }
+    
+    ok, msg = verify_tags_mp3(test_file, expected)
+    if ok:
+        print(f"  PASS: All tags verified correctly")
+        return True
+    else:
+        print(f"  FAIL: {msg}")
+        return False
+
+
+def test_embed_tags_overwrite_mode(test_dir):
+    """Test that overwrite mode works correctly."""
+    print("\n=== Test: embed_tags overwrite mode ===")
+    
+    test_file = test_dir / "overwrite_test.mp3"
+    if not create_silent_mp3(test_file):
+        print("  SKIP: ffmpeg not available")
+        return None
+    
+    # Add existing tags
+    add_existing_tags_mp3(test_file, title="Old Title", artist="Old Artist", album="Old Album")
+    
+    # Embed with new metadata (overwrite=True)
+    metadata = build_metadata_for_embedding(
+        author="New Author",
+        title="New Title"
+    )
+    
+    success = embed_tags(test_file, metadata, overwrite=True)
+    if not success:
+        print("  FAIL: embed_tags returned False")
+        return False
+    
+    # Verify new values
+    expected = {
+        'album': "New Title",
+        'artist': "New Author"
+    }
+    
+    ok, msg = verify_tags_mp3(test_file, expected)
+    if ok:
+        print(f"  PASS: Tags overwritten correctly")
+        return True
+    else:
+        print(f"  FAIL: {msg}")
+        return False
+
+
+def test_embed_tags_for_path(test_dir):
+    """Test the high-level embed_tags_for_path function."""
+    print("\n=== Test: embed_tags_for_path ===")
+    
+    book_dir = test_dir / "test_book"
+    book_dir.mkdir(exist_ok=True)
+    
+    # Create multiple test files
+    files_created = 0
+    for i in range(3):
+        test_file = book_dir / f"chapter_{i+1:02d}.mp3"
+        if create_silent_mp3(test_file):
+            files_created += 1
+    
+    if files_created == 0:
+        print("  SKIP: ffmpeg not available")
+        return None
+    
+    # Build metadata
+    metadata = build_metadata_for_embedding(
+        author="Test Author",
+        title="Test Book",
+        series="Test Series",
+        series_num="1",
+        narrator="Test Narrator",
+        year="2024"
+    )
+    
+    # Run embedding
+    result = embed_tags_for_path(
+        book_dir,
+        metadata,
+        create_backup=True,
+        overwrite=True
+    )
+    
+    if not result['success']:
+        print(f"  FAIL: embed_tags_for_path failed: {result.get('error')}")
+        return False
+    
+    if result['files_processed'] != files_created:
+        print(f"  FAIL: Expected {files_created} files processed, got {result['files_processed']}")
+        return False
+    
+    # Verify sidecar was created
+    sidecar_path = book_dir / SIDECAR_FILENAME
+    if not sidecar_path.exists():
+        print("  FAIL: Sidecar backup not created")
+        return False
+    
+    print(f"  PASS: Processed {result['files_processed']} files, sidecar created")
+    return True
+
+
+def run_tests():
+    """Run all tests."""
+    print("=" * 60)
+    print("Audio Tagging Module Tests")
+    print("=" * 60)
+    
+    # Create temp directory for tests
+    with tempfile.TemporaryDirectory(prefix="audio_tag_test_") as tmpdir:
+        test_dir = Path(tmpdir)
+        print(f"Test directory: {test_dir}")
+        
+        results = []
+        
+        # Run tests
+        results.append(("collect_audio_files", test_collect_audio_files(test_dir)))
+        results.append(("snapshot + backup", test_snapshot_and_backup(test_dir)))
+        results.append(("embed_tags (MP3)", test_embed_tags_mp3(test_dir)))
+        results.append(("overwrite mode", test_embed_tags_overwrite_mode(test_dir)))
+        results.append(("embed_tags_for_path", test_embed_tags_for_path(test_dir)))
+        
+        # Summary
+        print("\n" + "=" * 60)
+        print("Summary")
+        print("=" * 60)
+        
+        passed = 0
+        failed = 0
+        skipped = 0
+        
+        for name, result in results:
+            if result is True:
+                status = "PASS"
+                passed += 1
+            elif result is False:
+                status = "FAIL"
+                failed += 1
+            else:
+                status = "SKIP"
+                skipped += 1
+            print(f"  {name}: {status}")
+        
+        print(f"\nTotal: {passed} passed, {failed} failed, {skipped} skipped")
+        
+        return failed == 0
+
+
+if __name__ == '__main__':
+    success = run_tests()
+    sys.exit(0 if success else 1)
+


### PR DESCRIPTION
Thanks for the great work on this so far! I've made a few changes to design a metadata embedding feature for your review.

- Introduce metadata embedding feature to write verified metadata into audio file tags during fixes
- Expand history table to store additional metadata (narrator, series, year, edition, variant)
- Update settings page to include metadata embedding options
- Enhance CHANGELOG and documentation to reflect new features and settings
- Add CLAUDE.md to guide AI contributors on repo standards/best practices

Metadata Feature Summary:

Embed metadata into audiobook audio files using the approved/verified metadata already produced by the pipeline (providers → AI parse/verify), running only when a fix is applied (users' choice), and supporting all scanner audio formats.

Formats: .m4b .mp3 .m4a .flac .ogg .opus .wma .aac (best-effort; skip formats that mutagen can’t write safely)
When: on auto-fix rename and manual Apply Fix only
Write mode: overwrite managed fields (title/author/series/narrator/year/edition/variant)
Rollback: create/update a sidecar JSON backup before modifying tags