### PR TITLE
Hotfix: Fix settings page crash (#173)

### DIFF
--- a/templates/hooks_settings.html
+++ b/templates/hooks_settings.html
@@ -1,5 +1,5 @@
 <!-- Post-Processing Hooks Tab (Issue #166) -->
-<!-- Included in settings.html via {% include 'hooks_settings.html' %} -->
+{# Included in settings.html via include 'hooks_settings.html' #}
 
 <div class="row">
     <div class="col-lg-8">


### PR DESCRIPTION
## Summary
- Fixes blank settings page on beta.133 caused by infinite Jinja2 template recursion
- One-line fix: HTML comment → Jinja comment in hooks_settings.html

Merges develop → main (hotfix).