### PR TITLE
fix: Crash when author_last sanitization returns None (#79)

### DIFF
--- a/library_manager/utils/path_safety.py
+++ b/library_manager/utils/path_safety.py
@@ -455,7 +455,10 @@ def build_new_path(lib_path, author, title, series=None, series_num=None, narrat
         # Issue #96: Author name format variations
         author_first, author_last = parse_author_name(author)
         safe_author_first = sanitize_path_component(author_first) if author_first else ''
-        safe_author_last = sanitize_path_component(author_last) if author_last else safe_author
+        # Fallback to full author if last name extraction fails (e.g., "James S. A" -> last='A' gets rejected)
+        safe_author_last = sanitize_path_component(author_last) if author_last else None
+        if not safe_author_last:
+            safe_author_last = safe_author  # Use full author name as fallback
         # {author_lf} = "LastName, FirstName", {author_fl} = "FirstName LastName"
         author_lf = format_author_lf(author)
         author_fl = format_author_fl(author)


### PR DESCRIPTION
## Summary

Fixes crash reported by @Merijeek in #79:

```
TypeError: replace() argument 2 must be str, not None
  File "/app/library_manager/utils/path_safety.py", line 467, in build_new_path
    path_str = path_str.replace('{author_last}', safe_author_last)
```

## Root Cause

1. Audio transcription returns truncated author: `"James S. A"` (missing "Corey")
2. `parse_author_name("James S. A")` returns `('James S.', 'A')`
3. `sanitize_path_component('A')` returns `None` (single letter rejected as too short)
4. `safe_author_last = None`
5. `replace('{author_last}', None)` crashes

## Fix

Check if `sanitize_path_component()` returns `None` and fall back to full author name:

```python
safe_author_last = sanitize_path_component(author_last) if author_last else None
if not safe_author_last:
    safe_author_last = safe_author  # Use full author name as fallback
```

## Testing

- 250 tests pass
- Manual verification: `"James S. A"` now uses full author as fallback instead of crashing