### PR TITLE
feat: In-app hints + folder triage system (#103, #110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.124] - 2026-02-11
+
+### Added
+
+- **Issue #110 Part 2: Folder triage** - New `library_manager/folder_triage.py` module that
+  categorizes folder names as clean/messy/garbage before processing. Clean folders use path hints
+  normally. Messy folders (scene release tags, torrent markers, quality indicators) skip path
+  parsing and rely on audio/metadata only. Garbage folders (hash names, numbers-only, generic
+  placeholders) also skip path hints and get a confidence penalty. Triage results stored in DB
+  and logged during scans. Integrated into Whisper transcription hints, AI identification
+  prompts, and the processing pipeline queue.
+
+---
+
 ## [0.9.0-beta.123] - 2026-02-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.123] - 2026-02-11
+
+### Added
+
+- **Issue #103: In-app hints and tooltips** - New `library_manager/hints.py` module with contextual
+  documentation for all features and settings. Hover over the (?) icon next to any setting to see a
+  plain-language explanation of what it does. Tooltips added to: all identification layers, AI
+  providers, confidence threshold, trust modes, safety toggles, watch folder, ebook management,
+  metadata embedding, community features, and more. Library page filter chips and action buttons also
+  show helpful tooltips on hover. Users never need to ask "what does this do?" again.
+
+---
+
 ## [0.9.0-beta.122] - 2026-02-11
 
 ### Added

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.122"
+APP_VERSION = "0.9.0-beta.123"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:
@@ -111,6 +111,8 @@ from library_manager.instance import (
     get_instance_data,
     save_instance_data,
 )
+from library_manager.hints import get_all_hints
+from library_manager.folder_triage import triage_folder, triage_book_path, should_use_path_hints, confidence_modifier
 
 # Try to import P2P cache (optional - gracefully degrades if not available)
 try:
@@ -3196,31 +3198,39 @@ def search_book_searxng(query, duration_hours=None):
     return []
 
 
-def calculate_input_quality(folder_name, filenames, info):
+def calculate_input_quality(folder_name, filenames, info, folder_triage='clean'):
     """
     Score the quality of input data for AI identification.
     Returns a score 0-100 and list of usable clues found.
 
     Low quality inputs (random numbers, 'unknown', no words) should not be
     trusted to AI as it will hallucinate famous books.
+
+    Issue #110: folder_triage controls whether folder name is trusted as input.
     """
     score = 0
     clues = []
 
-    # Check folder name for useful info
-    folder_clean = re.sub(r'[_\-\d\.\[\]\(\)]', ' ', folder_name or '').strip()
-    words = [w for w in folder_clean.split() if len(w) > 2 and w.lower() not in ('unknown', 'audiobook', 'audio', 'book', 'mp3', 'the', 'and', 'part')]
+    # Issue #110: Only trust folder name for clean folders
+    use_folder = should_use_path_hints(folder_triage)
 
-    if words:
-        score += min(40, len(words) * 10)  # Up to 40 points for meaningful words
-        clues.append(f"folder_words: {words[:5]}")
+    if use_folder:
+        # Check folder name for useful info
+        folder_clean = re.sub(r'[_\-\d\.\[\]\(\)]', ' ', folder_name or '').strip()
+        words = [w for w in folder_clean.split() if len(w) > 2 and w.lower() not in ('unknown', 'audiobook', 'audio', 'book', 'mp3', 'the', 'and', 'part')]
 
-    # Check for author-title pattern (e.g., "Author - Title")
-    if ' - ' in (folder_name or ''):
-        score += 20
-        clues.append("has_author_title_separator")
+        if words:
+            score += min(40, len(words) * 10)  # Up to 40 points for meaningful words
+            clues.append(f"folder_words: {words[:5]}")
 
-    # Check metadata tags
+        # Check for author-title pattern (e.g., "Author - Title")
+        if ' - ' in (folder_name or ''):
+            score += 20
+            clues.append("has_author_title_separator")
+    else:
+        clues.append(f"folder_skipped: triage={folder_triage}")
+
+    # Check metadata tags (always trusted regardless of folder triage)
     if info.get('title') and info.get('title') not in ('none', 'Unknown', ''):
         score += 25
         clues.append(f"has_title_tag: {info.get('title')[:30]}")
@@ -3238,6 +3248,12 @@ def calculate_input_quality(folder_name, filenames, info):
     if re.match(r'^(unknown|audiobook|audio|book)?[\s_\-]*\d+$', folder_name or '', re.IGNORECASE):
         score = max(0, score - 50)  # Heavy penalty for "unknown_123" type names
         clues.append("PENALTY: numeric_garbage_name")
+
+    # Issue #110: Apply confidence modifier for garbage folders
+    modifier = confidence_modifier(folder_triage)
+    if modifier:
+        score = max(0, score + modifier)
+        clues.append(f"triage_modifier: {modifier}")
 
     return min(100, score), clues
 
@@ -4972,6 +4988,8 @@ def deep_scan_library(config):
                 flat_author, flat_title = extract_author_title(author)
                 # Issue #132: Resolve path to prevent duplicates
                 flat_path = str(author_dir.resolve())
+                # Issue #110: Triage folder name quality
+                flat_triage = triage_folder(author)
 
                 checked += 1
 
@@ -4987,13 +5005,15 @@ def deep_scan_library(config):
                         if has_profile:
                             continue
                     flat_book_id = existing_flat['id']
+                    c.execute('UPDATE books SET folder_triage = ? WHERE id = ?',
+                             (flat_triage, flat_book_id))
                 else:
-                    c.execute('''INSERT INTO books (path, current_author, current_title, status)
-                                 VALUES (?, ?, ?, 'pending')''', (flat_path, flat_author, flat_title))
+                    c.execute('''INSERT INTO books (path, current_author, current_title, status, folder_triage)
+                                 VALUES (?, ?, ?, 'pending', ?)''', (flat_path, flat_author, flat_title, flat_triage))
                     conn.commit()
                     flat_book_id = c.lastrowid
                     scanned += 1
-                    logger.info(f"Added flat book: {flat_author} - {flat_title}")
+                    logger.info(f"Added flat book: {flat_author} - {flat_title} (triage: {flat_triage})")
 
                 # Queue for processing
                 c.execute('SELECT id FROM queue WHERE book_id = ?', (flat_book_id,))
@@ -5136,6 +5156,8 @@ def deep_scan_library(config):
                                 continue  # No audio files, skip
 
                             checked += 1
+                            # Issue #110: Triage folder name quality
+                            series_book_triage = triage_folder(book_title)
 
                             # Check if already tracked
                             c.execute('SELECT id, status, profile, user_locked FROM books WHERE path = ?', (book_path,))
@@ -5149,9 +5171,11 @@ def deep_scan_library(config):
                                     if has_profile:
                                         continue
                                 book_id = existing_book['id']
+                                c.execute('UPDATE books SET folder_triage = ? WHERE id = ?',
+                                         (series_book_triage, book_id))
                             else:
-                                c.execute('''INSERT INTO books (path, current_author, current_title, status)
-                                             VALUES (?, ?, ?, 'pending')''', (book_path, author, book_title))
+                                c.execute('''INSERT INTO books (path, current_author, current_title, status, folder_triage)
+                                             VALUES (?, ?, ?, 'pending', ?)''', (book_path, author, book_title, series_book_triage))
                                 conn.commit()
                                 book_id = c.lastrowid
                                 scanned += 1
@@ -5194,6 +5218,11 @@ def deep_scan_library(config):
 
                 # This is a valid book folder - count it
                 checked += 1
+
+                # Issue #110: Triage folder name quality
+                folder_triage_result = triage_folder(title)
+                if folder_triage_result != 'clean':
+                    logger.info(f"Folder triage: {folder_triage_result} - {title[:60]}")
 
                 # Analyze title
                 title_issues = analyze_title(title, author)
@@ -5257,9 +5286,12 @@ def deep_scan_library(config):
                             queued += 1
                             continue
                     book_id = existing['id']
+                    # Update triage for existing books (backfill)
+                    c.execute('UPDATE books SET folder_triage = ? WHERE id = ?',
+                             (folder_triage_result, book_id))
                 else:
-                    c.execute('''INSERT INTO books (path, current_author, current_title, status)
-                                 VALUES (?, ?, ?, 'pending')''', (path, author, title))
+                    c.execute('''INSERT INTO books (path, current_author, current_title, status, folder_triage)
+                                 VALUES (?, ?, ?, 'pending', ?)''', (path, author, title, folder_triage_result))
                     conn.commit()
                     book_id = c.lastrowid
                     scanned += 1
@@ -5512,19 +5544,26 @@ def transcribe_audio_intro(file_path, duration_seconds=45):
                 initial_prompt = "This is an audiobook introduction. The narrator typically announces the book title, author name, and narrator."
 
                 # Add folder hints to the prompt if available
+                # Issue #110: Only use folder hints for clean triage folders
                 folder_path = Path(file_path).parent
                 folder_name = folder_path.name
                 parent_name = folder_path.parent.name if folder_path.parent else ""
 
-                # Extract potential author/title from folder structure for spelling hints
-                hints = []
-                if parent_name and parent_name not in ['audiobooks', 'Unknown', '']:
-                    hints.append(parent_name)
-                if folder_name and folder_name not in ['audiobooks', 'Unknown', '']:
-                    hints.append(folder_name)
+                # Check folder triage before trusting folder names as hints
+                folder_triage_result = triage_folder(folder_name)
 
-                if hints:
-                    initial_prompt += f" Possible names: {', '.join(hints)}."
+                if should_use_path_hints(folder_triage_result):
+                    # Extract potential author/title from folder structure for spelling hints
+                    hints = []
+                    if parent_name and parent_name not in ['audiobooks', 'Unknown', '']:
+                        hints.append(parent_name)
+                    if folder_name and folder_name not in ['audiobooks', 'Unknown', '']:
+                        hints.append(folder_name)
+
+                    if hints:
+                        initial_prompt += f" Possible names: {', '.join(hints)}."
+                else:
+                    logger.info(f"[LAYER 1/AUDIO] Skipping folder hints (triage: {folder_triage_result}): {folder_name[:40]}")
 
                 # Transcribe with better settings for accuracy
                 segments, info = whisper_model.transcribe(
@@ -6760,6 +6799,12 @@ def is_worker_running():
 def inject_worker_status():
     """Inject worker_running into all templates automatically."""
     return {'worker_running': is_worker_running()}
+
+
+@app.context_processor
+def inject_hints():
+    """Inject hints dictionary into all templates for tooltips."""
+    return {'hints': get_all_hints()}
 
 # ============== ROUTES ==============
 
@@ -9111,7 +9156,8 @@ def api_library():
         # Issue #36: Filter out series_folder and multi_book_files - they should never appear in queue
         order = build_order_by(QUEUE_SORT_COLS, 'q.priority, q.added_at')
         c.execute('''SELECT q.id as queue_id, q.reason, q.added_at, q.priority,
-                            b.id as book_id, b.path, b.current_author, b.current_title, b.status
+                            b.id as book_id, b.path, b.current_author, b.current_title, b.status,
+                            b.folder_triage
                      FROM queue q
                      JOIN books b ON q.book_id = b.id
                      WHERE b.status NOT IN ('series_folder', 'multi_book_files', 'verified', 'fixed')
@@ -9128,7 +9174,8 @@ def api_library():
                 'status': 'in_queue',
                 'reason': row['reason'],
                 'priority': row['priority'],
-                'added_at': row['added_at']
+                'added_at': row['added_at'],
+                'folder_triage': row['folder_triage'] or 'clean'
             })
 
     elif status_filter == 'fixed':

--- a/library_manager/database.py
+++ b/library_manager/database.py
@@ -126,6 +126,13 @@ def init_db(db_path=None):
         except:
             pass  # Column already exists
 
+    # Add folder_triage column - categorizes folder name quality (clean/messy/garbage)
+    # Issue #110: Used to decide whether to trust path-derived hints
+    try:
+        c.execute("ALTER TABLE books ADD COLUMN folder_triage TEXT DEFAULT 'clean'")
+    except:
+        pass  # Column already exists
+
     # Stats table - daily stats
     c.execute('''CREATE TABLE IF NOT EXISTS stats (
         id INTEGER PRIMARY KEY,

--- a/library_manager/folder_triage.py
+++ b/library_manager/folder_triage.py
@@ -1,0 +1,98 @@
+"""
+Folder triage - categorize folder names by cleanliness.
+
+Determines processing strategy per-folder:
+- CLEAN: Use folder name as hints for author/title parsing
+- MESSY: Skip path parsing, rely on audio/metadata only
+- GARBAGE: Skip path parsing, expect harder match, lower confidence
+
+Issue #110 Part 2
+"""
+import os
+import re
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Scene release tags, torrent markers, quality indicators
+MESSY_PATTERNS = [
+    r'\{[a-z]+\}',              # {mb}, {cbt}
+    r'\[[A-Z0-9]+\]',           # [FLAC], [MP3]
+    r'\([A-Za-z]+\)',            # (Thorne), (narrator)
+    r'^\d{4}\s*-',              # 2023 -
+    r'\d{2}\.\d{2}\.\d{2}',     # 01.10.42
+    r'\d+k\b',                  # 62k, 128k
+    r'\d+kbps',                 # 64kbps
+    r'\bHQ\b|\bLQ\b',           # Quality markers
+    r'-[A-Z]{2,4}$',            # -TEAM suffix (scene release)
+    r'\.com\b',                 # Website in name
+    r'\bwww\.',                 # Website prefix
+    r'\b(rip|ripped|scene)\b',  # Rip indicators
+    r'\b(x264|aac|mp3|flac|ogg|m4b)\b',  # Codec in name
+]
+
+# Completely useless folder names
+GARBAGE_PATTERNS = [
+    r'^[a-f0-9]{12,}$',         # Hash-only names (12+ hex chars)
+    r'^[\d\s\-\.]+$',           # Numbers only
+    r'^(New Folder|tmp|downloads?|torrents?|audiobooks?|untitled)$',
+    r'^(CD|Disc|Track)\s*\d+$', # Disc/track folders
+    r'^Unknown\s*(Artist|Author|Album)?$',  # Generic unknowns
+]
+
+# Compiled patterns for performance (compiled once at import time)
+_MESSY_COMPILED = [re.compile(p, re.IGNORECASE) for p in MESSY_PATTERNS]
+_GARBAGE_COMPILED = [re.compile(p, re.IGNORECASE) for p in GARBAGE_PATTERNS]
+
+
+def triage_folder(folder_name):
+    """
+    Categorize a folder name by cleanliness.
+
+    Returns:
+        'clean'   - Folder name looks like a real author/title
+        'messy'   - Has scene tags or markers but might have useful info
+        'garbage' - Completely useless (hash, numbers, generic placeholder)
+    """
+    if not folder_name or not folder_name.strip():
+        return 'garbage'
+
+    folder_name = folder_name.strip()
+
+    # Check garbage first (most restrictive)
+    for pattern in _GARBAGE_COMPILED:
+        if pattern.match(folder_name):
+            return 'garbage'
+
+    # Check messy patterns
+    for pattern in _MESSY_COMPILED:
+        if pattern.search(folder_name):
+            return 'messy'
+
+    return 'clean'
+
+
+def triage_book_path(book_path):
+    """
+    Triage the book folder from a full book path.
+
+    For a path like /audiobooks/Author Name/Book Title,
+    triages the immediate parent folder (Book Title).
+
+    Returns:
+        tuple: (triage_result, folder_name)
+    """
+    folder_name = os.path.basename(book_path) if book_path else ''
+    return triage_folder(folder_name), folder_name
+
+
+def should_use_path_hints(triage_result):
+    """Whether path-derived hints should be trusted for this triage category."""
+    return triage_result == 'clean'
+
+
+def confidence_modifier(triage_result):
+    """Confidence adjustment based on folder triage category."""
+    if triage_result == 'garbage':
+        return -10
+    return 0

--- a/library_manager/hints.py
+++ b/library_manager/hints.py
@@ -1,0 +1,118 @@
+"""
+In-app documentation hints for Library Manager.
+Provides contextual help text for UI tooltips and hover explanations.
+"""
+
+HINTS = {
+    # === Identification Layers ===
+    'layer_1': 'Database Lookups: Searches Skaldleita, Audnexus, OpenLibrary, Google Books, and Hardcover for metadata matches. Free, fast, no API key needed.',
+    'layer_2': 'AI Verification: When databases return uncertain matches, AI (Gemini, OpenRouter, or Ollama) cross-checks the results. Uses your configured AI provider.',
+    'layer_3': 'Audio Analysis: Extracts the first 90 seconds of audio to identify the book from narrator intros and title announcements. Can use Skaldleita GPU or your own Gemini API.',
+    'layer_4': 'Content Analysis: Last resort. Transcribes story text with Whisper and sends it to AI to identify the book. Slowest but catches edge cases other layers miss.',
+
+    # === AI Providers ===
+    'skaldleita': 'Free GPU-powered audio identification service. Transcribes your audiobook intro and matches it against 50M+ books. Does not use your API quota.',
+    'gemini': 'Google Gemini AI. Free tier offers 14,400 calls/day with Gemma 3 models. Handles both text verification and native audio analysis.',
+    'openrouter': 'API gateway to multiple AI models. Free models available (Llama, Gemma). Used as fallback when Gemini is unavailable or for Layer 4 content analysis.',
+    'ollama': 'Self-hosted AI. Run models locally with no API costs or rate limits. Requires separate Ollama installation.',
+
+    # === Confidence & Verification ===
+    'confidence_threshold': 'Minimum confidence percentage before a book is considered identified. Higher values mean more certainty but slower processing. Lower values accept weaker matches faster.',
+    'confidence_percentage': 'How certain the system is about this identification. Built from multiple sources: audio analysis (85 weight), ID3 tags (80), metadata files (75), database lookups (65), AI (60), path analysis (40). Multiple agreeing sources boost confidence.',
+    'deep_scan_mode': 'Runs ALL enabled identification layers for every book, even if an earlier layer already found a confident match. Slower but more thorough.',
+
+    # === Status Meanings ===
+    'status_pending': 'A rename has been proposed. Review the suggested author/title and click Apply to rename, or Reject to dismiss.',
+    'status_verified': 'This book is already in the correct Author/Title folder. No changes needed.',
+    'status_fixed': 'This book was successfully renamed and moved to its new Author/Title location.',
+    'status_queued': 'Waiting to be identified. Will be processed automatically when the worker runs, or click Process Queue to start now.',
+    'status_error': 'Something went wrong during identification or renaming. Check the error message for details.',
+    'status_attention': 'Could not be auto-identified with enough confidence. Needs manual review - click Edit to set the correct author and title.',
+    'status_orphan': 'Loose audio files without a proper folder structure. Click Organize to move them into an Author/Title folder.',
+    'status_locked': 'Protected from automatic changes. Unlock to allow the system to process this book again.',
+    'status_duplicate': 'Multiple copies of the same book detected in your library.',
+    'status_reversed': 'Author and title folders appear swapped (e.g., Title/Author instead of Author/Title).',
+
+    # === Settings - Library Tab ===
+    'library_paths': 'Folders containing your audiobook library. Each path is scanned for book folders. Supports multiple paths (one per line).',
+    'naming_format': 'How renamed folders are structured. Author/Title works with Audiobookshelf, Plex, and Jellyfin. Custom templates let you include series, narrator, year, and more.',
+    'series_grouping': 'Groups series books under a shared folder: Author/Series Name/1 - Title. Keeps multi-book series organized together.',
+    'standardize_initials': 'Normalizes author initials to a consistent format (e.g., "JRR Tolkien" and "J.R.R. Tolkien" both become "J. R. R. Tolkien"). Prevents duplicate author folders.',
+    'strip_unabridged': 'Removes "(Unabridged)", "[Unabridged]", and similar markers from book titles during rename.',
+    'multilang_naming': 'Controls how non-English books are named. Native keeps the original language title. Preferred translates to your language. Tagged adds a language indicator.',
+
+    # === Settings - Watch Folder ===
+    'watch_folder': 'Monitors a folder for new audiobooks and automatically organizes them into your library. Great for processing downloads or imports.',
+    'watch_interval': 'How often (in seconds) to check the watch folder for new files.',
+    'watch_min_age': 'Minimum file age before processing. Prevents picking up files still being downloaded or copied.',
+    'watch_hard_links': 'Use hard links instead of moving files. Only works when watch folder and library are on the same filesystem. Saves disk space during processing.',
+
+    # === Settings - Processing Tab ===
+    'background_processing': 'Automatically processes queue items without manual intervention. Disable to only process when you click Process Queue.',
+    'scan_interval': 'Hours between automatic library scans. The system checks for new or changed books at this interval.',
+    'batch_size': 'Number of books processed in each batch. Higher values process faster but use more API calls at once.',
+    'max_requests_per_hour': 'Rate limit for API calls. Prevents hitting provider rate limits. Range: 10-500.',
+
+    # === Settings - AI Setup Tab ===
+    'gemini_api_key': 'Free API key from Google AI Studio (aistudio.google.com). Enables Gemini AI for text verification and audio analysis. 14,400 free calls per day.',
+    'openrouter_api_key': 'API key from openrouter.ai. Provides access to free AI models as fallback, and enables Layer 4 content analysis.',
+    'bookdb_api_key': 'Optional Skaldleita API key. Increases your rate limit from 500 to 1000 requests per hour. Free to register.',
+    'google_books_api_key': 'Optional Google Books API key for higher rate limits on book lookups.',
+    'ai_provider': 'Which AI to try first for text verification. Falls back to other configured providers automatically if the primary fails.',
+    'provider_chain': 'Order in which providers are tried. If the first one fails or is unavailable, the next one is used automatically.',
+
+    # === Settings - Safety Tab ===
+    'auto_fix': 'Automatically applies safe renames without asking. Only applies non-drastic changes (e.g., fixing capitalization). Drastic author changes still require approval.',
+    'protect_author_changes': 'When the author changes completely (e.g., "Unknown" to "Stephen King"), the fix is sent to Pending for manual review instead of auto-applying.',
+    'trust_the_process': 'YOLO mode. Auto-applies ALL changes when AI and audio analysis agree, including drastic author changes. No safety net. Back up your library first.',
+    'skip_confirmations': 'Removes "Are you sure?" popups when clicking Apply, Reject, or Undo. Faster workflow but no second chances.',
+
+    # === Settings - Advanced Tab ===
+    'metadata_embedding': 'Writes metadata tags (title, author, narrator, series) directly into audio files when fixes are applied. Supports MP3, M4B, FLAC, and Ogg.',
+    'ebook_management': 'Enables scanning and organizing ebook files (.epub, .mobi, .azw3, .pdf). Can merge ebooks into the same Author/Title folders as audiobooks or keep them separate.',
+    'isbn_lookup': 'Extracts ISBN from EPUB/PDF metadata for more accurate book matching.',
+    'error_reporting': 'Shares anonymous error reports to help improve Library Manager. Never includes file paths, API keys, or personal data.',
+    'community_contributions': 'Shares extracted metadata (author, title, narrator) with other Library Manager users. When 2+ users agree on metadata, it becomes verified for everyone.',
+    'p2p_cache': 'Shares book lookup results via a decentralized peer-to-peer network. Helps when Skaldleita is temporarily unavailable.',
+    'language_detection': 'Uses Gemini to detect the spoken language of audiobooks from audio samples.',
+    'strict_language_matching': 'Only matches books in your preferred language. Prevents cross-language mismatches (e.g., a Russian audiobook matching an English database entry).',
+    'preserve_original_titles': 'Keeps foreign language titles as-is instead of translating them to your preferred language.',
+    'deep_verification': 'Re-verifies your entire library against APIs, even books that look correctly named. Use when you suspect misattributed books in an imported collection.',
+
+    # === Trust Mode ===
+    'sl_trust_full': 'Accepts Skaldleita matches at 80%+ confidence and skips AI verification. Recommended - GPU Whisper with 50M book database is usually accurate.',
+    'sl_trust_boost': 'Uses Skaldleita results as a strong hint, then verifies with database APIs. Skips AI. Good middle ground.',
+    'sl_trust_legacy': 'Uses AI to verify uncertain Skaldleita matches. Most thorough but uses more API quota.',
+
+    # === Source Icons ===
+    'source_bookdb': 'Identified via Skaldleita - GPU-powered audio fingerprinting matched against 50M+ book database.',
+    'source_audio': 'Identified from audio analysis - narrator intro or title announcement detected.',
+    'source_ai': 'Verified by AI - an AI model confirmed the identification.',
+    'source_id3': 'Metadata from embedded ID3/audio tags in the file itself.',
+    'source_json': 'Metadata from a JSON sidecar file (e.g., metadata.json, info.json).',
+    'source_path': 'Inferred from the folder path and filename structure.',
+    'source_googlebooks': 'Matched via Google Books API.',
+    'source_openlibrary': 'Matched via OpenLibrary API.',
+    'source_audnexus': 'Matched via Audnexus (Audible metadata).',
+    'source_hardcover': 'Matched via Hardcover API (indie/modern books).',
+    'source_user': 'Manually set by user - overrides all other sources.',
+
+    # === Voice ID ===
+    'voice_id': 'Identifies narrators by voice fingerprint - like Shazam for audiobooks. Builds a community narrator library that improves over time.',
+
+    # === Misc UI ===
+    'free_badge': 'This feature is completely free - no API key or payment required.',
+    'uses_tokens_badge': 'This feature uses API calls from your configured provider. Check your provider dashboard for usage.',
+    'scan_library': 'Scans your library paths for new or changed audiobook folders. Does not process them - just discovers what needs to be identified.',
+    'process_queue': 'Starts processing all queued books through the identification pipeline (Layer 1 through Layer 4, depending on your settings).',
+}
+
+
+def get_hint(key: str, default: str = '') -> str:
+    """Get a hint by key, returns empty string if not found."""
+    return HINTS.get(key, default)
+
+
+def get_all_hints() -> dict:
+    """Get all hints for template rendering."""
+    return HINTS.copy()

--- a/templates/library.html
+++ b/templates/library.html
@@ -85,6 +85,61 @@
         opacity: 1;
         color: #00d9ff;
     }
+    .hint-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        border: 1px solid rgba(0, 217, 255, 0.4);
+        color: rgba(0, 217, 255, 0.6);
+        font-size: 9px;
+        font-weight: bold;
+        font-style: normal;
+        cursor: help;
+        margin-left: 3px;
+        position: relative;
+        vertical-align: middle;
+        line-height: 1;
+    }
+    .hint-icon:hover {
+        border-color: #00d9ff;
+        color: #00d9ff;
+    }
+    .hint-icon .hint-text {
+        display: none;
+        position: absolute;
+        bottom: calc(100% + 8px);
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(15, 52, 96, 0.95);
+        border: 1px solid rgba(0, 217, 255, 0.3);
+        color: #eee;
+        padding: 8px 12px;
+        border-radius: 6px;
+        font-size: 0.8rem;
+        font-weight: normal;
+        font-style: normal;
+        line-height: 1.4;
+        white-space: normal;
+        width: 260px;
+        z-index: 1000;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        pointer-events: none;
+    }
+    .hint-icon .hint-text::after {
+        content: '';
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        border: 6px solid transparent;
+        border-top-color: rgba(0, 217, 255, 0.3);
+    }
+    .hint-icon:hover .hint-text {
+        display: block;
+    }
 </style>
 
 <!-- Filter Chips -->
@@ -95,42 +150,42 @@
             <span class="ms-2">All</span>
             <span class="count" id="count-all">0</span>
         </a>
-        <a href="#" class="filter-chip" data-filter="pending" onclick="setFilter('pending'); return false;">
+        <a href="#" class="filter-chip" data-filter="pending" onclick="setFilter('pending'); return false;" title="{{ hints.status_pending }}">
             <i class="bi bi-hourglass-split text-warning"></i>
             <span class="ms-2">Pending</span>
             <span class="count" id="count-pending">0</span>
         </a>
-        <a href="#" class="filter-chip" data-filter="orphan" onclick="setFilter('orphan'); return false;">
+        <a href="#" class="filter-chip" data-filter="orphan" onclick="setFilter('orphan'); return false;" title="{{ hints.status_orphan }}">
             <i class="bi bi-file-earmark-music text-info"></i>
             <span class="ms-2">Orphans</span>
             <span class="count" id="count-orphan">0</span>
         </a>
-        <a href="#" class="filter-chip" data-filter="queue" onclick="setFilter('queue'); return false;">
+        <a href="#" class="filter-chip" data-filter="queue" onclick="setFilter('queue'); return false;" title="{{ hints.status_queued }}">
             <i class="bi bi-list-task text-primary"></i>
             <span class="ms-2">Queue</span>
             <span class="count" id="count-queue">0</span>
         </a>
-        <a href="#" class="filter-chip" data-filter="fixed" onclick="setFilter('fixed'); return false;" title="Books that were renamed/moved to new locations">
+        <a href="#" class="filter-chip" data-filter="fixed" onclick="setFilter('fixed'); return false;" title="{{ hints.status_fixed }}">
             <i class="bi bi-check-circle text-success"></i>
             <span class="ms-2">Fixed</span>
             <span class="count" id="count-fixed">0</span>
         </a>
-        <a href="#" class="filter-chip" data-filter="verified" onclick="setFilter('verified'); return false;" title="Books already in correct location - no changes needed">
+        <a href="#" class="filter-chip" data-filter="verified" onclick="setFilter('verified'); return false;" title="{{ hints.status_verified }}">
             <i class="bi bi-patch-check text-success"></i>
             <span class="ms-2">Verified</span>
             <span class="count" id="count-verified">0</span>
         </a>
-        <a href="#" class="filter-chip" data-filter="error" onclick="setFilter('error'); return false;">
+        <a href="#" class="filter-chip" data-filter="error" onclick="setFilter('error'); return false;" title="{{ hints.status_error }}">
             <i class="bi bi-exclamation-triangle text-danger"></i>
             <span class="ms-2">Errors</span>
             <span class="count" id="count-error">0</span>
         </a>
-        <a href="#" class="filter-chip" data-filter="attention" onclick="setFilter('attention'); return false;">
+        <a href="#" class="filter-chip" data-filter="attention" onclick="setFilter('attention'); return false;" title="{{ hints.status_attention }}">
             <i class="bi bi-eye text-warning"></i>
             <span class="ms-2">Attention</span>
             <span class="count" id="count-attention">0</span>
         </a>
-        <a href="#" class="filter-chip" data-filter="locked" onclick="setFilter('locked'); return false;">
+        <a href="#" class="filter-chip" data-filter="locked" onclick="setFilter('locked'); return false;" title="{{ hints.status_locked }}">
             <i class="bi bi-lock-fill text-info"></i>
             <span class="ms-2">Locked</span>
             <span class="count" id="count-locked">0</span>
@@ -177,10 +232,10 @@
 <div class="card mb-4">
     <div class="card-body py-2">
         <div class="d-flex flex-wrap align-items-center gap-2">
-            <button class="btn btn-primary btn-sm" onclick="scanLibrary()" id="btn-scan">
+            <button class="btn btn-primary btn-sm" onclick="scanLibrary()" id="btn-scan" title="{{ hints.scan_library }}">
                 <i class="bi bi-search"></i> Scan Library
             </button>
-            <button class="btn btn-success btn-sm" onclick="processQueue()" id="btn-process">
+            <button class="btn btn-success btn-sm" onclick="processQueue()" id="btn-process" title="{{ hints.process_queue }}">
                 <i class="bi bi-play-fill"></i> Process Queue
             </button>
             <button class="btn btn-warning btn-sm" onclick="applyAllPending()" id="btn-apply-all" style="display: none;">
@@ -227,7 +282,7 @@
                     <th style="width: 14%; cursor: pointer; user-select: none;" onclick="toggleSort('status')" title="Sort by status">
                         Status <span class="sort-icon" id="sort-icon-status"></span>
                     </th>
-                    <th style="width: 18%;">Details</th>
+                    <th style="width: 18%;">Details <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.confidence_percentage }}</span></span></th>
                     <th style="width: 13%;">Actions</th>
                 </tr>
             </thead>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2,6 +2,64 @@
 {% block title %}Settings - Library Manager{% endblock %}
 
 {% block content %}
