### PR TITLE
fix: Add HMAC signing to search_bookdb() match requests (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.120] - 2026-02-09
+
+### Fixed
+
+- **Issue #140: Missing HMAC signing on /match requests** - The security commit (beta.117)
+  added HMAC request signing to all Skaldleita endpoints but missed `search_bookdb()`. Now
+  `/match` requests include `X-LM-Signature` and `X-LM-Timestamp` headers consistent with
+  all other Skaldleita API calls. Note: most of the search issues reported in #140 are
+  Skaldleita data gaps tracked in deucebucket/skaldleita#83, #84, #85.
+
+---
+
 ## [0.9.0-beta.119] - 2026-02-08
 
 ### Added

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.119"
+APP_VERSION = "0.9.0-beta.120"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/library_manager/providers/bookdb.py
+++ b/library_manager/providers/bookdb.py
@@ -138,10 +138,13 @@ def search_bookdb(title, author=None, api_key=None, retry_count=0, bookdb_url=No
         # Build the filename to match - include author if we have it
         filename = f"{author} - {title}" if author else title
 
+        headers = get_signed_headers()
+        headers["X-API-Key"] = api_key
+
         resp = requests.post(
             f"{base_url}/match",
             json={"filename": filename},
-            headers={"X-API-Key": api_key, "User-Agent": get_user_agent()},
+            headers=headers,
             timeout=10
         )
 


### PR DESCRIPTION
## Summary

- `search_bookdb()` was the only Skaldleita API function missing HMAC request signing after the security commit (ec81148)
- All other endpoints (identify_audio, poll, contribute, community_lookup) were updated but `/match` was missed
- Now includes `X-LM-Signature` and `X-LM-Timestamp` headers alongside the existing `X-API-Key`

## Investigation for #140

Merijeek reported Craig Alanson books failing. Root cause analysis:

| Problem | Where | Status |
|---------|-------|--------|
| `/search` returns irrelevant results for Craig Alanson | Skaldleita | deucebucket/skaldleita#83 |
| "Fallout" (ExForce #13) not in database, Columbus Day missing series link | Skaldleita | deucebucket/skaldleita#84 |
| Author misspellings (Craig Allenson, Craig Galanson) | AI providers | Known limitation |
| Missing HMAC signing on `/match` calls | **This PR** | Fixed |

The signing gap wasn't causing the failures (Skaldleita still accepts unsigned `/match`), but it should be consistent with all other endpoints.

## Test plan

- [ ] Verify `/match` still returns results with signed headers
- [ ] Check no regressions in book identification pipeline