### PR TITLE
feat: Expand hooks with event system and body templates (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,69 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.115] - 2026-02-05
+
+### Added
+
+- **Issue #119: HMAC Request Signing** - Cryptographic security for Skaldleita API
+  - All requests now include `X-LM-Signature` (HMAC-SHA256) and `X-LM-Timestamp` headers
+  - Prevents unauthorized API usage - requests without valid signatures rejected
+  - Timestamp validation prevents replay attacks
+  - Fixed missing headers on `contribute_to_bookdb()` and `lookup_community_consensus()`
+
+---
+
+## [0.9.0-beta.114] - 2026-02-03
+
+### Changed
+
+- **Issue #117: Email-Only API Key Delivery** - Keys no longer displayed on screen
+  - API key removed from registration response
+  - Key is auto-saved and emailed to user
+  - Prevents key theft if someone knows your email but doesn't have email access
+  - UI shows masked placeholder after registration
+
+---
+
+## [0.9.0-beta.113] - 2026-02-03
+
+### Added
+
+- **Issue #115: In-App Skaldleita API Key Registration**
+  - New `library_manager/instance.py` module - Generates persistent `SKALD-XXXXXX` instance IDs
+  - Register for API key directly from Settings page
+  - New endpoints: `/api/skaldleita/register`, `/api/skaldleita/validate`, `/api/instance/info`
+  - Auto-saves key to `secrets.json` on successful registration
+  - Rate limits: 1000 req/hr with key, 500 without
+
+---
+
+## [0.9.0-beta.112] - 2026-02-03
+
+### Added
+
+- **Issue #110: File Validation Module** - Pre-processing file checks
+  - New `library_manager/file_validation.py` module
+  - `validate_audio_file()` - Check single file with ffprobe
+  - `batch_validate()` - Check multiple files
+  - Catches: corrupt files, missing audio streams, truncated downloads, files < 10 min
+
+---
+
+## [0.9.0-beta.111] - 2026-02-03
+
+### Added
+
+- **Issue #102: Precog Consensus Voting System** - "Minority Report" style identification
+  - New `library_manager/precog.py` module (450+ lines)
+  - Multiple sources vote on book identity with weighted consensus
+  - Source weights: audio (90) > metadata (80) > API (70) > AI (55) > path (30)
+  - Generic title protection: "Match Game", "The End" require 85% consensus (vs 70% normal)
+  - Human review flags: split votes, drastic author changes, low confidence
+  - 10 unit tests in `test-env/test-precog.py`
+
+---
+
 ## [0.9.0-beta.110] - 2026-02-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.139] - 2026-03-21
+
+### Added
+
+- **Issue #187: Expanded hook events with filtering and custom payloads** - Hooks now fire on 8
+  event types (`fixed`, `skipped`, `error`, `needs_attention`, `scan_complete`, `queue_empty`,
+  `layer_escalation`, `manual_review`) instead of just `fixed`. Each hook supports a `run_on`
+  list for per-hook event filtering, so a single hook can subscribe to only the events it cares
+  about. New `body_template` field enables custom webhook payloads with full template variable
+  support. All events use a standardized envelope format with `event`, `timestamp`, and
+  event-specific `data`. New `emit_event()` helper centralizes event dispatching across the
+  codebase. Fully backward compatible — existing hooks default to `run_on: ["fixed"]` and
+  behave exactly as before.
+
+---
+
 ## [0.9.0-beta.133] - 2026-02-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@ All notable changes to Library Manager will be documented in this file.
 ### Added
 
 - **Issue #187: Expanded hook events with filtering and custom payloads** - Hooks now fire on 8