+<style>
+    .hint-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        border: 1px solid rgba(0, 217, 255, 0.4);
+        color: rgba(0, 217, 255, 0.6);
+        font-size: 10px;
+        font-weight: bold;
+        font-style: normal;
+        cursor: help;
+        margin-left: 4px;
+        position: relative;
+        vertical-align: middle;
+        line-height: 1;
+        flex-shrink: 0;
+    }
+    .hint-icon:hover {
+        border-color: #00d9ff;
+        color: #00d9ff;
+    }
+    .hint-icon .hint-text {
+        display: none;
+        position: absolute;
+        bottom: calc(100% + 8px);
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(15, 52, 96, 0.95);
+        border: 1px solid rgba(0, 217, 255, 0.3);
+        color: #eee;
+        padding: 8px 12px;
+        border-radius: 6px;
+        font-size: 0.8rem;
+        font-weight: normal;
+        font-style: normal;
+        line-height: 1.4;
+        white-space: normal;
+        width: 280px;
+        z-index: 1000;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        pointer-events: none;
+    }
+    .hint-icon .hint-text::after {
+        content: '';
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        border: 6px solid transparent;
+        border-top-color: rgba(0, 217, 255, 0.3);
+    }
+    .hint-icon:hover .hint-text {
+        display: block;
+    }
+</style>
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h2><i class="bi bi-gear"></i> Settings</h2>
     <span class="text-muted">v{{ version }}</span>
