### PR TITLE
fix: Stop re-searching unresolved books every scan cycle (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.133] - 2026-02-28
+
+### Fixed
+
+- **Issue #168: Stop re-searching unresolved books every scan cycle** - Background scans were
+  re-queuing every unresolved book and resetting `verification_layer` to 1, wiping all progress.
+  Books that exhausted all 4 layers and were marked `needs_attention` got re-queued because the
+  scan didn't check for that status — same books searched 60+ times/day (642K+ wasted API requests
+  in 14 days). Added retry tracking (`attempt_count`, `last_attempted`, `max_layer_reached`) with
+  exponential backoff (24h × 2^attempts, capped at ~32 days). New `should_requeue_book()` helper
+  gates all re-queuing sites. Configurable `max_book_retries` in Settings > Processing (default 3,
+  0 = unlimited with backoff).
+
+---
+
 ## [0.9.0-beta.132] - 2026-02-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.132-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.133-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 

--- a/library_manager/config.py
+++ b/library_manager/config.py
@@ -69,6 +69,7 @@ DEFAULT_CONFIG = {
     "scan_interval_hours": 6,
     "batch_size": 10,
     "max_requests_per_hour": 200,
+    "max_book_retries": 3,  # Issue #168: Max times to re-process a book before giving up (0=unlimited)
     "auto_fix": False,
     "protect_author_changes": True,  # Require manual approval when author changes completely
     "enabled": True,

--- a/library_manager/pipeline/base_layer.py
+++ b/library_manager/pipeline/base_layer.py
@@ -174,9 +174,10 @@ class ProcessingLayer(ABC):
                             status = 'pending_fix',
                             verification_layer = ?,
                             profile = ?,
-                            confidence = ?
+                            confidence = ?,
+                            max_layer_reached = MAX(COALESCE(max_layer_reached, 0), ?)
                             WHERE id = ?''',
-                         (self.layer_number, profile_json, result.confidence, item['book_id']))
+                         (self.layer_number, profile_json, result.confidence, self.layer_number, item['book_id']))
 
                 c.execute('DELETE FROM queue WHERE id = ?', (item['queue_id'],))
                 conn.commit()
@@ -190,9 +191,10 @@ class ProcessingLayer(ABC):
 
                 c.execute('''UPDATE books SET
                             verification_layer = ?,
+                            max_layer_reached = MAX(COALESCE(max_layer_reached, 0), ?),
                             status = CASE WHEN status = 'needs_attention' THEN 'pending' ELSE status END
                             WHERE id = ?''',
-                         (next_layer, item['book_id']))
+                         (next_layer, next_layer, item['book_id']))
                 conn.commit()
 
                 self.logger.debug(f"[{self.layer_name}] Advancing to layer {next_layer}: {item.get('current_title', 'Unknown')}")

--- a/library_manager/worker.py
+++ b/library_manager/worker.py
@@ -437,8 +437,12 @@ def process_all_queue(
                     conn2 = get_db()
                     try:
                         c2 = conn2.cursor()
+                        # Issue #168: Increment attempt_count and record last_attempted
                         c2.execute('''UPDATE books SET status = 'needs_attention',
-                                        error_message = 'All processing layers exhausted - could not identify this book automatically'
+                                        error_message = 'All processing layers exhausted - could not identify this book automatically',
+                                        attempt_count = COALESCE(attempt_count, 0) + 1,
+                                        last_attempted = CURRENT_TIMESTAMP,
+                                        max_layer_reached = MAX(COALESCE(max_layer_reached, 0), COALESCE(verification_layer, 0))
                                      WHERE id IN (
                                          SELECT q.book_id FROM queue q
                                          JOIN books b ON q.book_id = b.id

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -458,11 +458,19 @@
                                            value="{{ config.batch_size }}" min="1" max="10">
                                 </div>
                             </div>
-                            <div class="mb-0">
-                                <label class="form-label small">Max API Calls/Hour</label>
-                                <input type="number" class="form-control form-control-sm bg-dark text-light" name="max_requests_per_hour"
-                                       value="{{ config.max_requests_per_hour }}" min="10" max="500" style="max-width: 120px;">
-                                <small class="text-muted">Range: 10-500 (prevents API rate limiting)</small>
+                            <div class="row">
+                                <div class="col-6 mb-2">
+                                    <label class="form-label small">Max API Calls/Hour</label>
+                                    <input type="number" class="form-control form-control-sm bg-dark text-light" name="max_requests_per_hour"
+                                           value="{{ config.max_requests_per_hour }}" min="10" max="500">
+                                    <small class="text-muted">10-500 (prevents rate limiting)</small>
+                                </div>
+                                <div class="col-6 mb-2">
+                                    <label class="form-label small">Max Book Retries</label>
+                                    <input type="number" class="form-control form-control-sm bg-dark text-light" name="max_book_retries"
+                                           value="{{ config.max_book_retries }}" min="0" max="10">
+                                    <small class="text-muted">0 = unlimited (with backoff)</small>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Adds retry tracking columns (`attempt_count`, `last_attempted`, `max_layer_reached`) to the books table with migration backfill
- New `should_requeue_book()` helper gates all 6 re-queuing sites in `deep_scan_library()` — skips `needs_attention`, exhausted retries, and books within exponential backoff window (24h × 2^attempts)
- `verification_layer` no longer unconditionally reset to 1, preserving progress for books that already advanced past Layer 1
- Configurable `max_book_retries` (default 3, 0=unlimited) in Settings > Processing

## Root Cause
`deep_scan_library()` ran every 6 hours and re-queued every unresolved book that wasn't in the queue, resetting `verification_layer = 1` unconditionally. Books marked `needs_attention` after exhausting all 4 layers were not excluded, causing the same books to be searched 60+ times/day (642K+ wasted API requests in 14 days).

## Test plan
- [ ] `python test-env/test-naming-issues.py` — 281 checks pass
- [ ] `ruff check . --select=F821` — clean (excluding deprecated dir)
- [ ] Unit test: `should_requeue_book()` assertions pass for all edge cases (needs_attention, max retries, backoff, user_locked, unlimited mode)
- [ ] Start app, verify existing `needs_attention` books are NOT re-queued on scan
- [ ] Verify new books still get queued normally at layer 1
- [ ] Settings UI: `max_book_retries` field renders and saves correctly

Closes #168