### PR TITLE
fix: Guard -1 sentinel in manual process endpoint (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Library Manager will be documented in this file.
 
-## [0.9.0-beta.130] - 2026-02-18
+## [0.9.0-beta.131] - 2026-02-18
 
 ### Fixed
 
@@ -13,6 +13,9 @@ All notable changes to Library Manager will be documented in this file.
   for recovery instead of marking books as "all processing layers exhausted." Previously, books
   that were perfectly identifiable could be permanently marked as failed if providers were
   rate-limited during processing.
+- **Issue #160: Guard sentinel in manual process endpoint** - The `-1` rate-limit sentinel from
+  `process_queue` was leaking into the `/api/process` endpoint response, showing `processed: -1`
+  in the UI. Now guarded with `max(0, l2_processed)`. (Caught by vibe-check review.)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.130-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.131-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 

--- a/app.py
+++ b/app.py
@@ -7779,7 +7779,8 @@ def api_process():
         # Layer 2: AI verification for items that passed through Layer 1
         if config.get('enable_ai_verification', True):
             l2_processed, l2_fixed = process_queue(config, limit)
-            total_processed += l2_processed
+            # Issue #160: process_queue returns -1 when rate-limited
+            total_processed += max(0, l2_processed)
             total_fixed += l2_fixed
 
         # Layer 3: Audio analysis (if enabled)

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.130"
+APP_VERSION = "0.9.0-beta.131"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/library_manager/pipeline/layer_ai_queue.py
+++ b/library_manager/pipeline/layer_ai_queue.py
@@ -88,7 +88,8 @@ def process_queue(
         verification_layer: Which layer's items to process (2=AI, 4=folder fallback)
 
     Returns:
-        Tuple of (processed_count, fixed_count)
+        Tuple of (processed_count, fixed_count). Returns (-1, 0) when rate-limited
+        (distinct from (0, 0) which means nothing to process).
 
     NOTE: This function uses a 3-phase approach to avoid holding DB locks during
     external AI API calls (which can take 5-30+ seconds):


### PR DESCRIPTION
## Summary

Addresses vibe-check review findings on PR #162. The `-1` rate-limit sentinel from `process_queue()` leaks into the `/api/process` endpoint (manual "Process Batch" button), causing `{processed: -1, verified: -1}` in the API response when the user is rate-limited.

- Guard `total_processed += max(0, l2_processed)` in `app.py:7782`
- Update `process_queue` docstring to document the `-1` return value

## Test plan

- [ ] Trigger manual process batch while rate-limited, verify response shows `processed: 0` not `-1`
- [ ] Normal processing still returns correct counts