@@ -169,6 +227,7 @@
                                        {% if config.series_grouping %}checked{% endif %}>
                                 <label class="form-check-label" for="series_grouping">
                                     <strong>Series Grouping</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.series_grouping }}</span></span>
                                     <br><small class="text-muted">Use <code>Author/Series/1 - Title/</code> format</small>
                                 </label>
                             </div>
@@ -178,6 +237,7 @@
                                        {% if config.standardize_author_initials %}checked{% endif %}>
                                 <label class="form-check-label" for="standardize_author_initials">
                                     <strong>Standardize Author Initials</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.standardize_initials }}</span></span>
                                     <br><small class="text-muted">Normalize to <code>J. R. R. Tolkien</code> format</small>
                                 </label>
                             </div>
@@ -187,6 +247,7 @@
                                        {% if config.strip_unabridged %}checked{% endif %}>
                                 <label class="form-check-label" for="strip_unabridged">
                                     <strong>Strip "Unabridged" from Titles</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.strip_unabridged }}</span></span>
                                     <br><small class="text-muted">Remove (Unabridged), [Unabridged], etc. from book titles</small>
                                 </label>
                             </div>
@@ -264,6 +325,7 @@
                                        {% if config.watch_mode %}checked{% endif %} onchange="toggleWatchOptions()">
                                 <label class="form-check-label" for="watch_mode">
                                     <strong>Enable Watch Folder</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.watch_folder }}</span></span>
                                     <br><small class="text-muted">Auto-organize new audiobooks from a folder</small>
                                 </label>
                             </div>
