### PR TITLE
Fix AttributeError when AI returns invalid type

### DIFF
--- a/library_manager/pipeline/layer_ai_queue.py
+++ b/library_manager/pipeline/layer_ai_queue.py
@@ -150,6 +150,11 @@ def process_queue(
         logger.warning("No results from AI")
         return 0, 0  # (processed, fixed)
 
+    # SAFETY: Ensure results is a list, not a string or other type
+    if not isinstance(results, list):
+        logger.error(f"AI returned invalid type: {type(results)} (expected list). Value: {repr(results)[:200]}")
+        return 0, 0
+
     # === PHASE 3: Process results and apply DB updates ===
     conn = get_db()
     c = conn.cursor()


### PR DESCRIPTION
## Summary
Fixes #86 - AttributeError crash when AI provider returns a string error instead of a list/None.

## Root Cause
When all AI providers fail or JSON parsing fails, sometimes a string error message is returned instead of  or a list. The code then tries to iterate  where  is a string, causing it to iterate over individual characters. At line 205,  fails because  is a string character, not a dict.

## The Fix
Added type checking after the AI call to ensure  is actually a list before processing:

```python
# SAFETY: Ensure results is a list, not a string or other type
if not isinstance(results, list):
    logger.error(f"AI returned invalid type: {type(results)} (expected list). Value: {repr(results)[:200]}")
    return 0, 0
```

## Testing
- Verified the fix handles string errors gracefully
- Logs the unexpected type and sample value for debugging
- Queue processing continues instead of crashing

## Follow-up
A deeper fix in `parse_json_response()` could prevent this at the source, but this defensive check provides immediate safety.