### PR TITLE
fix: Expand clean_search_title regex for author initials and parens (#169)

### DIFF
--- a/library_manager/utils/naming.py
+++ b/library_manager/utils/naming.py
@@ -113,7 +113,7 @@ def clean_search_title(messy_name):
     # Remove file extensions
     clean = re.sub(r'\.(mp3|m4b|m4a|epub|pdf|mobi|webm|opus)$', '', clean, flags=re.IGNORECASE)
     # Remove "by Author" at the end temporarily for searching
-    clean = re.sub(r'\s+by\s+[\w\s]+$', '', clean, flags=re.IGNORECASE)
+    clean = re.sub(r'\s+by\s+[\w\s.\'\-]+(?:\s*\([^)]*\))*$', '', clean, flags=re.IGNORECASE)
     # Remove audiobook-related junk (YouTube rip artifacts)
     clean = re.sub(r'\b(full\s+)?audiobook\b', '', clean, flags=re.IGNORECASE)
     clean = re.sub(r'\b(complete|unabridged|abridged)\b', '', clean, flags=re.IGNORECASE)

--- a/test-env/test-naming-issues.py
+++ b/test-env/test-naming-issues.py
@@ -1423,6 +1423,38 @@ def main():
         failed += 1
 
     # ==========================================
+    # Issue #169: clean_search_title "by Author" regex edge cases
+    # ==========================================
+    print("\n--- Issue #169: 'by Author' regex handles special characters ---")
+
+    by_author_tests = [
+        # Basic case (already worked)
+        ("The Great Gatsby by F Scott Fitzgerald", "The Great Gatsby"),
+        # Periods/initials in author name
+        ("The Great Gatsby by F. Scott Fitzgerald", "The Great Gatsby"),
+        ("A Space Odyssey by Arthur C. Clarke", "A Space Odyssey"),
+        # Apostrophes in author name
+        ("Leaving Las Vegas by John O'Brien", "Leaving Las Vegas"),
+        # Hyphens in author name
+        ("The Joy Luck Club by Mary-Jane Smith", "The Joy Luck Club"),
+        # Parenthetical content after author
+        ("LAST RITES by Ozzy Osbourne (Audiobook)(Nonfiction)", "LAST RITES"),
+        ("Some Book by Jane Doe (Unabridged)", "Some Book"),
+        # Combined edge cases
+        ("A Tale by J.R.R. Tolkien (Fantasy)", "A Tale"),
+        ("My Book by Mary O'Brien-Smith (Audiobook)", "My Book"),
+    ]
+
+    for input_title, expected in by_author_tests:
+        result = clean_search_title(input_title)
+        if test_result(f"By-author strip: '{input_title}'",
+                       result.strip() == expected,
+                       f"Expected '{expected}', got '{result.strip()}'"):
+            passed += 1
+        else:
+            failed += 1
+
+    # ==========================================
     # Summary
     # ==========================================
     print("\n" + "=" * 60)


### PR DESCRIPTION
## Summary
- Fix regex in `clean_search_title()` that failed to strip "by Author" when author names contained periods (initials like `F. Scott Fitzgerald`), apostrophes (`O'Brien`), or hyphens (`Mary-Jane`)
- Also handles trailing parenthetical content after author names (e.g., `(Audiobook)(Nonfiction)`)
- Added 9 test cases covering all edge cases

## Changes
- `library_manager/utils/naming.py:116` - Updated regex character class and added optional parens capture
- `test-env/test-naming-issues.py` - Added test cases for initials, apostrophes, hyphens, and parenthetical patterns

Closes #169

## Test plan
- [x] All 290 existing tests pass
- [x] 9 new edge case tests pass
- [x] ruff check clean