### PR TITLE
Fix #27: ABS connection lost on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.38] - 2025-12-17
+
+### Fixed
+- **ABS Connection Lost on Restart** (Issue #27) - Audiobookshelf API token not persisting
+  - Root cause: Token was filtered from config.json (for security) but never saved to secrets.json
+  - ABS connection now survives container restarts and settings page saves
+  - Token properly stored in secrets.json alongside other API keys
+
+- **Settings Page Wiping ABS Token** - Saving settings no longer overwrites ABS connection
+  - Settings page now preserves existing secrets when saving
+  - Previously, saving any setting would wipe the ABS token
+
+### Improved
+- **Bug Report Security** - Additional API keys now redacted in bug reports
+  - `abs_api_token`, `bookdb_api_key`, and `google_books_api_key` now redacted
+  - Prevents accidental exposure when sharing bug reports
+
+---
+
 ## [0.9.0-beta.37] - 2025-12-16
 
 ### Added


### PR DESCRIPTION
## Summary
- **ABS API token now properly persists** - Token saved to secrets.json, survives restarts
- **Settings page no longer wipes ABS token** - Preserves existing secrets when saving
- **Bug reports now redact additional keys** - abs_api_token, bookdb_api_key, google_books_api_key

## Root Cause
In beta.22, `abs_api_token` was added to `secrets_keys` to prevent it from being saved in plaintext to config.json (good for security). However, `save_secrets()` was never called in `api_abs_connect()` to actually persist the token to secrets.json.

Additionally, the settings page was overwriting the entire secrets.json file, which would wipe any existing ABS token when users saved other settings.

## Changes
1. `api_abs_connect()`: Now saves token to secrets.json using `save_secrets()`
2. `settings_page()`: Uses `load_secrets()` first to preserve existing secrets before updating
3. `DEFAULT_SECRETS`: Added `abs_api_token` with empty default
4. `api_bug_report()`: Added `abs_api_token`, `bookdb_api_key`, `google_books_api_key` to redaction list

## Test plan
- [x] Python syntax check passes
- [x] Unit tests for secrets persistence pass (14/14)
- [ ] Manual test: Connect ABS, restart container, verify connection persists
- [ ] Manual test: Connect ABS, save settings page, verify ABS stays connected
- [ ] Manual test: Generate bug report, verify no tokens visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)