### PR TITLE
feat: Add version bump check to CI (#105)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -79,8 +79,8 @@ jobs:
             echo "Code files changed:"
             echo "$CODE_CHANGED"
 
-            # Check if APP_VERSION was updated
-            if ! git diff $BASE_SHA...$HEAD_SHA -- app.py | grep -q 'APP_VERSION'; then
+            # Check if APP_VERSION was actually modified (not just mentioned in diff context)
+            if ! git diff $BASE_SHA...$HEAD_SHA -- app.py | grep -qE '^[+-].*APP_VERSION'; then
               echo ""
               echo "::error::Code changed but APP_VERSION not bumped!"
               echo "::error::Update APP_VERSION in app.py before merging."


### PR DESCRIPTION
Closes #105

Adds a `version-check` job to the CI that runs on PRs and verifies `APP_VERSION` was updated when code files change.

## What it checks

- Only runs on pull requests (not pushes)
- Detects changes to: `app.py`, `library_manager/*.py`, `templates/*.html`, `static/*.js|css`
- Excludes: test files, docs, README, CI config itself
- If code changed → requires `APP_VERSION` in app.py to be updated
- Clear error messages if check fails

## Why

We pushed beta.109, 110, 111 but forgot to bump the version string. Merijeek pulled `:develop` and was still seeing beta.108. This prevents that from happening again.