### PR TITLE
docs: Add missing README/CHANGELOG entries for beta.111-115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,69 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.115] - 2026-02-05
+
+### Added
+
+- **Issue #119: HMAC Request Signing** - Cryptographic security for Skaldleita API
+  - All requests now include `X-LM-Signature` (HMAC-SHA256) and `X-LM-Timestamp` headers
+  - Prevents unauthorized API usage - requests without valid signatures rejected
+  - Timestamp validation prevents replay attacks
+  - Fixed missing headers on `contribute_to_bookdb()` and `lookup_community_consensus()`
+
+---
+
+## [0.9.0-beta.114] - 2026-02-03
+
+### Changed
+
+- **Issue #117: Email-Only API Key Delivery** - Keys no longer displayed on screen
+  - API key removed from registration response
+  - Key is auto-saved and emailed to user
+  - Prevents key theft if someone knows your email but doesn't have email access
+  - UI shows masked placeholder after registration
+
+---
+
+## [0.9.0-beta.113] - 2026-02-03
+
+### Added
+
+- **Issue #115: In-App Skaldleita API Key Registration**
+  - New `library_manager/instance.py` module - Generates persistent `SKALD-XXXXXX` instance IDs
+  - Register for API key directly from Settings page
+  - New endpoints: `/api/skaldleita/register`, `/api/skaldleita/validate`, `/api/instance/info`
+  - Auto-saves key to `secrets.json` on successful registration
+  - Rate limits: 1000 req/hr with key, 500 without
+
+---
+
+## [0.9.0-beta.112] - 2026-02-03
+
+### Added
+
+- **Issue #110: File Validation Module** - Pre-processing file checks
+  - New `library_manager/file_validation.py` module
+  - `validate_audio_file()` - Check single file with ffprobe
+  - `batch_validate()` - Check multiple files
+  - Catches: corrupt files, missing audio streams, truncated downloads, files < 10 min
+
+---
+
+## [0.9.0-beta.111] - 2026-02-03
+
+### Added
+
+- **Issue #102: Precog Consensus Voting System** - "Minority Report" style identification
+  - New `library_manager/precog.py` module (450+ lines)
+  - Multiple sources vote on book identity with weighted consensus
+  - Source weights: audio (90) > metadata (80) > API (70) > AI (55) > path (30)
+  - Generic title protection: "Match Game", "The End" require 85% consensus (vs 70% normal)
+  - Human review flags: split votes, drastic author changes, low confidence
+  - 10 unit tests in `test-env/test-precog.py`
+
+---
+
 ## [0.9.0-beta.110] - 2026-02-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.114-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.115-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
@@ -15,6 +15,11 @@
 ---
 
 ## Recent Changes (stable)
+
+> **beta.115** - 🔒 **HMAC Request Signing** (Issue #119)
+> - **Cryptographic Signatures** - All Skaldleita API requests now signed with HMAC-SHA256
+> - **Prevents Unauthorized Use** - Requests without valid signatures are rejected
+> - **Timestamp Protection** - Replay attacks blocked via time-based validation
 
 > **beta.114** - 🔐 **Secure API Key Registration** (Issue #117)
 > - **Email-Only Delivery** - API keys no longer shown on screen, sent to email only
@@ -31,6 +36,12 @@
 > - **Pre-rename Checks** - Validates files before attempting renames
 > - **Path Safety** - Checks for invalid characters, path length limits
 > - **Better Errors** - Clear messages when files can't be renamed
+
+> **beta.111** - 🎯 **Precog Consensus Voting** (Issue #102)
+> - **Multi-Source Voting** - Audio, metadata, API, and AI sources vote on book identity
+> - **Weighted Consensus** - Audio (90) > Metadata (80) > API (70) > AI (55) > Path (30)
+> - **Generic Title Protection** - Ambiguous titles require 85% consensus instead of 70%
+> - **Human Review Flags** - Split votes and drastic changes flagged for review
 
 > **beta.110** - 📊 **Enhanced Status Bar** (transparency for users)
 > - **Know Your APIs** - Status bar shows exactly which API is processing your books

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.114"
+APP_VERSION = "0.9.0-beta.115"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:


### PR DESCRIPTION
## Summary
- Adds missing documentation for beta.111-115 features
- Bumps version to beta.115 for HMAC signing

## What was missing

| Version | Feature | README | CHANGELOG |
|---------|---------|--------|-----------|
| beta.115 | HMAC request signing (#119) | ❌→✅ | ❌→✅ |
| beta.114 | Email-only key delivery (#117) | ✅ | ❌→✅ |
| beta.113 | In-app registration (#115) | ✅ | ❌→✅ |
| beta.112 | File validation (#110) | ✅ | ❌→✅ |
| beta.111 | Precog consensus (#102) | ❌→✅ | ❌→✅ |

## Related
- Created deucebucket/vibe-check#5 to catch this in the future