### PR TITLE
feat: Add pipeline_order to default config (#66)

### DIFF
--- a/library_manager/config.py
+++ b/library_manager/config.py
@@ -116,6 +116,8 @@ DEFAULT_CONFIG = {
     # Text providers: "gemini", "openrouter", "ollama"
     "audio_provider_chain": ["bookdb", "gemini"],  # Order to try audio identification (bookdb = Skaldleita)
     "text_provider_chain": ["gemini", "openrouter"],  # Order to try text-based AI
+    # Pipeline layer ordering - controls the sequence layers execute in
+    "pipeline_order": ["audio_id", "audio_credits", "sl_requeue", "api_lookup", "ai_verify"],
     "deep_scan_mode": False,              # Always use all enabled layers regardless of confidence
     "profile_confidence_threshold": 85,   # Minimum confidence to skip remaining layers (0-100)
     "multibook_ai_fallback": True,         # Use AI for ambiguous chapter/multibook detection


### PR DESCRIPTION
## Summary
- Adds `pipeline_order` key to `DEFAULT_CONFIG` specifying the default layer execution sequence
- Pairs with the LayerRegistry (PR #180) which already reads this config key in `get_ordered_layers()`

## Changes
- **Modified** `library_manager/config.py` — Added `pipeline_order` list with default ordering: `["audio_id", "audio_credits", "sl_requeue", "api_lookup", "ai_verify"]`

Addresses #66 (PR 2 of 5, depends on #180)

## Test plan
- [x] ruff check clean
- [x] No behavior changes — config key exists but nothing reads it yet in production code