### PR TITLE
fix: Bump version to beta.111

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.108"
+APP_VERSION = "0.9.0-beta.111"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:


### PR DESCRIPTION
We forgot to bump the version number. Merijeek is pulling develop but seeing beta.108.