### PR TITLE
feat: Auto-enqueue books after watch folder processing (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.119] - 2026-02-08
+
+### Added
+
+- **Issue #126: Auto-enqueue after watch folder processing** - Books moved from the watch
+  folder to the library are now automatically added to the processing queue. Previously they
+  sat idle with status 'pending' until the user manually triggered a scan or processing.
+  Now they enter the full pipeline (audio ID, AI verification, etc.) immediately.
+
+---
+
 ## [0.9.0-beta.118] - 2026-02-08
 
 ### Fixed

--- a/app.py
+++ b/app.py
@@ -6693,14 +6693,11 @@ def process_watch_folder(config: dict) -> int:
                                      VALUES (?, ?, ?, 'pending', 'watch_folder', datetime('now'), datetime('now'))''',
                                   (new_path, author, title))
                         # Issue #126: Auto-enqueue for full pipeline processing
-                        c.execute('SELECT id FROM books WHERE path = ?', (new_path,))
-                        book_row = c.fetchone()
-                        if book_row:
-                            book_id = book_row['id']
-                            c.execute('''INSERT OR IGNORE INTO queue (book_id, reason, priority)
-                                        VALUES (?, ?, ?)''',
-                                     (book_id, 'watch_folder_new', 3))
-                            c.execute('UPDATE books SET verification_layer = 1 WHERE id = ?', (book_id,))
+                        book_id = c.lastrowid
+                        c.execute('''INSERT OR IGNORE INTO queue (book_id, reason, priority)
+                                    VALUES (?, ?, ?)''',
+                                 (book_id, 'watch_folder_new', 3))
+                        c.execute('UPDATE books SET verification_layer = 1 WHERE id = ?', (book_id,))
                             logger.info(f"Watch folder: Auto-enqueued for processing: {author}/{title}")
                     conn.commit()
                 except Exception as e:

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.118"
+APP_VERSION = "0.9.0-beta.119"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:
@@ -6692,6 +6692,16 @@ def process_watch_folder(config: dict) -> int:
                                      (path, current_author, current_title, status, source_type, added_at, updated_at)
                                      VALUES (?, ?, ?, 'pending', 'watch_folder', datetime('now'), datetime('now'))''',
                                   (new_path, author, title))
+                        # Issue #126: Auto-enqueue for full pipeline processing
+                        c.execute('SELECT id FROM books WHERE path = ?', (new_path,))
+                        book_row = c.fetchone()
+                        if book_row:
+                            book_id = book_row['id']
+                            c.execute('''INSERT OR IGNORE INTO queue (book_id, reason, priority)
+                                        VALUES (?, ?, ?)''',
+                                     (book_id, 'watch_folder_new', 3))
+                            c.execute('UPDATE books SET verification_layer = 1 WHERE id = ?', (book_id,))
+                            logger.info(f"Watch folder: Auto-enqueued for processing: {author}/{title}")
                     conn.commit()
                 except Exception as e:
                     logger.debug(f"Watch folder: Could not add to books table: {e}")

--- a/app.py
+++ b/app.py
@@ -6698,7 +6698,7 @@ def process_watch_folder(config: dict) -> int:
                                     VALUES (?, ?, ?)''',
                                  (book_id, 'watch_folder_new', 3))
                         c.execute('UPDATE books SET verification_layer = 1 WHERE id = ?', (book_id,))
-                            logger.info(f"Watch folder: Auto-enqueued for processing: {author}/{title}")
+                        logger.info(f"Watch folder: Auto-enqueued for processing: {author}/{title}")
                     conn.commit()
                 except Exception as e:
                     logger.debug(f"Watch folder: Could not add to books table: {e}")


### PR DESCRIPTION
## Summary

Books dropped into the watch folder are now automatically queued for the full processing pipeline after being moved to the library.

**Before:** Watch folder moved books to `/library/Author/Title` and inserted them into the DB with `status='pending'`, but never added a queue entry. Books sat idle until the user manually triggered a scan or clicked "Process Queue."

**After:** After the move + DB insert, the book is immediately added to the queue with `verification_layer=1` and reason `watch_folder_new`. The next pipeline run picks it up automatically.

Unknown-author books still go to `needs_attention` for manual review (no change there).

Closes #126

## Test plan
- [ ] Drop a book into the watch folder on sandbox
- [ ] Check logs for "Auto-enqueued for processing" message
- [ ] Verify book appears in queue via `/api/queue`
- [ ] Confirm it processes through the pipeline without manual intervention