### PR TITLE
fix: Process Queue button stalls - switch to background pipeline (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.118] - 2026-02-08
+
+### Fixed
+
+- **Issue #137: "Process Queue" button stalls** - The button now uses background processing
+  with live status bar updates instead of blocking the browser. Previously the HTTP request
+  would block while waiting for Skaldleita audio analysis (30+ seconds per book) with no
+  feedback to the user. Now runs the full pipeline (all layers including audio) and the
+  status bar shows exactly what's happening: current book, provider, queue position, etc.
+
+---
+
 ## [0.9.0-beta.117] - 2026-02-08
 
 ### Fixed

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -313,23 +313,33 @@ function deepRescan() {
 function processQueue() {
     const btn = document.getElementById('process-btn');
     btn.disabled = true;
-    btn.innerHTML = '<i class="bi bi-hourglass-split"></i> Processing...';
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Processing...';
 
-    fetch('/api/process', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({limit: 3})
-    })
+    // Issue #137: Use background endpoint so status bar shows live updates
+    fetch('/api/process_background', {method: 'POST'})
         .then(r => r.json())
         .then(data => {
-            btn.disabled = false;
-            btn.innerHTML = '<i class="bi bi-play-fill"></i> Process Queue (1 batch)';
-            alert(`Processed! ${data.fixed} books analyzed.`);
-            location.reload();
+            if (!data.success) {
+                btn.disabled = false;
+                btn.innerHTML = '<i class="bi bi-play-fill"></i> Process Queue';
+                alert(data.message || 'Processing already running');
+                return;
+            }
+            // Poll for completion - status bar handles live updates
+            const pollInterval = setInterval(() => {
+                fetch('/api/process_status').then(r => r.json()).then(status => {
+                    if (!status.active) {
+                        clearInterval(pollInterval);
+                        btn.disabled = false;
+                        btn.innerHTML = '<i class="bi bi-play-fill"></i> Process Queue';
+                        refreshDashboard();
+                    }
+                });
+            }, 3000);
         })
         .catch(e => {
             btn.disabled = false;
-            btn.innerHTML = '<i class="bi bi-play-fill"></i> Process Queue (1 batch)';
+            btn.innerHTML = '<i class="bi bi-play-fill"></i> Process Queue';
             alert('Error: ' + e);
         });
 }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -334,6 +334,10 @@ function processQueue() {
                         btn.innerHTML = '<i class="bi bi-play-fill"></i> Process Queue';
                         refreshDashboard();
                     }
+                }).catch(() => {
+                    clearInterval(pollInterval);
+                    btn.disabled = false;
+                    btn.innerHTML = '<i class="bi bi-play-fill"></i> Process Queue';
                 });
             }, 3000);
         })

--- a/templates/library.html
+++ b/templates/library.html
@@ -810,6 +810,12 @@ function processQueue() {
                         addActivity('Processing complete', 'success');
                         loadLibrary();
                     }
+                }).catch(() => {
+                    clearInterval(pollInterval);
+                    btn.disabled = false;
+                    btn.innerHTML = '<i class="bi bi-play-fill"></i> Process Queue';
+                    isProcessing = false;
+                    addActivity('Status polling failed - refresh to check', 'error');
                 });
             }, 3000);
         })

--- a/templates/library.html
+++ b/templates/library.html
@@ -782,24 +782,36 @@ function processQueue() {
     const btn = document.getElementById('btn-process');
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Processing...';
-    addActivity('Processing queue...', 'info');
+    addActivity('Starting full pipeline processing...', 'info');
     isProcessing = true;
     suppressProcessingWarning = false;  // Reset warning suppression for new processing session
 
-    fetch('/api/process', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({limit: 5})})
+    // Issue #137: Use background endpoint so status bar shows live updates
+    // (audio analysis via Skaldleita can take 30+ seconds per book)
+    fetch('/api/process_background', {method: 'POST'})
         .then(r => r.json())
         .then(data => {
-            btn.disabled = false;
-            btn.innerHTML = '<i class="bi bi-play-fill"></i> Process Queue';
-            isProcessing = false;
-            // Issue #57: Show clearer status message explaining fixed vs verified
-            if (data.message) {
-                addActivity(data.message, data.status === 'complete' ? 'success' : 'info');
-            } else {
-                // Fallback for older API response format
-                addActivity(`Processed ${data.fixed} items`, 'success');
+            if (!data.success) {
+                btn.disabled = false;
+                btn.innerHTML = '<i class="bi bi-play-fill"></i> Process Queue';
+                isProcessing = false;
+                addActivity(data.message || 'Processing already running', 'warning');
+                return;
             }
-            loadLibrary();
+            addActivity('Background processing started - watch the status bar', 'info');
+            // Poll for completion - status bar handles live updates
+            const pollInterval = setInterval(() => {
+                fetch('/api/process_status').then(r => r.json()).then(status => {
+                    if (!status.active) {
+                        clearInterval(pollInterval);
+                        btn.disabled = false;
+                        btn.innerHTML = '<i class="bi bi-play-fill"></i> Process Queue';
+                        isProcessing = false;
+                        addActivity('Processing complete', 'success');
+                        loadLibrary();
+                    }
+                });
+            }, 3000);
         })
         .catch(e => {
             btn.disabled = false;


### PR DESCRIPTION
## Summary

Fixes the "processing stalls" bug reported by @Merijeek in #130.

**Root cause:** The "Process Queue" button called `/api/process` which:
1. **Blocked the HTTP request** - browser hung with just a spinner, no feedback
2. **Only ran Layers 1+2** (API lookup + AI) - never ran audio analysis via Skaldleita
3. Books needing audio ID were invisible to the button - it returned "processed 0"

**The fix:**
- Both buttons (dashboard + library) now use `/api/process_background`
- Background processor runs the **full pipeline** (`process_all_queue`) including audio analysis
- Status bar shows live updates: current book, Skaldleita queue position, provider being used
- Polls every 3s to detect completion, then re-enables button and refreshes

Closes #130

## Test plan
- [ ] Click "Process Queue" with items needing audio identification
- [ ] Status bar shows live updates (current book, provider)
- [ ] Button shows spinner during processing, re-enables on completion
- [ ] No browser hang/timeout during Skaldleita audio analysis
- [ ] Dashboard refreshes automatically when processing completes