@@ -324,6 +386,7 @@
                                        {% if config.ebook_management %}checked{% endif %} onchange="toggleEbookOptions()">
                                 <label class="form-check-label" for="ebook_management">
                                     <strong>Enable Ebook Management</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.ebook_management }}</span></span>
                                     <br><small class="text-muted">Organize .epub, .mobi, .azw3, .pdf files</small>
                                 </label>
                             </div>
@@ -344,6 +407,7 @@
                                            {% if config.enable_isbn_lookup %}checked{% endif %}>
                                     <label class="form-check-label" for="enable_isbn_lookup">
                                         <strong>ISBN Lookup</strong>
+                                        <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.isbn_lookup }}</span></span>
                                         <br><small class="text-muted">Extract ISBN from EPUB/PDF metadata for better matching (requires ebooklib/pypdf)</small>
                                     </label>
                                 </div>
@@ -369,6 +433,7 @@
                                        {% if config.enabled %}checked{% endif %}>
                                 <label class="form-check-label" for="enabled">
                                     <strong>Enable Background Processing</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.background_processing }}</span></span>
                                     <br><small class="text-muted">Automatically process queue items in the background</small>
                                 </label>
                             </div>
@@ -408,12 +473,15 @@
                                        id="deep_scan_mode" {% if config.deep_scan_mode %}checked{% endif %}>
                                 <label class="form-check-label" for="deep_scan_mode">
                                     <strong>Deep Scan Mode</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.deep_scan_mode }}</span></span>
                                     <br><small class="text-muted">Run ALL enabled layers for every book (slower, more thorough)</small>
                                 </label>
                             </div>
 
                             <div class="mb-0">
