### PR TITLE
fix: Queue count, duplicate entries, series grouping (#131, #132, #133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.117] - 2026-02-08
+
+### Fixed
+
+- **Issue #131: Queue count mismatch** - Dashboard "ready to process" badge now counts only
+  actually processable items, matching the filters used by the processing pipeline. Previously
+  counted all queue items including ones blocked by status or layer filters.
+- **Issue #131: Orphaned queue items** - Books that exhaust all processing layers are now
+  properly marked as "Needs Attention" instead of being stuck in an invisible limbo state.
+- **Issue #132: Duplicate book entries** - Library scan now resolves all paths before database
+  insertion, preventing duplicate entries when symlinks or mount points cause the same file to
+  have different path representations.
+- **Issue #133: Series grouping with custom templates** - When `series_grouping` is enabled
+  and the custom naming template doesn't include `{series_num}`, the series number is now
+  automatically prepended to the title folder (matching built-in format behavior).
+- **Issue #135: Output folder routing** - All pipeline layers (audio ID, audio credits, AI
+  queue) now route watch folder items to the configured output folder. Previously only Layer 4
+  honored the output folder setting.
+
+---
+
 ## [0.9.0-beta.110] - 2026-02-03
 
 ### Added

--- a/app.py
+++ b/app.py
@@ -5988,7 +5988,7 @@ def apply_fix(history_id):
         except ValueError:
             pass
 
-    # Check new_path is in a library (always required - this is where the book goes)
+    # Check new_path is in a library or output folder (this is where the book goes)
     new_in_library = False
     for lib in library_paths:
         try:
@@ -5997,6 +5997,16 @@ def apply_fix(history_id):
             break
         except ValueError:
             continue
+
+    # Issue #135: Also accept output folder as valid destination
+    if not new_in_library:
+        watch_output_folder = config.get('watch_output_folder', '').strip()
+        if watch_output_folder:
+            try:
+                new_path.resolve().relative_to(Path(watch_output_folder).resolve())
+                new_in_library = True
+            except ValueError:
+                pass
 
     # Issue #49: Allow watch folder items to have old_path in watch folder
     old_path_valid = old_in_library or (is_watch_folder_item and old_in_watch_folder)

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.116"
+APP_VERSION = "0.9.0-beta.117"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:
@@ -4859,7 +4859,8 @@ def deep_scan_library(config):
                 # Parse filename to extract searchable title
                 filename = loose_file.stem  # filename without extension
                 cleaned_filename = clean_search_title(filename)
-                path_str = str(loose_file)
+                # Issue #132: Resolve path to prevent duplicates from symlinks/mount differences
+                path_str = str(loose_file.resolve())
 
                 # Check if already in books table
                 c.execute('SELECT id, user_locked FROM books WHERE path = ?', (path_str,))
@@ -4969,7 +4970,8 @@ def deep_scan_library(config):
 
                 # Extract author/title from folder name
                 flat_author, flat_title = extract_author_title(author)
-                flat_path = str(author_dir)
+                # Issue #132: Resolve path to prevent duplicates
+                flat_path = str(author_dir.resolve())
 
                 checked += 1
 
@@ -5017,7 +5019,8 @@ def deep_scan_library(config):
                     continue
 
                 title = title_dir.name
-                path = str(title_dir)
+                # Issue #132: Resolve path to prevent duplicates from symlinks/mount differences
+                path = str(title_dir.resolve())
 
                 # Issue #53: Strip author prefix from book folder name
                 # If folder is "David Baldacci - Dream Town" and parent is "David Baldacci",
@@ -8577,7 +8580,11 @@ def api_stats():
     c.execute('SELECT COUNT(*) as count FROM books')
     total = c.fetchone()['count']
 
-    c.execute('SELECT COUNT(*) as count FROM queue')
+    # Issue #131: Count only processable queue items (matching process_queue filters)
+    c.execute('''SELECT COUNT(*) as count FROM queue q
+                 JOIN books b ON q.book_id = b.id
+                 WHERE b.status NOT IN ('verified', 'fixed', 'series_folder', 'multi_book_files', 'needs_attention')
+                   AND (b.user_locked IS NULL OR b.user_locked = 0)''')
     queue = c.fetchone()['count']
 
     c.execute("SELECT COUNT(*) as count FROM books WHERE status = 'fixed'")

