### PR TITLE
fix: Prevent AI hallucination on generic titles (#79)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ test-env/chaos-test-library/
 test-env/test-secrets.json
 .TODO.md
 CLAUDE.md
+
+# Testers file - contains IPs and private info, NEVER commit
+.testers.json

--- a/test-env/lookup-tester.sh
+++ b/test-env/lookup-tester.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Lookup tester logs by name or IP hint
+# Usage: ./lookup-tester.sh <tester_name_or_ip_hint>
+#
+# Examples:
+#   ./lookup-tester.sh merijeek
+#   ./lookup-tester.sh 158        # Last octet
+#   ./lookup-tester.sh 71.184     # Partial IP
+
+TESTERS_FILE="/mnt/ai_brain_ssd/projects/library-manager/.testers.json"
+SKALDLEITA_LOG="/mnt/bookdb-ssd/bookdb/logs/api.log"
+ID_QUEUE_DB="/mnt/bookdb-ssd/bookdb/src/identification_queue.db"
+STAGING_DB="/mnt/bookdb-ssd/bookdb/data/staging.db"
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <tester_name_or_ip_hint>"
+    echo ""
+    echo "Known testers (from .testers.json):"
+    if [ -f "$TESTERS_FILE" ]; then
+        jq -r '.testers | keys[]' "$TESTERS_FILE" 2>/dev/null
+    fi
+    exit 1
+fi
+
+SEARCH="$1"
+
+echo "=== Searching for: $SEARCH ==="
+echo ""
+
+# Check if it's a known tester name
+if [ -f "$TESTERS_FILE" ]; then
+    TESTER_INFO=$(jq -r ".testers.\"$SEARCH\" // empty" "$TESTERS_FILE" 2>/dev/null)
+    if [ -n "$TESTER_INFO" ]; then
+        echo "=== Tester Profile ==="
+        echo "$TESTER_INFO" | jq .
+        echo ""
+
+        # Get IP hints for this tester
+        IP_HINTS=$(echo "$TESTER_INFO" | jq -r '.ip_hints[]? // empty' 2>/dev/null)
+        if [ -n "$IP_HINTS" ]; then
+            SEARCH="$IP_HINTS"
+            echo "Using IP hint: $SEARCH"
+        fi
+    fi
+fi
+
+echo "=== Recent Skaldleita Activity (last 50 matches) ==="
+grep "$SEARCH" "$SKALDLEITA_LOG" 2>/dev/null | tail -50
+
+echo ""
+echo "=== Identification Jobs ==="
+sqlite3 "$ID_QUEUE_DB" "SELECT ticket_id, user_id, status, folder_hint, datetime(created_at) as created FROM identification_jobs WHERE user_id LIKE '%$SEARCH%' ORDER BY created_at DESC LIMIT 20;" 2>/dev/null
+
+echo ""
+echo "=== Request Stats ==="
+grep "$SEARCH" "$SKALDLEITA_LOG" 2>/dev/null | wc -l | xargs echo "Total log entries:"
+grep "$SEARCH" "$SKALDLEITA_LOG" 2>/dev/null | grep "POST /api/identify_audio" | wc -l | xargs echo "Audio submissions:"
+grep "$SEARCH" "$SKALDLEITA_LOG" 2>/dev/null | grep "POST /match" | wc -l | xargs echo "Text matches:"

--- a/test-env/test-naming-issues.py
+++ b/test-env/test-naming-issues.py
@@ -1299,6 +1299,66 @@ def main():
         failed += 1
 
     # ==========================================
+    # Issue #79: Generic Title Hallucination Prevention (Merijeek)
+    # "Match Game" was being attributed to fake author "Doc Raymond"
+    # ==========================================
+    print("\n--- Issue #79: Generic Title Hallucination Prevention ---")
+
+    # Check that the prompt includes generic title warning
+    with open('app.py', 'r') as f:
+        app_content = f.read()
+
+    # Test 1: identify_book_with_ai prompt has generic title warning
+    if test_result("identify_book_with_ai prompt warns about generic titles",
+                   "GENERIC TITLE WARNING" in app_content and "Match Game" in app_content,
+                   "Prompt should warn about ambiguous titles like 'Match Game'"):
+        passed += 1
+    else:
+        failed += 1
+
+    # Test 2: build_prompt has generic title warning
+    if test_result("build_prompt warns about hallucinating authors",
+                   "DO NOT HALLUCINATE AUTHORS" in app_content,
+                   "build_prompt should warn against author hallucination"):
+        passed += 1
+    else:
+        failed += 1
+
+    # Test 3: validate_ai_result checks for generic titles
+    if test_result("validate_ai_result detects generic title + no author input",
+                   "generic_title_author_uncertain" in app_content,
+                   "Validation should flag generic titles with uncertain authors"):
+        passed += 1
+    else:
+        failed += 1
+
+    # Test 4: Generic word patterns are defined for detection
+    generic_patterns_defined = "generic_patterns = [" in app_content and "'game'" in app_content
+    if test_result("Generic title patterns defined (game, hunt, prey, etc.)",
+                   generic_patterns_defined,
+                   "Should have list of generic title words"):
+        passed += 1
+    else:
+        failed += 1
+
+    # Test 5: Reasoning requirement in prompt
+    if test_result("AI prompt requires reasoning for identification",
+                   "REASONING REQUIRED" in app_content or "reasoning" in app_content.lower(),
+                   "AI should explain why it identified the book"):
+        passed += 1
+    else:
+        failed += 1
+
+    # Test 6: Prompt instructs to return null over guessing
+    prefer_null = "return null rather than guess" in app_content.lower() or "prefer null over guessing" in app_content.lower() or "return null" in app_content.lower()
+    if test_result("AI prompt prefers null over guessing",
+                   prefer_null,
+                   "Prompt should tell AI to return null if uncertain"):
+        passed += 1
+    else:
+        failed += 1
+
+    # ==========================================
     # Summary
     # ==========================================
     print("\n" + "=" * 60)


### PR DESCRIPTION
## Summary

Fixes #79 - Generic titles like "Match Game" were being attributed to hallucinated authors (e.g., "Doc Raymond").

**Root cause:** The AI prompt encouraged guessing authors for any recognized title, and validation only checked title similarity - author hallucination passed through.

## Changes

### Prompt Improvements
- **identify_book_with_ai**: Added `GENERIC TITLE WARNING` section explaining that titles like "Match Game", "The Game", "Home", etc. are ambiguous and should return low confidence or null
- **identify_book_with_ai**: Added `REASONING REQUIRED` section so AI must explain WHY it identified the book
- **build_prompt**: Added `DO NOT HALLUCINATE AUTHORS` warning with examples

### Validation Improvements  
- **validate_ai_result**: Now detects when:
  - Input folder has no author separator (`-` or `/`)
  - Title is short (≤3 words) AND contains generic patterns
  - AI returned an author anyway
  - → Flags as `generic_title_author_uncertain` with low confidence

### Generic Patterns Detected
`game`, `hunt`, `prey`, `gone`, `home`, `storm`, `dark`, `night`, `day`, `fire`, `ice`, `blood`, `death`, `life`, `love`, `war`, `peace`

## Testing

- Added 6 new tests for hallucination prevention
- All 250 tests pass
- Syntax verified with py_compile

## What This Fixes

**Before:**
- Input: `Match Game` (no author)
- AI invents: `Doc Raymond - Match Game`  
- Validation: ✅ passes (title matched)
- Result: Fake author accepted

**After:**
- Input: `Match Game` (no author)
- AI either:
  - Returns null (preferred)
  - Or returns with low confidence + reasoning
- Validation: Flags as `generic_title_author_uncertain`
- Result: Low confidence, won't auto-apply

## Also Included

- `.gitignore`: Added `.testers.json` for private tester tracking
- `test-env/lookup-tester.sh`: Helper script to look up tester logs by name or IP