-                                <label class="form-label">Confidence Threshold: <strong id="threshold-display">{{ config.profile_confidence_threshold or 85 }}%</strong></label>
+                                <label class="form-label">Confidence Threshold: <strong id="threshold-display">{{ config.profile_confidence_threshold or 85 }}%</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.confidence_threshold }}</span></span>
+                                </label>
                                 <input type="range" class="form-range" name="profile_confidence_threshold"
                                        id="profile_confidence_threshold" min="50" max="100" step="5"
                                        value="{{ config.profile_confidence_threshold or 85 }}"
@@ -440,6 +508,7 @@
                                 <label class="form-label mb-1">
                                     <i class="bi bi-shield-check text-success"></i>
                                     <strong>Skaldleita Trust Mode</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.skaldleita }}</span></span>
                                 </label>
                                 <select name="sl_trust_mode" class="form-select form-select-sm">
                                     <option value="full" {% if config.sl_trust_mode == 'full' or config.sl_trust_mode is not defined %}selected{% endif %}>
@@ -465,6 +534,7 @@
                                 <label class="form-check-label" for="enable_api_lookups">
                                     <i class="bi bi-cloud text-info"></i> <strong>Layer 1: Database Lookups</strong>
                                     <span class="badge bg-success">Free</span>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.layer_1 }}</span></span>
                                     <br><small class="text-muted">Skaldleita, Audnexus, OpenLibrary, Google Books</small>
                                 </label>
                             </div>
