### PR TITLE
fix: Settings page crash from infinite template recursion (#173)

### DIFF
--- a/templates/hooks_settings.html
+++ b/templates/hooks_settings.html
@@ -1,5 +1,5 @@
 <!-- Post-Processing Hooks Tab (Issue #166) -->
-<!-- Included in settings.html via {% include 'hooks_settings.html' %} -->
+{# Included in settings.html via include 'hooks_settings.html' #}
 
 <div class="row">
     <div class="col-lg-8">


### PR DESCRIPTION
## Summary
- `hooks_settings.html` had `{% include 'hooks_settings.html' %}` inside an HTML comment on line 2
- Jinja2 processes template tags inside HTML comments — this caused infinite self-inclusion (RecursionError after 971 iterations)
- Settings page returned 500 for all users on beta.133
- Fix: changed to Jinja comment (`{# #}`) which is properly ignored

## Root Cause
Introduced in PR #167 (post-processing hooks). The comment was meant as documentation but Jinja2 doesn't distinguish HTML comments from regular content when scanning for `{% %}` tags.

## Test plan
- [ ] Settings page loads (HTTP 200, not 500)
- [ ] All settings tabs render correctly
- [ ] Post-processing hooks tab still works

Addresses #173