### PR TITLE
Fix #88: Filter Synology @eaDir and system folders at book level

### DIFF
--- a/app.py
+++ b/app.py
@@ -4952,13 +4952,15 @@ def deep_scan_library(config):
                     continue
 
                 # Skip system/metadata folders - these are NEVER books
+                # Issue #88: Added @eaDir, #recycle (Synology), .Trash*, .AppleDouble, __MACOSX
                 system_folders = {'metadata', 'tmp', 'temp', 'cache', 'config', 'data', 'logs', 'log',
                                   'backup', 'backups', 'old', 'new', 'test', 'tests', 'sample', 'samples',
                                   '.thumbnails', 'thumbnails', 'covers', 'images', 'artwork', 'art',
                                   'extras', 'bonus', 'misc', 'other', 'various', 'unknown', 'unsorted',
                                   'downloads', 'incoming', 'processing', 'completed', 'done', 'failed',
-                                  'streams', 'chapters', 'parts', '.streams', '.cache', '.metadata'}
-                if title.lower() in system_folders or title.startswith('.'):
+                                  'streams', 'chapters', 'parts', '.streams', '.cache', '.metadata',
+                                  '@eadir', '#recycle', '.appledouble', '__macosx', '.trash'}
+                if title.lower() in system_folders or title.startswith('.') or title.startswith('@') or title.startswith('#'):
                     logger.debug(f"Skipping system folder: {path}")
                     continue
 
@@ -5010,6 +5012,11 @@ def deep_scan_library(config):
                                 continue
                             book_title = book_dir.name
                             book_path = str(book_dir)
+
+                            # Issue #88: Skip system folders inside series (Synology @eaDir, etc.)
+                            if book_title.lower() in system_folders or book_title.startswith('.') or book_title.startswith('@') or book_title.startswith('#'):
+                                logger.debug(f"Skipping system folder in series: {book_path}")
+                                continue
 
                             # Issue #53: Strip author prefix from book folder name
                             # If folder is "David Baldacci - Dream Town" and parent is "David Baldacci",


### PR DESCRIPTION
## Summary
- Filters Synology `@eaDir` extended attribute folders from book scanning
- Also filters `#recycle`, `.AppleDouble`, `__MACOSX`, `.Trash` system folders
- Applies filter at both regular book level and inside series folders

## What was happening
Synology NAS creates `@eaDir` folders to store extended attributes. These were being picked up by the scanner as book titles, causing garbage entries like `Walter M. Miller Jr/@eaDir` to appear in the library.

## Changes
1. Added `@eadir`, `#recycle`, `.appledouble`, `__macosx`, `.trash` to the `system_folders` set
2. Added `title.startswith('@')` and `title.startswith('#')` checks to catch any @ or # prefixed folders
3. Applied the same filter when processing book subfolders inside series folders

## Test plan
- [ ] Verify Synology users no longer see @eaDir entries after rescan
- [ ] Verify normal books are still detected correctly
- [ ] Verify series books are still detected correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)