### PR TITLE
fix: Rate-limited batches no longer trigger false exhaustion (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.130] - 2026-02-18
+
+### Fixed
+
+- **Issue #160: Rate-limited batches no longer trigger false exhaustion** - Layer 4 processing
+  now distinguishes between "genuinely unidentifiable books" and "AI providers temporarily
+  unavailable." Rate-limited batches return a distinct signal (`-1`) and are not counted toward
+  the 3-strike exhaustion rule. When circuit breakers are open on AI providers, the worker waits
+  for recovery instead of marking books as "all processing layers exhausted." Previously, books
+  that were perfectly identifiable could be permanently marked as failed if providers were
+  rate-limited during processing.
+
+---
+
 ## [0.9.0-beta.129] - 2026-02-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.129-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.130-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
@@ -15,6 +15,11 @@
 ---
 
 ## Recent Changes (stable)
+
+> **beta.130** - **Fix: Rate-Limited Batches No Longer Trigger False Exhaustion** (Issue #160)
+> - **Rate-limited batches skipped** - When AI providers are rate-limited, batches are no longer counted toward the 3-strike "all processing layers exhausted" rule
+> - **Circuit breaker awareness** - Layer 4 now waits for providers to recover instead of permanently marking identifiable books as failed
+> - **Distinct signal for rate limiting** - `process_queue` returns `-1` (rate-limited) vs `0` (genuinely empty) so the worker can react correctly
 
 > **beta.129** - **UI: Feedback Widget Moved to Nav Bar** (Issue #159)
 > - **Bug icon in nav bar** - Feedback/bug report button moved from floating bottom-right circle to a consistent bug icon in the top navigation bar

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.129"
+APP_VERSION = "0.9.0-beta.130"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/library_manager/pipeline/layer_ai_queue.py
+++ b/library_manager/pipeline/layer_ai_queue.py
@@ -100,7 +100,7 @@ def process_queue(
     allowed, calls_made, max_calls = check_rate_limit(config)
     if not allowed:
         logger.warning(f"Rate limit reached: {calls_made}/{max_calls} calls. Waiting...")
-        return 0, 0
+        return -1, 0  # Signal rate-limited (distinct from 0,0 = nothing to process)
 
     # Check if AI verification is enabled (before opening connection)
     if not config.get('enable_ai_verification', True):


### PR DESCRIPTION
Closes #160

## Problem

When AI providers (Gemini, OpenRouter) hit rate limits or circuit breakers during Layer 4 processing, `process_queue` returned `(0, 0)` - the same signal as "nothing to process". The Layer 4 loop counted these toward its 3-strike exhaustion rule, permanently marking identifiable books as "all processing layers exhausted" even though they just needed the rate limit to clear.

## Fix

1. **Distinct rate-limit signal**: `process_queue` in `layer_ai_queue.py` now returns `(-1, 0)` when rate-limited instead of `(0, 0)`, so the caller can distinguish "rate limited" from "genuinely nothing to process".

2. **Rate-limit handling in Layer 4 loop**: When `processed == -1`, the worker waits 30 seconds and retries without incrementing `empty_batch_count`.

3. **Circuit breaker awareness**: Before incrementing `empty_batch_count`, the worker checks if any configured AI providers have tripped circuit breakers. If so, it waits for recovery instead of counting toward exhaustion.

## Files Changed

- `library_manager/pipeline/layer_ai_queue.py` - Return `-1, 0` on rate limit
- `library_manager/worker.py` - Handle rate-limit signal and circuit breaker state in Layer 4 loop