@@ -475,6 +545,7 @@
                                 <label class="form-check-label" for="enable_ai_verification">
                                     <i class="bi bi-robot text-warning"></i> <strong>Layer 2: AI Verification</strong>
                                     <span class="badge bg-warning text-dark">Uses Tokens</span>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.layer_2 }}</span></span>
                                     <br><small class="text-muted">Ask AI when databases don't have a confident match</small>
                                 </label>
                             </div>
@@ -487,6 +558,7 @@
                                     <i class="bi bi-soundwave text-danger"></i> <strong>Layer 3: Audio Analysis</strong>
                                     <span class="badge bg-warning text-dark">Uses Tokens</span>
                                     {% if not config.gemini_api_key %}<span class="badge bg-secondary">Needs Gemini</span>{% endif %}
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.layer_3 }}</span></span>
                                     <br><small class="text-muted">Listen to first 90 seconds for narrator intro</small>
                                 </label>
                             </div>
@@ -498,6 +570,7 @@
                                 <label class="form-check-label" for="use_skaldleita_for_audio">
                                     <i class="bi bi-cloud-arrow-up text-primary"></i> Use Skaldleita for Audio ID
                                     <span class="badge bg-success">Recommended</span>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.skaldleita }}</span></span>
                                     <br><small class="text-muted">GPU Whisper + 50M book database (faster, no rate limits). Disable to use your own AI/Whisper.</small>
                                 </label>
                             </div>