-  event types (`fixed`, `skipped`, `error`, `needs_attention`, `scan_complete`, `queue_empty`,
-  `layer_escalation`, `manual_review`) instead of just `fixed`. Each hook supports a `run_on`
-  list for per-hook event filtering, so a single hook can subscribe to only the events it cares
-  about. New `body_template` field enables custom webhook payloads with full template variable
-  support. All events use a standardized envelope format with `event`, `timestamp`, and
-  event-specific `data`. New `emit_event()` helper centralizes event dispatching across the
-  codebase. Fully backward compatible — existing hooks default to `run_on: ["fixed"]` and
-  behave exactly as before.
+  event types (`scan_started`, `scan_completed`, `book_discovered`, `rename_proposed`,
+  `rename_applied`, `rename_rejected`, `processing_failed`, `queue_empty`) instead of just
+  `fixed`. Each hook supports a `run_on` list for per-hook event filtering, so a single hook
+  can subscribe to only the events it cares about. New `body_template` field enables custom
+  webhook payloads with full template variable support (enables Discord/Slack/Home Assistant
+  without code). All events use a standardized envelope format with `event`, `timestamp`,
+  `app_version`, and event-specific `payload`. New `emit_event()` helper centralizes event
+  dispatching across the codebase. Fully backward compatible — existing hooks default to
+  `run_on: ["rename_applied"]` and the legacy `"fixed"` event name is aliased automatically.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.114-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.115-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
@@ -15,6 +15,11 @@
 ---
 
 ## Recent Changes (stable)
