### PR TITLE
feat: Sortable columns on library page (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.122] - 2026-02-11
+
+### Added
+
+- **Issue #111: Sortable columns** - Library table columns (Author, Title, Status) can now be
+  sorted by clicking column headers. Click once for ascending, again for descending, third click
+  clears sort back to default order. Visual arrow indicators show active sort column and direction.
+  Sort state preserved during pagination and filter changes. Backend validates sort columns against
+  a whitelist to prevent SQL injection.
+
+---
+
 ## [0.9.0-beta.121] - 2026-02-10
 
 ### Fixed

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.121"
+APP_VERSION = "0.9.0-beta.122"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/templates/library.html
+++ b/templates/library.html
@@ -73,6 +73,18 @@
         padding: 2px 8px;
         font-size: 0.8rem;
     }
+    /* Issue #111: Sortable column headers */
+    th[onclick]:hover {
+        color: #00d9ff;
+    }
+    .sort-icon {
+        font-size: 0.7rem;
+        opacity: 0.5;
+    }
+    .sort-icon.active {
+        opacity: 1;
+        color: #00d9ff;
+    }
 </style>
 
 <!-- Filter Chips -->
@@ -206,9 +218,15 @@
             <thead style="position: sticky; top: 0; background: rgba(22, 33, 62, 0.98); z-index: 10;">
                 <tr>
                     <th style="width: 3%;"><input type="checkbox" id="select-all" onclick="toggleSelectAll()" title="Select all visible"></th>
-                    <th style="width: 23%;">Author</th>
-                    <th style="width: 29%;">Title</th>
-                    <th style="width: 14%;">Status</th>
+                    <th style="width: 23%; cursor: pointer; user-select: none;" onclick="toggleSort('author')" title="Sort by author">
+                        Author <span class="sort-icon" id="sort-icon-author"></span>
+                    </th>
+                    <th style="width: 29%; cursor: pointer; user-select: none;" onclick="toggleSort('title')" title="Sort by title">
+                        Title <span class="sort-icon" id="sort-icon-title"></span>
+                    </th>
+                    <th style="width: 14%; cursor: pointer; user-select: none;" onclick="toggleSort('status')" title="Sort by status">
+                        Status <span class="sort-icon" id="sort-icon-status"></span>
+                    </th>
                     <th style="width: 18%;">Details</th>
                     <th style="width: 13%;">Actions</th>
                 </tr>
@@ -348,6 +366,8 @@
 <script>
 let currentFilter = 'all';
 let currentPage = 1;
+let currentSort = '';
+let currentSortDir = 'asc';
 let libraryData = null;
 let skipConfirmations = {{ 'true' if config.get('skip_confirmations') else 'false' }};
 let isProcessing = false;
@@ -381,6 +401,38 @@ function setFilter(filter) {
 
 let currentSearch = '';
 
+// Issue #111: Sort column toggle
+function toggleSort(column) {
+    if (currentSort === column) {
+        // Same column: toggle direction, or clear on third click
+        if (currentSortDir === 'asc') {
+            currentSortDir = 'desc';
+        } else {
+            currentSort = '';
+            currentSortDir = 'asc';
+        }
+    } else {
+        currentSort = column;
+        currentSortDir = 'asc';
+    }
+    currentPage = 1;
+    loadLibrary();
+}
+
+function updateSortIcons() {
+    document.querySelectorAll('.sort-icon').forEach(icon => {
+        icon.textContent = '';
+        icon.classList.remove('active');
+    });
+    if (currentSort) {
+        const icon = document.getElementById(`sort-icon-${currentSort}`);
+        if (icon) {
+            icon.textContent = currentSortDir === 'asc' ? '\u25B2' : '\u25BC';
+            icon.classList.add('active');
+        }
+    }
+}
+
 function loadLibrary() {
     const tbody = document.getElementById('items-table');
     tbody.innerHTML = `
@@ -396,6 +448,9 @@ function loadLibrary() {
     if (currentSearch) {
         url += `&search=${encodeURIComponent(currentSearch)}`;
     }
+    if (currentSort) {
+        url += `&sort=${currentSort}&sort_dir=${currentSortDir}`;
+    }
     fetch(url)
         .then(r => r.json())
         .then(data => {
@@ -403,6 +458,7 @@ function loadLibrary() {
             updateCounts(data.counts);
             renderItems(data.items);
             renderPagination(data.page, data.total_pages);
+            updateSortIcons();
 
             // Show/hide contextual buttons (with null checks for robustness)
             const btnApplyAll = document.getElementById('btn-apply-all');

--- a/templates/library.html
+++ b/templates/library.html
@@ -455,6 +455,8 @@ function loadLibrary() {
         .then(r => r.json())
         .then(data => {
             libraryData = data;
+            currentSort = data.sort || '';
+            currentSortDir = data.sort_dir || 'asc';
             updateCounts(data.counts);
             renderItems(data.items);
             renderPagination(data.page, data.total_pages);


### PR DESCRIPTION
## Summary
- Click Author, Title, or Status column headers to sort ascending
- Click again for descending, third click clears sort
- Sort state preserved across filter changes and pagination
- Backend validates sort column names against a whitelist (no SQL injection)
- Works across all filter views: verified, pending, queue, errors, search, media types, etc.
- Orphan sorting handled in Python since orphans aren't from SQL

## Test plan
- [ ] Click Author header — items sort A-Z, arrow indicator shows
- [ ] Click again — items sort Z-A, arrow flips
- [ ] Click third time — sort clears, back to default order
- [ ] Switch filter tabs — sort resets, no errors
- [ ] Try Title and Status columns same way
- [ ] Search with sort active — results are sorted
- [ ] Pagination with sort — page 2+ maintains sort order