--- a/library_manager/pipeline/layer_audio_credits.py
+++ b/library_manager/pipeline/layer_audio_credits.py
@@ -228,6 +228,17 @@ def process_layer_3_audio(
                     except ValueError:
                         continue
 
+                # Issue #135: Route watch folder items to output folder
+                watch_folder = config.get('watch_folder', '').strip()
+                watch_output = config.get('watch_output_folder', '').strip()
+                if watch_folder and watch_output and lib_path is None:
+                    try:
+                        if book_path.resolve().is_relative_to(Path(watch_folder).resolve()):
+                            lib_path = Path(watch_output)
+                            logger.info(f"[LAYER 3] Watch folder book: routing to output folder {lib_path}")
+                    except Exception:
+                        pass
+
                 if lib_path is None:
                     lib_path = book_path.parent.parent
                     logger.warning(f"[LAYER 3] Book path {book_path} not under any configured library, guessing lib_path={lib_path}")

--- a/library_manager/pipeline/layer_audio_credits.py
+++ b/library_manager/pipeline/layer_audio_credits.py
@@ -236,8 +236,8 @@ def process_layer_3_audio(
                         if book_path.resolve().is_relative_to(Path(watch_folder).resolve()):
                             lib_path = Path(watch_output)
                             logger.info(f"[LAYER 3] Watch folder book: routing to output folder {lib_path}")
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug(f"Watch folder path check failed: {e}")
 
                 if lib_path is None:
                     lib_path = book_path.parent.parent

--- a/library_manager/pipeline/layer_audio_id.py
+++ b/library_manager/pipeline/layer_audio_id.py
@@ -326,8 +326,8 @@ def process_layer_1_audio(
                             try:
                                 if Path(book_path).resolve().is_relative_to(Path(watch_folder).resolve()):
                                     dest_path = Path(watch_output)
-                            except Exception:
-                                pass
+                            except Exception as e:
+                                logger.debug(f"Watch folder path check failed: {e}")
                         # Detect language for multi-language naming
                         lang_code = _detect_title_language(title)
                         computed_path = build_new_path(

--- a/library_manager/pipeline/layer_audio_id.py
+++ b/library_manager/pipeline/layer_audio_id.py
@@ -318,10 +318,20 @@ def process_layer_1_audio(
                     library_paths = current_config.get('library_paths', [])
                     new_path_str = None
                     if library_paths:
+                        # Issue #135: Use output folder for watch folder items
+                        dest_path = Path(library_paths[0])
+                        watch_folder = current_config.get('watch_folder', '').strip()
+                        watch_output = current_config.get('watch_output_folder', '').strip()
+                        if watch_folder and watch_output:
+                            try:
+                                if Path(book_path).resolve().is_relative_to(Path(watch_folder).resolve()):
+                                    dest_path = Path(watch_output)
+                            except Exception:
+                                pass
                         # Detect language for multi-language naming
                         lang_code = _detect_title_language(title)
                         computed_path = build_new_path(
-                            Path(library_paths[0]), author, title,
+                            dest_path, author, title,
                             series=ebook_result.get('series'),
                             series_num=ebook_result.get('series_num'),
                             language_code=lang_code,
@@ -599,10 +609,20 @@ def process_layer_1_audio(
                 library_paths = audio_config.get('library_paths', [])
                 new_path_str = None
                 if library_paths:
+                    # Issue #135: Use output folder for watch folder items
+                    dest_path = Path(library_paths[0])
+                    watch_folder = audio_config.get('watch_folder', '').strip()
+                    watch_output = audio_config.get('watch_output_folder', '').strip()
+                    if watch_folder and watch_output:
+                        try:
+                            if Path(book_path).resolve().is_relative_to(Path(watch_folder).resolve()):
+                                dest_path = Path(watch_output)
+                        except Exception:
+                            pass
                     # Detect language for multi-language naming
                     lang_code = _detect_title_language(title)
                     computed_path = build_new_path(
-                        Path(library_paths[0]), author, title,
+                        dest_path, author, title,
                         series=series, series_num=series_num, narrator=narrator,
                         language_code=lang_code,
                         config=audio_config

--- a/library_manager/utils/path_safety.py
+++ b/library_manager/utils/path_safety.py
@@ -506,6 +506,20 @@ def build_new_path(lib_path, author, title, series=None, series_num=None, narrat
             logger.error(f"BLOCKED: Custom template resulted in empty path")
             return None
 
+        # Issue #133: When series_grouping is enabled but the custom template doesn't
+        # include {series_num}, auto-prepend series number to the title folder (last part)
+        # so the behavior matches built-in naming formats
+        if series_grouping and safe_series and series_num and '{series_num' not in custom_template:
+            try:
+                num = float(str(series_num).replace(',', '.'))
+                if num == int(num):
+                    formatted_num = f"{int(num):02d}"
+                else:
+                    formatted_num = str(series_num)
+            except (ValueError, TypeError):
+                formatted_num = str(series_num)
+            parts[-1] = f"{formatted_num} - {parts[-1]}"
+
         result_path = lib_path
         for part in parts:
             result_path = result_path / part

--- a/library_manager/worker.py
+++ b/library_manager/worker.py
@@ -402,7 +402,26 @@ def process_all_queue(
                 empty_batch_count += 1
                 logger.warning(f"No items processed but {remaining} remain (attempt {empty_batch_count}/3)")
                 if empty_batch_count >= 3:
-                    logger.info(f"Layer 4 cannot process remaining {remaining} items")
+                    logger.info(f"Layer 4 cannot process remaining {remaining} items - marking as needs_attention")
+                    # Issue #131: Mark orphaned queue items as needs_attention
+                    # so they're visible to the user instead of stuck in limbo
+                    conn2 = get_db()
+                    c2 = conn2.cursor()
+                    c2.execute('''UPDATE books SET status = 'needs_attention',
+                                    error_message = 'All processing layers exhausted - could not identify this book automatically'
+                                 WHERE id IN (
+                                     SELECT q.book_id FROM queue q
+                                     JOIN books b ON q.book_id = b.id
+                                     WHERE b.status NOT IN ('verified', 'fixed', 'needs_attention')
+                                 )''')
+                    orphaned = c2.rowcount
+                    c2.execute('''DELETE FROM queue WHERE book_id IN (
+                                     SELECT id FROM books WHERE status = 'needs_attention'
+                                 )''')
+                    conn2.commit()
+                    conn2.close()
+                    if orphaned:
+                        logger.info(f"Marked {orphaned} orphaned queue items as needs_attention")
                     break
                 time.sleep(10)
                 continue


### PR DESCRIPTION
## Summary

Fixes four bugs reported by @Merijeek in #130:

- **Queue count mismatch (#131)**: Dashboard "ready to process" count now matches what's actually processable. Previously counted ALL queue items including ones filtered out by status/layer. Also marks orphaned queue items as `needs_attention` when Layer 4 gives up, instead of leaving them stuck in limbo.
- **Duplicate book entries (#132)**: Library scan now uses `Path.resolve()` for all path construction, matching watch folder behavior. Prevents duplicate DB entries when symlinks or mount points cause the same physical file to have different path representations.
- **Series grouping with custom templates (#133)**: When `series_grouping` is enabled and the custom naming template doesn't include `{series_num}`, the series number prefix is now automatically prepended to the title folder — same behavior as built-in formats.
- **Output folder ignored by pipeline (#135)**: Layer 1 (audio ID) and Layer 3 (audio credits) now route watch folder items to the configured output folder, matching Layer 4 behavior. Also fixed `apply_fix()` to accept output folder as a valid destination path.

## Test plan
- [ ] Queue badge count matches actual processable items
- [ ] Books that fail all layers appear in "Needs Attention" view
- [ ] No duplicate entries after rescan with symlinked paths
- [ ] Series numbers appear with custom template + series_grouping enabled
- [ ] Watch folder books route to output folder through all pipeline layers