@@ -509,6 +582,7 @@
                                 <label class="form-check-label" for="enable_voice_id">
                                     <i class="bi bi-person-badge text-success"></i> Voice ID (Skaldleita)
                                     <span class="badge bg-info text-dark">NEW</span>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.voice_id }}</span></span>
                                     <br><small class="text-muted">Identify narrators by voice fingerprint - like Shazam for audiobooks. Builds community narrator library.</small>
                                 </label>
                             </div>
@@ -520,6 +594,7 @@
                                 <label class="form-check-label" for="enable_content_analysis">
                                     <i class="bi bi-book text-info"></i> <strong>Layer 4: Content Analysis</strong>
                                     <span class="badge bg-info text-dark">Final Resort</span>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.layer_4 }}</span></span>
                                     <br><small class="text-muted">Transcribe story text to identify book (uses Whisper + AI)</small>
                                 </label>
                             </div>
@@ -949,6 +1024,7 @@
                                 <label class="form-check-label" for="auto_fix">
                                     <strong>Auto-Apply Fixes</strong>
                                     <span class="badge bg-warning text-dark">Caution</span>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.auto_fix }}</span></span>
                                     <br><small class="text-muted">Apply safe fixes automatically (non-drastic changes only)</small>
                                 </label>
                             </div>