+
+> **beta.115** - 🔒 **HMAC Request Signing** (Issue #119)
+> - **Cryptographic Signatures** - All Skaldleita API requests now signed with HMAC-SHA256
+> - **Prevents Unauthorized Use** - Requests without valid signatures are rejected
+> - **Timestamp Protection** - Replay attacks blocked via time-based validation
 
 > **beta.114** - 🔐 **Secure API Key Registration** (Issue #117)
 > - **Email-Only Delivery** - API keys no longer shown on screen, sent to email only
@@ -31,6 +36,12 @@
 > - **Pre-rename Checks** - Validates files before attempting renames
 > - **Path Safety** - Checks for invalid characters, path length limits
 > - **Better Errors** - Clear messages when files can't be renamed
+
+> **beta.111** - 🎯 **Precog Consensus Voting** (Issue #102)
+> - **Multi-Source Voting** - Audio, metadata, API, and AI sources vote on book identity
+> - **Weighted Consensus** - Audio (90) > Metadata (80) > API (70) > AI (55) > Path (30)
+> - **Generic Title Protection** - Ambiguous titles require 85% consensus instead of 70%
+> - **Human Review Flags** - Split votes and drastic changes flagged for review
 
 > **beta.110** - 📊 **Enhanced Status Bar** (transparency for users)
 > - **Know Your APIs** - Status bar shows exactly which API is processing your books

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.133-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.139-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.114"
+APP_VERSION = "0.9.0-beta.115"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.133"
+APP_VERSION = "0.9.0-beta.139"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/library_manager/hooks.py
+++ b/library_manager/hooks.py
@@ -1,7 +1,10 @@
-"""Post-processing hooks for Library Manager (Issue #166).
+"""Post-processing hooks for Library Manager (Issue #166, #187).
 
 Runs external commands or webhooks after a book is successfully renamed.
 Use cases: m4binder conversion, ABS library scan, Discord notifications, etc.
+
+Issue #187: Extended event system with run_on filtering, body_template support,
+standardized event envelope, and emit_event() helper.
 
 This is a self-contained Flask Blueprint - routes, logic, DB schema all in one file.
 """
@@ -13,7 +16,7 @@ import sqlite3
 import subprocess
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import requests as http_requests
 from flask import Blueprint, request, jsonify
@@ -40,6 +43,23 @@ TEMPLATE_VARIABLES = [
     'new_series_num', 'new_year',
     'old_author', 'old_title',
 ]
+
+# Supported hook events with descriptions (Issue #187)
+HOOK_EVENTS = {
+    'scan_started': 'Library scan has started',
+    'scan_completed': 'Library scan finished',
+    'book_discovered': 'A new book was found during scanning',
+    'rename_proposed': 'A rename fix has been proposed for review',
+    'rename_applied': 'A rename was successfully applied (formerly "fixed")',
+    'rename_rejected': 'A proposed rename was rejected by the user',
+    'processing_failed': 'Book processing encountered an error',
+    'queue_empty': 'The processing queue is empty',
+}
+
+# Backward compat: map old event name to new
+_EVENT_ALIASES = {
+    'fixed': 'rename_applied',
+}
 
 
 # ============== DATABASE ==============
@@ -115,7 +135,14 @@ def build_hook_context(book_id, history_id, old_path, new_path,
                        new_author='', new_title='',
                        new_narrator='', new_series='', new_series_num='',
                        new_year='', media_type='audiobook', event='fixed'):
-    """Build the template variable dict from fix data. All values stringified."""
+    """Build the template variable dict from fix data. All values stringified.
+
+    Note: the ``event`` param still accepts 'fixed' for backward compat; it is
+    normalised to 'rename_applied' internally.
+    """
+    # Normalize legacy event name
+    event = _EVENT_ALIASES.get(event, event)
+
     ctx = {
         'book_id': str(book_id),
         'history_id': str(history_id),
@@ -131,7 +158,7 @@ def build_hook_context(book_id, history_id, old_path, new_path,
         'new_year': str(new_year or ''),
         'media_type': str(media_type or 'audiobook'),
         'event': str(event),
-        'timestamp': datetime.now().isoformat(),
+        'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
     }
     # Convenience aliases
     ctx['author'] = ctx['new_author']
@@ -141,6 +168,43 @@ def build_hook_context(book_id, history_id, old_path, new_path,
     ctx['series_num'] = ctx['new_series_num']
     ctx['year'] = ctx['new_year']
     return ctx
+
+
+def build_event_context(event_name, payload=None):
+    """Build a generic event context dict for non-rename events.
+
+    For events like scan_started or queue_empty that don't have book-specific data.
+    All values are stringified for template substitution.
+    """
+    event_name = _EVENT_ALIASES.get(event_name, event_name)
+    ctx = {
+        'event': str(event_name),
+        'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+    }
+    # Merge any event-specific payload fields
+    if payload:
+        for key, value in payload.items():
+            ctx[key] = str(value) if value is not None else ''
+    return ctx
+
+
+def _build_webhook_envelope(event_name, payload_dict, app_version=None):
+    """Wrap a payload dict in the standardized event envelope (Issue #187).
+
+    Envelope format:
+        {
+            "event": "rename_applied",
+            "timestamp": "2026-03-21T14:32:00Z",
+            "app_version": "0.9.0-beta.133",
+            "payload": { ... }
+        }
+    """
+    return {
+        'event': event_name,
+        'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'app_version': app_version or '',
+        'payload': payload_dict,
+    }
 
 
 def substitute_template(template, context, shell_escape=False):
@@ -226,8 +290,28 @@ def execute_command_hook(hook, context):
 
 # ============== WEBHOOK EXECUTION ==============
 
-def execute_webhook_hook(hook, context, secrets=None):
+def _resolve_body_template(body_template, context):
+    """Recursively substitute {{variable}} placeholders in a body_template structure.
+
+    body_template can be a dict, list, or string. All string values get substitution.
+    Returns a new structure with substituted values.
+    """
+    if isinstance(body_template, str):
+        return substitute_template(body_template, context)
+    elif isinstance(body_template, dict):
+        return {k: _resolve_body_template(v, context) for k, v in body_template.items()}
+    elif isinstance(body_template, list):
+        return [_resolve_body_template(item, context) for item in body_template]
+    else:
+        return body_template
+
+
+def execute_webhook_hook(hook, context, secrets=None, app_version=None):
     """Send an HTTP webhook with context as JSON payload.
+
+    If ``body_template`` is set on the hook, it is used as the payload with
+    template variables substituted.  Otherwise, the context is wrapped in the
+    standardised event envelope (Issue #187).
 
     Returns dict with: success, exit_code (HTTP status), stdout (response body), error, duration_ms
     """
@@ -247,13 +331,20 @@ def execute_webhook_hook(hook, context, secrets=None):
     # Substitute template variables in URL (no shell escaping needed for URLs)
     resolved_url = substitute_template(url, context)
 
-    # Build payload
-    payload = {k: v for k, v in context.items()}
+    # Build payload - body_template takes priority (Issue #187)
+    body_template = hook.get('body_template')
+    if body_template:
+        payload = _resolve_body_template(body_template, context)
+    else:
+        # Wrap in standardized envelope
+        event_name = context.get('event', 'rename_applied')
+        payload = _build_webhook_envelope(event_name, context, app_version)
 
     start = time.monotonic()
     try:
         if method == 'GET':
-            resp = http_requests.get(resolved_url, params=payload, headers=headers, timeout=timeout)
+            resp = http_requests.get(resolved_url, params=payload if isinstance(payload, dict) else {},
+                                     headers=headers, timeout=timeout)
         else:
             headers.setdefault('Content-Type', 'application/json')
             resp = http_requests.post(resolved_url, json=payload, headers=headers, timeout=timeout)
@@ -283,7 +374,19 @@ def execute_webhook_hook(hook, context, secrets=None):
 
 # ============== ORCHESTRATOR ==============
 
-def run_hooks(context, config, get_db, secrets=None):
+def _normalize_run_on(run_on_list):
+    """Normalize a hook's run_on list, mapping legacy event names.
+
+    Handles backward compat: 'fixed' -> 'rename_applied'.
+    Returns a set for fast membership testing.
+    """
+    normalized = set()
+    for event in run_on_list:
+        normalized.add(_EVENT_ALIASES.get(event, event))
+    return normalized
+
+
+def run_hooks(context, config, get_db, secrets=None, app_version=None):
     """Main orchestrator - called from apply_fix() after a successful rename.
 
     Iterates enabled hooks, routes to correct executor, handles sync/async.
@@ -293,7 +396,9 @@ def run_hooks(context, config, get_db, secrets=None):
     if not hooks:
         return
 
-    event = context.get('event', 'fixed')
+    event = context.get('event', 'rename_applied')
+    # Normalize legacy event name in context
+    event = _EVENT_ALIASES.get(event, event)
     history_id = context.get('history_id')
     book_id = context.get('book_id')
 
@@ -304,8 +409,9 @@ def run_hooks(context, config, get_db, secrets=None):
         if not hook.get('enabled', True):
             continue
 
-        # Check if this hook should run for this event type
-        run_on = hook.get('run_on', ['fixed'])
+        # Check if this hook should run for this event type (Issue #187)
+        # Default to ['rename_applied'] for backward compat (covers old 'fixed' hooks)
+        run_on = _normalize_run_on(hook.get('run_on', ['rename_applied']))
         if event not in run_on:
             continue
 
@@ -313,18 +419,18 @@ def run_hooks(context, config, get_db, secrets=None):
         hook_type = hook.get('type', 'command')
         mode = hook.get('mode', 'sync')
 
-        logger.info(f"[HOOKS] Running {hook_type} hook: {hook_name} (mode={mode})")
+        logger.info(f"[HOOKS] Running {hook_type} hook: {hook_name} (mode={mode}, event={event})")
 
         if mode == 'async':
             # Fire and forget in a background thread
             t = threading.Thread(
                 target=_run_single_hook,
-                args=(hook, hook_name, hook_type, context, secrets, get_db, history_id, book_id),
+                args=(hook, hook_name, hook_type, context, secrets, get_db, history_id, book_id, app_version),
                 daemon=True,
             )
             t.start()
         else:
-            result = _run_single_hook(hook, hook_name, hook_type, context, secrets, get_db, history_id, book_id)
+            result = _run_single_hook(hook, hook_name, hook_type, context, secrets, get_db, history_id, book_id, app_version)
             if result and not result.get('success'):
                 any_error = True
                 if not first_error:
@@ -348,11 +454,11 @@ def run_hooks(context, config, get_db, secrets=None):
             logger.error(f"[HOOKS] Failed to update history hook status: {e}")
 
 
-def _run_single_hook(hook, hook_name, hook_type, context, secrets, get_db, history_id, book_id):
+def _run_single_hook(hook, hook_name, hook_type, context, secrets, get_db, history_id, book_id, app_version=None):
     """Execute a single hook and log the result."""
     try:
         if hook_type == 'webhook':
-            result = execute_webhook_hook(hook, context, secrets)
+            result = execute_webhook_hook(hook, context, secrets, app_version=app_version)
         else:
             result = execute_command_hook(hook, context)
 
@@ -369,6 +475,37 @@ def _run_single_hook(hook, hook_name, hook_type, context, secrets, get_db, histo
         error_result = {'success': False, 'error': str(e), 'duration_ms': 0}
         _log_hook_execution(get_db, history_id, book_id, hook_name, hook_type, error_result)
         return error_result
+
+
+# ============== EVENT EMISSION (Issue #187) ==============
+
+def emit_event(event_name, context_dict, config, get_db, secrets=None, app_version=None):
+    """Emit a hook event, filtering hooks by their run_on list.
+
+    This is the primary entry point for triggering hooks from anywhere in the app.
+    It normalizes the event name, ensures the context has the event field set,
+    and delegates to run_hooks() which handles filtering, sync/async, and logging.
+
+    Args:
+        event_name: One of the HOOK_EVENTS keys (e.g. 'rename_applied', 'scan_started')
+        context_dict: Dict of template variables for this event.
+                      For rename events, use build_hook_context().
+                      For other events, use build_event_context() or pass a plain dict.
+        config: The app config dict (must contain 'post_processing_hooks')
+        get_db: Database connection factory
+        secrets: Optional secrets dict for webhook auth
+        app_version: Optional app version string for webhook envelope
+    """
+    # Normalize legacy event names
+    event_name = _EVENT_ALIASES.get(event_name, event_name)
+
+    # Ensure context has the event and timestamp fields
+    context_dict['event'] = event_name
+    if 'timestamp' not in context_dict:
+        context_dict['timestamp'] = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    logger.debug(f"[HOOKS] Emitting event: {event_name}")
+    run_hooks(context_dict, config, get_db, secrets=secrets, app_version=app_version)
 
 
 # ============== TEST HOOK ==============
@@ -393,7 +530,7 @@ def test_hook(hook, secrets=None):
         new_series_num='',
         new_year='1977',
         media_type='audiobook',
-        event='fixed',
+        event='rename_applied',
     )
 
     hook_type = hook.get('type', 'command')
@@ -461,6 +598,12 @@ def api_hooks_log_clear():
         return jsonify({'success': True})
     except Exception as e:
         return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@hooks_bp.route('/api/hooks/events')
+def api_hooks_events():
+    """Return available hook events with descriptions (Issue #187)."""
+    return jsonify({'events': HOOK_EVENTS})
 
 
 @hooks_bp.route('/api/hooks/save', methods=['POST'])

--- a/templates/hooks_settings.html
+++ b/templates/hooks_settings.html
@@ -171,6 +171,71 @@
                         <input type="text" class="form-control bg-dark text-light font-monospace" id="hook-headers"
                                placeholder='{"Authorization": "Bearer {{webhook_secret}}"}'>
                     </div>
+                    <div class="mb-3">
+                        <label class="form-label">Body Template <small class="text-muted">(JSON, optional - overrides default payload)</small></label>
+                        <textarea class="form-control bg-dark text-light font-monospace" id="hook-body-template" rows="4"
+                                  placeholder='{"embeds": [{"title": "Book: {{title}}", "description": "Author: {{author}}"}]}'></textarea>
+                        <small class="text-muted">Custom JSON payload with <code>{{"{{"}}variable{{"}}"}}</code> placeholders. Leave empty for the default event envelope.</small>
+                    </div>
+                </div>
+
+                <!-- Event Triggers (Issue #187) -->
+                <div class="mb-3">
+                    <label class="form-label">Trigger on Events</label>
+                    <div class="row" id="hook-events-checkboxes">
+                        <div class="col-md-6">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="rename_applied" id="hook-evt-rename_applied" checked>
+                                <label class="form-check-label" for="hook-evt-rename_applied">
+                                    <strong>rename_applied</strong> <small class="text-muted">- Rename was applied</small>
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="rename_proposed" id="hook-evt-rename_proposed">
+                                <label class="form-check-label" for="hook-evt-rename_proposed">
+                                    <strong>rename_proposed</strong> <small class="text-muted">- Rename proposed for review</small>
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="rename_rejected" id="hook-evt-rename_rejected">
+                                <label class="form-check-label" for="hook-evt-rename_rejected">
+                                    <strong>rename_rejected</strong> <small class="text-muted">- Rename rejected by user</small>
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="book_discovered" id="hook-evt-book_discovered">
+                                <label class="form-check-label" for="hook-evt-book_discovered">
+                                    <strong>book_discovered</strong> <small class="text-muted">- New book found during scan</small>
+                                </label>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="scan_started" id="hook-evt-scan_started">
+                                <label class="form-check-label" for="hook-evt-scan_started">
+                                    <strong>scan_started</strong> <small class="text-muted">- Library scan started</small>
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="scan_completed" id="hook-evt-scan_completed">
+                                <label class="form-check-label" for="hook-evt-scan_completed">
+                                    <strong>scan_completed</strong> <small class="text-muted">- Library scan finished</small>
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="processing_failed" id="hook-evt-processing_failed">
+                                <label class="form-check-label" for="hook-evt-processing_failed">
+                                    <strong>processing_failed</strong> <small class="text-muted">- Processing error</small>
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="queue_empty" id="hook-evt-queue_empty">
+                                <label class="form-check-label" for="hook-evt-queue_empty">
+                                    <strong>queue_empty</strong> <small class="text-muted">- Processing queue is empty</small>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="row">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2261,6 +2261,7 @@ function renderHooksList() {
                 <strong>${escapeHtml(hook.name)}</strong>
                 <span class="badge ${hook.type === 'webhook' ? 'bg-info' : 'bg-secondary'} ms-1" style="font-size: 0.65rem;">${hook.type}</span>
                 <span class="badge ${hook.mode === 'async' ? 'bg-warning text-dark' : 'bg-dark'} ms-1" style="font-size: 0.65rem;">${hook.mode || 'sync'}</span>
+                ${(hook.run_on || ['rename_applied']).map(e => '<span class="badge bg-dark border border-secondary ms-1" style="font-size: 0.6rem;">' + escapeHtml(e) + '</span>').join('')}
                 <br><small class="text-muted font-monospace">${escapeHtml(hook.type === 'webhook' ? (hook.url || '').substring(0, 60) : (hook.command || '').substring(0, 60))}${(hook.type === 'webhook' ? hook.url : hook.command || '').length > 60 ? '...' : ''}</small>
             </div>
             <div class="btn-group btn-group-sm ms-2">
@@ -2296,10 +2297,13 @@ function addHook() {
     document.getElementById('hook-url').value = '';
     document.getElementById('hook-method').value = 'POST';
     document.getElementById('hook-headers').value = '';
+    document.getElementById('hook-body-template').value = '';
     document.getElementById('hook-timeout').value = '300';
     document.getElementById('hook-mode').value = 'sync';
     document.getElementById('hook-on-error').value = 'log';
     document.getElementById('hook-test-result').style.display = 'none';
+    // Reset event checkboxes - default to rename_applied only
+    setEventCheckboxes(['rename_applied']);
     toggleHookTypeFields();
     new bootstrap.Modal(document.getElementById('hookEditModal')).show();
 }
@@ -2314,10 +2318,13 @@ function editHook(index) {
     document.getElementById('hook-url').value = hook.url || '';
     document.getElementById('hook-method').value = hook.method || 'POST';
     document.getElementById('hook-headers').value = hook.headers ? JSON.stringify(hook.headers) : '';
+    document.getElementById('hook-body-template').value = hook.body_template ? JSON.stringify(hook.body_template, null, 2) : '';
     document.getElementById('hook-timeout').value = hook.timeout || 300;
     document.getElementById('hook-mode').value = hook.mode || 'sync';
     document.getElementById('hook-on-error').value = hook.on_error || 'log';
     document.getElementById('hook-test-result').style.display = 'none';
+    // Load event checkboxes (default to rename_applied for backward compat)
+    setEventCheckboxes(hook.run_on || ['rename_applied']);
     toggleHookTypeFields();
     new bootstrap.Modal(document.getElementById('hookEditModal')).show();
 }
@@ -2337,6 +2344,28 @@ function moveHook(index, direction) {
     hooksData[newIndex] = temp;
     renderHooksList();
     saveHooksToServer();
+}
+
+// Event checkbox helpers (Issue #187)
+const HOOK_EVENT_NAMES = ['scan_started', 'scan_completed', 'book_discovered', 'rename_proposed',
+                          'rename_applied', 'rename_rejected', 'processing_failed', 'queue_empty'];
+
+function setEventCheckboxes(selectedEvents) {
+    // Normalize legacy 'fixed' -> 'rename_applied'
+    const normalized = selectedEvents.map(e => e === 'fixed' ? 'rename_applied' : e);
+    HOOK_EVENT_NAMES.forEach(evt => {
+        const cb = document.getElementById('hook-evt-' + evt);
+        if (cb) cb.checked = normalized.includes(evt);
+    });
+}
+
+function getSelectedEvents() {
+    const selected = [];
+    HOOK_EVENT_NAMES.forEach(evt => {
+        const cb = document.getElementById('hook-evt-' + evt);
+        if (cb && cb.checked) selected.push(evt);
+    });
+    return selected;
 }
 
 function toggleHookTypeFields() {
@@ -2362,6 +2391,21 @@ function saveHookFromModal() {
         catch (e) { alert('Invalid JSON in headers field'); return; }
     }
 
+    // Parse body_template if provided
+    let bodyTemplateObj = undefined;
+    const bodyTemplateStr = document.getElementById('hook-body-template').value.trim();
+    if (bodyTemplateStr && type === 'webhook') {
+        try { bodyTemplateObj = JSON.parse(bodyTemplateStr); }
+        catch (e) { alert('Invalid JSON in body template field'); return; }
+    }
+
+    // Collect selected events
+    const selectedEvents = getSelectedEvents();
+    if (selectedEvents.length === 0) {
+        alert('Please select at least one event to trigger this hook');
+        return;
+    }
+
     const hook = {
         name: name,
         type: type,
@@ -2369,11 +2413,12 @@ function saveHookFromModal() {
         url: type === 'webhook' ? document.getElementById('hook-url').value.trim() : undefined,
         method: type === 'webhook' ? document.getElementById('hook-method').value : undefined,
         headers: type === 'webhook' ? headersObj : undefined,
+        body_template: bodyTemplateObj,
         timeout: parseInt(document.getElementById('hook-timeout').value) || 300,
         mode: document.getElementById('hook-mode').value,
         on_error: document.getElementById('hook-on-error').value,
         enabled: true,
-        run_on: ['fixed']
+        run_on: selectedEvents
     };
 
     // Validate


### PR DESCRIPTION
## Summary
- Expands hook system from `fixed`-only to 8 event types: `scan_started`, `scan_completed`, `book_discovered`, `rename_proposed`, `rename_applied`, `rename_rejected`, `processing_failed`, `queue_empty`
- Adds `run_on` filtering — each hook specifies which events trigger it
- Adds `body_template` support for custom webhook payloads (Discord/Slack/HA)
- Standardized event envelope format with `{event, timestamp, app_version, payload}`
- `emit_event()` helper as primary entry point for triggering hooks
- `/api/hooks/events` endpoint listing available events
- Backward compatible: hooks without `run_on` default to `["rename_applied"]`, legacy `"fixed"` aliased
- Settings UI with event checkboxes and body_template textarea

Closes #187