### PR TITLE
feat: Add standalone layer execution API and UI (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.137] - 2026-03-10
+
+### Added
+
+- **Issue #66: Standalone layer execution** - Play button next to each layer in the pipeline
+  settings section. Runs a single pipeline layer on demand via `POST /api/pipeline/run-layer/<id>`.
+  Shows spinner during execution and result badge with processed/resolved counts.
+
+---
+
 ## [0.9.0-beta.136] - 2026-03-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.136-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.137-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.136"
+APP_VERSION = "0.9.0-beta.137"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/app.py
+++ b/app.py
@@ -8064,6 +8064,95 @@ def api_process_status():
     return jsonify(get_processing_status())
 
 
+@app.route('/api/pipeline/run-layer/<layer_id>', methods=['POST'])
+def api_run_single_layer(layer_id):
+    """Run a single pipeline layer on demand.
+
+    Executes one batch of the specified layer synchronously.
+    The request blocks until the layer finishes processing its batch.
+    """
+    global _bg_processing_active
+
+    # Validate layer_id exists in registry
+    from library_manager.pipeline.registry import default_registry
+    layer_info = default_registry.get_layer(layer_id)
+    if layer_info is None:
+        return jsonify({
+            'success': False,
+            'message': f'Unknown layer: {layer_id}'
+        }), 404
+
+    # Check that background processing is not currently running
+    if _bg_processing_active:
+        return jsonify({
+            'success': False,
+            'message': 'Background processing is already running. Wait for it to finish.'
+        }), 409
+
+    config = load_config()
+
+    # Check that the layer is enabled in config
+    if not config.get(layer_info.config_enable_key, True):
+        return jsonify({
+            'success': False,
+            'message': f'Layer "{layer_info.layer_name}" is disabled. Enable it in settings first.'
+        }), 400
+
+    # Map layer_id to the corresponding processing function
+    layer_functions = {
+        'audio_id': lambda: process_layer_1_audio(config),
+        'audio_credits': lambda: process_layer_3_audio(config, verification_layer=2),
+        'sl_requeue': lambda: process_sl_requeue_verification(config),
+        'api_lookup': lambda: process_layer_1_api(config),
+        'ai_verify': lambda: process_queue(config, verification_layer=4),
+    }
+
+    layer_func = layer_functions.get(layer_id)
+    if layer_func is None:
+        return jsonify({
+            'success': False,
+            'message': f'Layer "{layer_id}" does not have a processing function mapped.'
+        }), 501
+
+    # Update status to show this layer is running
+    update_processing_status('active', True)
+    update_processing_status('layer_name', layer_info.layer_name)
+    update_processing_status('current', f'Running {layer_info.layer_name} (manual)...')
+
+    try:
+        processed, resolved = layer_func()
+        # process_queue returns -1 when rate-limited
+        if processed == -1:
+            processed = 0
+            message = f'{layer_info.layer_name}: Rate limited, try again later.'
+        elif processed == 0:
+            message = f'{layer_info.layer_name}: No items to process at this layer.'
+        else:
+            message = f'{layer_info.layer_name}: {processed} processed, {resolved} resolved.'
+
+        log_action("run_layer", detail=f"layer={layer_id} processed={processed} resolved={resolved}", result="success")
+
+        return jsonify({
+            'success': True,
+            'layer_id': layer_id,
+            'layer_name': layer_info.layer_name,
+            'processed': max(0, processed),
+            'resolved': resolved,
+            'message': message
+        })
+    except Exception as e:
+        logger.error(f"Error running layer {layer_id}: {e}", exc_info=True)
+        return jsonify({
+            'success': False,
+            'message': f'Error running {layer_info.layer_name}: {str(e)}'
+        }), 500
+    finally:
+        update_processing_status('active', False)
+        update_processing_status('layer_name', 'Idle')
+        update_processing_status('current', 'Idle')
+        clear_current_book()
+
+
 @app.route('/api/live_status')
 def api_live_status():
     """Get comprehensive live status for the status bar.

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3,6 +3,12 @@
 
 {% block content %}
 <style>
+    .spin-icon {
+        animation: spin-anim 1s linear infinite;
+    }
+    @keyframes spin-anim {
+        100% { transform: rotate(360deg); }
+    }
     .hint-icon {
         display: inline-flex;
         align-items: center;
@@ -720,6 +726,12 @@
                                         </button>
                                         <button type="button" class="btn btn-sm btn-outline-secondary pipeline-move-down" title="Move down" onclick="movePipelineLayer(this, 1)">
                                             <i class="bi bi-arrow-down"></i>
+                                        </button>
+                                        <button type="button" class="btn btn-sm btn-outline-primary pipeline-run-btn ms-1"
+                                                title="Run this layer now"
+                                                data-layer-id="{{ layer.layer_id }}"
+                                                onclick="runPipelineLayer(this)">
+                                            <i class="bi bi-play-fill"></i>
                                         </button>
                                     </div>
                                 </div>
@@ -2643,6 +2655,55 @@ function resetPipelineOrder() {
     });
     items.forEach(function(item) { list.appendChild(item); });
     updatePipelineOrderInput();
+}
+
+function runPipelineLayer(btn) {
+    var layerId = btn.getAttribute('data-layer-id');
+    var icon = btn.querySelector('i');
+    var origClass = icon.className;
+
+    // Show spinner
+    icon.className = 'bi bi-arrow-repeat spin-icon';
+    btn.disabled = true;
+
+    // Remove any previous result badge on this layer
+    var layerDiv = btn.closest('.pipeline-layer');
+    var oldBadge = layerDiv.querySelector('.pipeline-run-result');
+    if (oldBadge) oldBadge.remove();
+
+    fetch('/api/pipeline/run-layer/' + layerId, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'}
+    })
+    .then(function(resp) { return resp.json(); })
+    .then(function(data) {
+        icon.className = origClass;
+        btn.disabled = false;
+
+        var badge = document.createElement('span');
+        badge.className = 'pipeline-run-result badge ms-2 small';
+        if (data.success) {
+            badge.classList.add('bg-success');
+            badge.textContent = data.processed + ' processed, ' + data.resolved + ' resolved';
+        } else {
+            badge.classList.add('bg-danger');
+            badge.textContent = data.message || 'Error';
+        }
+        layerDiv.querySelector('.flex-grow-1').appendChild(badge);
+
+        // Auto-remove after 10 seconds
+        setTimeout(function() { badge.remove(); }, 10000);
+    })
+    .catch(function(err) {
+        icon.className = origClass;
+        btn.disabled = false;
+
+        var badge = document.createElement('span');
+        badge.className = 'pipeline-run-result badge bg-danger ms-2 small';
+        badge.textContent = 'Network error';
+        layerDiv.querySelector('.flex-grow-1').appendChild(badge);
+        setTimeout(function() { badge.remove(); }, 10000);
+    });
 }
 
 // Drag and drop for pipeline layers


### PR DESCRIPTION
## Summary
- Adds `POST /api/pipeline/run-layer/<layer_id>` endpoint to run individual pipeline layers on demand
- Play button next to each layer in the Settings pipeline section
- Shows spinner during execution and result badge (processed/resolved counts) on completion

## Changes
- **Modified** `app.py` — New API endpoint with layer validation, conflict detection, and status tracking
- **Modified** `templates/settings.html` — Play buttons, spinner animation, result display via fetch API

Addresses #66 (PR 5 of 5)

## Test plan
- [x] All 290 tests pass
- [x] ruff F821 clean
- [ ] Click play button on each layer, verify it runs and shows results
- [ ] Verify button is disabled while layer is running
- [ ] Verify error handling when background worker is active