@@ -959,6 +1035,7 @@
                                 <label class="form-check-label" for="protect_author_changes">
                                     <strong>Require Approval for Author Changes</strong>
                                     <span class="badge bg-success">Recommended</span>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.protect_author_changes }}</span></span>
                                     <br><small class="text-muted">When author changes completely (e.g. "Unknown" → "Stephen King"), send to Pending</small>
                                 </label>
                             </div>
@@ -978,6 +1055,7 @@
                                 <label class="form-check-label" for="trust_the_process">
                                     <strong class="text-danger">Trust the Process</strong>
                                     <span class="badge bg-danger">YOLO MODE</span>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.trust_the_process }}</span></span>
                                     <br><small class="text-muted">Auto-apply <strong>ALL</strong> changes when AI + audio analysis agree. No safety net.</small>
                                     <br><small class="text-danger"><i class="bi bi-exclamation-triangle"></i> Can rename entire library automatically. BACKUP FIRST!</small>
                                 </label>
@@ -996,6 +1074,7 @@
                                        {% if config.skip_confirmations %}checked{% endif %}>
                                 <label class="form-check-label" for="skip_confirmations">
                                     <strong>Skip Confirmation Dialogs</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.skip_confirmations }}</span></span>
                                     <br><small class="text-muted">No "Are you sure?" popups when clicking Apply, Reject, or Undo</small>
                                 </label>
                             </div>
@@ -1016,6 +1095,7 @@
                                        {% if config.metadata_embedding_enabled %}checked{% endif %} onchange="toggleEmbeddingOptions()">
                                 <label class="form-check-label" for="metadata_embedding_enabled">
                                     <strong>Enable Metadata Embedding</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.metadata_embedding }}</span></span>
                                     <br><small class="text-muted">Write metadata tags into audio files when fixes are applied</small>
                                 </label>
                             </div>
@@ -1112,6 +1192,7 @@
                                        {% if config.strict_language_matching is not defined or config.strict_language_matching %}checked{% endif %}>
                                 <label class="form-check-label" for="strict_language_matching">
                                     <strong>Strict Language Matching</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.strict_language_matching }}</span></span>
                                     <br><small class="text-muted">Only match books in your preferred language (prevents cross-language mismatches)</small>
                                 </label>
                             </div>
@@ -1129,6 +1210,7 @@
                                 <label class="form-check-label" for="detect_language_from_audio">
                                     <strong>Detect Language from Audio</strong>
                                     <span class="badge bg-info">BETA</span>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.language_detection }}</span></span>
                                     <br><small class="text-muted">Use Gemini to detect spoken language</small>
                                 </label>
                             </div>
@@ -1146,6 +1228,7 @@
                                        {% if config.anonymous_error_reporting %}checked{% endif %} onchange="toggleErrorReportingOptions()">
                                 <label class="form-check-label" for="anonymous_error_reporting">
                                     <strong>Anonymous Error Reporting</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.error_reporting }}</span></span>
                                     <br><small class="text-muted">Help improve Library Manager by sharing anonymous error reports</small>
                                 </label>
                             </div>
@@ -1175,6 +1258,7 @@
                                        {% if config.contribute_to_community %}checked{% endif %}>
                                 <label class="form-check-label" for="contribute_to_community">
                                     <strong>Contribute to Community Database</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.community_contributions }}</span></span>
                                     <br><small class="text-muted">Help others identify audiobooks by sharing metadata extracted from audio</small>
                                 </label>
                             </div>
@@ -1197,6 +1281,7 @@
                                        {% if config.enable_p2p_cache %}checked{% endif %}>
                                 <label class="form-check-label" for="enable_p2p_cache">
                                     <strong>Enable P2P Book Cache</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.p2p_cache }}</span></span>
                                     <br><small class="text-muted">Share book lookup cache with other Library Manager users via decentralized network</small>
                                 </label>
                             </div>


### PR DESCRIPTION
## Summary

Two features in one PR since they landed on the same branch during parallel team work:

### Issue #103: In-app hints/tooltips
- New `library_manager/hints.py` module with contextual documentation for all features
- Hover tooltips on settings toggles, status badges, and key UI elements
- Users never need to ask "what does this do?" - answer is one hover away

### Issue #110 Part 2: Folder triage
- New `library_manager/folder_triage.py` module categorizes folder names as clean/messy/garbage
- **Clean** folders: use path hints normally for author/title parsing
- **Messy** folders (scene tags, torrent markers, quality indicators): skip path parsing, rely on audio/metadata
- **Garbage** folders (hash names, numbers-only, placeholders): skip path hints + confidence penalty
- Integrated into: deep scan, AI identification prompts, Whisper transcription hints, processing pipeline
- Triage results stored in `folder_triage` column in books table
- Scan summary logs triage breakdown (clean/messy/garbage counts)

Closes #103
Partial #110