### PR TITLE
fix: Move feedback widget to nav bar bug icon (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.129] - 2026-02-18
+
+### Changed
+
+- **Issue #159: Feedback widget moved to nav bar** - Replaced floating bottom-right feedback button
+  with a bug icon (`bi-bug`) in the top navigation bar. Eliminates confusing overlap with the
+  dashboard Quick Actions button. Consistent placement and behavior across all pages. Feedback
+  modal and error auto-reporting remain unchanged.
+
+---
+
 ## [0.9.0-beta.128] - 2026-02-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.128-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.129-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
@@ -15,6 +15,10 @@
 ---
 
 ## Recent Changes (stable)
+
+> **beta.129** - **UI: Feedback Widget Moved to Nav Bar** (Issue #159)
+> - **Bug icon in nav bar** - Feedback/bug report button moved from floating bottom-right circle to a consistent bug icon in the top navigation bar
+> - **No more overlapping buttons** - Eliminates confusing dual floating buttons on the dashboard page
 
 > **beta.125** - **Bug Fixes: Badge Counts, Author Matching, Pipeline Filters** (Issues #150, #152)
 > - **Badge count fix** - Dashboard and library page queue counts now match actual processable items

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.128"
+APP_VERSION = "0.9.0-beta.129"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/templates/base.html
+++ b/templates/base.html
@@ -788,6 +788,9 @@
                     </li>
                 </ul>
                 <div class="d-flex align-items-center">
+                    <a href="#" class="nav-link me-2 p-1" onclick="showFeedbackModal(); return false;" title="{{ _('Report Bug') }}"
+                        <i class="bi bi-bug" style="font-size: 1.1rem;"></i>
+                    </a>
                     <span id="update-badge" class="badge bg-success me-2" style="display: none; cursor: pointer;" onclick="showUpdateModal()">
                         <i class="bi bi-arrow-up-circle"></i> {{ _('Update Available') }}
                     </span>
@@ -891,20 +894,6 @@
             </div>
         </div>
     </div>
-
-    <!-- Feedback Button -->
-    <button id="feedback-btn" onclick="showFeedbackModal()" title="{{ _('Send Feedback') }}"
-        style="position: fixed; bottom: 24px; right: 24px; z-index: 1040;
-               width: 48px; height: 48px; border-radius: 50%; border: none;
-               background: var(--theme-accent-primary); color: #fff;
-               box-shadow: 0 4px 16px rgba(0,0,0,0.4); cursor: pointer;
-               display: flex; align-items: center; justify-content: center;
-               font-size: 1.3rem; transition: transform 0.2s, box-shadow 0.2s;">
-        <i class="bi bi-chat-dots"></i>
-    </button>
-    <style>
-        #feedback-btn:hover { transform: scale(1.1); box-shadow: 0 6px 24px rgba(0,0,0,0.5); }
-    </style>
 
     <!-- Feedback Modal -->
     <div class="modal fade" id="feedbackModal" tabindex="-1">

--- a/templates/base.html
+++ b/templates/base.html
@@ -788,7 +788,7 @@
                     </li>
                 </ul>
                 <div class="d-flex align-items-center">
-                    <a href="#" class="nav-link me-2 p-1" onclick="showFeedbackModal(); return false;" title="{{ _('Report Bug') }}"
+                    <a href="#" class="nav-link me-2 p-1" onclick="showFeedbackModal(); return false;" title="{{ _('Report Bug') }}">
                         <i class="bi bi-bug" style="font-size: 1.1rem;"></i>
                     </a>
                     <span id="update-badge" class="badge bg-success me-2" style="display: none; cursor: pointer;" onclick="showUpdateModal()">


### PR DESCRIPTION
## Summary

- Removed the floating feedback button (fixed bottom-right corner) from `base.html`
- Added a bug icon (`bi-bug`) to the top navigation bar that triggers the existing `showFeedbackModal()` function
- All feedback modals, error auto-reporting, toast notifications, and JS functions remain unchanged

Closes #159