### PR TITLE
feat: Custom Layer Builder wizard UI (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.140] - 2026-03-21
+
+### Added
+
+- **Issue #186: Custom Layer Builder wizard UI** - New "Plugins" tab in settings with a 4-step
+  wizard for creating custom HTTP API metadata sources without writing code. Step 1 collects name
+  and description, step 2 configures URL template with variable placeholders, HTTP method, timeout,
+  and authentication (none/bearer/API key header/basic auth), step 3 maps API response fields to
+  book profile fields via JSONPath expressions with a configurable confidence weight slider, and
+  step 4 provides live API testing with sample book data showing HTTP status, response time, mapped
+  field values, and raw response. Full CRUD via `/api/plugins/` endpoints: list, save, delete, and
+  toggle layers. Each custom layer is stored in `config.json` under `custom_layers` and feeds into
+  the existing `CustomApiLayer` processing pipeline.
+
+---
+
 ## [0.9.0-beta.139] - 2026-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.139-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.140-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
@@ -15,6 +15,11 @@
 ---
 
 ## Recent Changes (stable)
+
+> **beta.140** - **Feature: Custom Layer Builder** (Issue #186)
+> - **Plugins tab** - New settings tab with 4-step wizard to add custom HTTP API metadata sources
+> - **No-code API integration** - Configure URL templates, authentication, JSONPath response mapping, and confidence weights
+> - **Live testing** - Test API calls with sample book data before saving, with mapped field preview
 
 > **beta.134** - **Hotfix: Settings Page Crash** (Issue #173)
 > - Jinja2 template recursion bug in hooks_settings.html caused blank settings page for all users on beta.133

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.139"
+APP_VERSION = "0.9.0-beta.140"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:
@@ -121,6 +121,7 @@ from library_manager.folder_triage import triage_folder, triage_book_path, shoul
 from library_manager.file_validation import validate_audio_file, check_ffmpeg_available
 from library_manager.hints import get_all_hints
 from library_manager.hooks import hooks_bp, run_hooks, build_hook_context
+from library_manager.plugins import plugins_bp
 
 # Try to import P2P cache (optional - gracefully degrades if not available)
 try:
@@ -561,6 +562,7 @@ logging.getLogger('werkzeug').setLevel(logging.ERROR)
 app = Flask(__name__)
 app.secret_key = 'library-manager-secret-key-2024'
 app.register_blueprint(hooks_bp)
+app.register_blueprint(plugins_bp)
 
 # ============== INTERNATIONALIZATION (i18n) ==============
 # Flask-Babel for UI translations - book metadata (author/title) is NOT translated

--- a/library_manager/plugins.py
+++ b/library_manager/plugins.py
@@ -1,0 +1,270 @@
+"""Custom Layer Builder API routes (Issue #186).
+
+Flask Blueprint providing CRUD and test endpoints for custom HTTP API layers.
+These layers let users add their own book metadata sources without writing code.
+"""
+import json
+import logging
+import re
+import time
+
+import requests as http_requests
+from flask import Blueprint, request, jsonify
+
+from library_manager.config import CONFIG_PATH, load_config, load_secrets
+from library_manager.pipeline.custom_layer import (
+    extract_jsonpath, _build_auth_headers, _substitute_url_template
+)
+
+logger = logging.getLogger(__name__)
+
+plugins_bp = Blueprint('plugins', __name__)
+
+# Keys that must never be written to config.json
+SECRETS_KEYS = ['openrouter_api_key', 'gemini_api_key', 'google_books_api_key',
+                'abs_api_token', 'bookdb_api_key', 'webhook_secret']
+
+
+def _slugify(name):
+    """Convert a layer name to a safe layer_id slug."""
+    slug = name.lower().strip()
+    slug = re.sub(r'[^a-z0-9]+', '_', slug)
+    slug = slug.strip('_')
+    return slug or 'custom_layer'
+
+
+def _save_config_safe(config):
+    """Save config.json, stripping secret keys."""
+    config_only = {k: v for k, v in config.items() if k not in SECRETS_KEYS}
+    with open(CONFIG_PATH, 'w') as f:
+        json.dump(config_only, f, indent=2)
+
+
+@plugins_bp.route('/api/plugins/layers')
+def api_plugins_list():
+    """List all custom layers from config."""
+    config = load_config()
+    layers = config.get('custom_layers', [])
+    return jsonify({'success': True, 'layers': layers})
+
+
+@plugins_bp.route('/api/plugins/save-layer', methods=['POST'])
+def api_plugins_save():
+    """Save or update a custom layer in config.json."""
+    data = request.get_json()
+    if not data:
+        return jsonify({'success': False, 'error': 'No data provided'}), 400
+
+    layer = data.get('layer', {})
+    if not layer.get('layer_name'):
+        return jsonify({'success': False, 'error': 'Layer name is required'}), 400
+    if not layer.get('url_template'):
+        return jsonify({'success': False, 'error': 'URL template is required'}), 400
+
+    # Auto-generate layer_id from name if not provided
+    if not layer.get('layer_id'):
+        layer['layer_id'] = _slugify(layer['layer_name'])
+
+    # Ensure defaults
+    layer.setdefault('enabled', True)
+    layer.setdefault('method', 'GET')
+    layer.setdefault('timeout', 10)
+    layer.setdefault('source_weight', 55)
+    layer.setdefault('order', 35)
+    layer.setdefault('on_error', 'skip')
+    layer.setdefault('response_mapping', {})
+    layer.setdefault('request_fields', ['title', 'author'])
+    layer.setdefault('circuit_breaker', {'max_failures': 3, 'cooldown': 300})
+
+    # Clamp timeout
+    layer['timeout'] = max(1, min(int(layer.get('timeout', 10)), 60))
+    layer['source_weight'] = max(0, min(int(layer.get('source_weight', 55)), 100))
+
+    try:
+        config = load_config()
+        custom_layers = config.get('custom_layers', [])
+
+        # Check if updating existing layer
+        existing_idx = None
+        for i, existing in enumerate(custom_layers):
+            if existing.get('layer_id') == layer['layer_id']:
+                existing_idx = i
+                break
+
+        if existing_idx is not None:
+            custom_layers[existing_idx] = layer
+        else:
+            custom_layers.append(layer)
+
+        config['custom_layers'] = custom_layers
+        _save_config_safe(config)
+
+        return jsonify({'success': True, 'layer_id': layer['layer_id']})
+    except Exception as e:
+        logger.error(f"[PLUGINS] Failed to save layer: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@plugins_bp.route('/api/plugins/layer/<layer_id>', methods=['DELETE'])
+def api_plugins_delete(layer_id):
+    """Remove a custom layer from config.json."""
+    try:
+        config = load_config()
+        custom_layers = config.get('custom_layers', [])
+        original_count = len(custom_layers)
+
+        custom_layers = [l for l in custom_layers if l.get('layer_id') != layer_id]
+
+        if len(custom_layers) == original_count:
+            return jsonify({'success': False, 'error': f'Layer "{layer_id}" not found'}), 404
+
+        config['custom_layers'] = custom_layers
+        _save_config_safe(config)
+
+        return jsonify({'success': True})
+    except Exception as e:
+        logger.error(f"[PLUGINS] Failed to delete layer {layer_id}: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@plugins_bp.route('/api/plugins/toggle-layer', methods=['POST'])
+def api_plugins_toggle():
+    """Toggle a custom layer's enabled state."""
+    data = request.get_json()
+    if not data or not data.get('layer_id'):
+        return jsonify({'success': False, 'error': 'No layer_id provided'}), 400
+
+    layer_id = data['layer_id']
+    enabled = bool(data.get('enabled', True))
+
+    try:
+        config = load_config()
+        custom_layers = config.get('custom_layers', [])
+
+        found = False
+        for layer in custom_layers:
+            if layer.get('layer_id') == layer_id:
+                layer['enabled'] = enabled
+                found = True
+                break
+
+        if not found:
+            return jsonify({'success': False, 'error': f'Layer "{layer_id}" not found'}), 404
+
+        config['custom_layers'] = custom_layers
+        _save_config_safe(config)
+
+        return jsonify({'success': True, 'enabled': enabled})
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@plugins_bp.route('/api/plugins/test-layer', methods=['POST'])
+def api_plugins_test():
+    """Test a custom layer config by making the actual API call.
+
+    Receives a layer config and test book data (title/author),
+    makes the HTTP request server-side, and returns the results.
+    """
+    data = request.get_json()
+    if not data:
+        return jsonify({'success': False, 'error': 'No data provided'}), 400
+
+    layer = data.get('layer', {})
+    test_title = data.get('test_title', 'The Final Empire')
+    test_author = data.get('test_author', 'Brandon Sanderson')
+
+    url_template = layer.get('url_template', '')
+    if not url_template:
+        return jsonify({'success': False, 'error': 'No URL template provided'}), 400
+
+    method = layer.get('method', 'GET').upper()
+    timeout = max(1, min(int(layer.get('timeout', 10)), 60))
+
+    # Build template context from test data
+    context = {
+        'title': test_title,
+        'author': test_author,
+        'narrator': '',
+        'path': '/test/path',
+        'isbn': '',
+    }
+
+    # Substitute URL template
+    url = _substitute_url_template(url_template, context)
+
+    # Build auth headers
+    secrets = load_secrets()
+    auth_config = layer.get('auth')
+    auth_headers = _build_auth_headers(auth_config, secrets)
+
+    headers = dict(auth_headers)
+    headers['Accept'] = 'application/json'
+
+    result = {
+        'success': True,
+        'url': url,
+        'method': method,
+        'status_code': None,
+        'response_time_ms': None,
+        'mapped_fields': {},
+        'raw_response': None,
+        'error': None,
+    }
+
+    start = time.monotonic()
+    try:
+        if method == 'POST':
+            body = {f: context.get(f, '') for f in layer.get('request_fields', ['title', 'author'])}
+            headers.setdefault('Content-Type', 'application/json')
+            resp = http_requests.post(url, json=body, headers=headers, timeout=timeout)
+        else:
+            resp = http_requests.get(url, headers=headers, timeout=timeout)
+
+        duration_ms = int((time.monotonic() - start) * 1000)
+        result['status_code'] = resp.status_code
+        result['response_time_ms'] = duration_ms
+
+        # Try to parse JSON response
+        try:
+            resp_data = resp.json()
+            # Truncate raw response for display (max 2000 chars)
+            raw_str = json.dumps(resp_data, indent=2)
+            result['raw_response'] = raw_str[:2000] + ('...' if len(raw_str) > 2000 else '')
+
+            # Apply response mappings
+            response_mapping = layer.get('response_mapping', {})
+            for field_name, jsonpath in response_mapping.items():
+                value = extract_jsonpath(resp_data, jsonpath)
+                if value is not None:
+                    result['mapped_fields'][field_name] = str(value)
+                else:
+                    result['mapped_fields'][field_name] = None
+
+        except (ValueError, json.JSONDecodeError):
+            result['raw_response'] = resp.text[:500]
+            result['error'] = 'Response is not valid JSON'
+
+        if not (200 <= resp.status_code < 300):
+            result['success'] = False
+            result['error'] = f'HTTP {resp.status_code}'
+
+    except http_requests.Timeout:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        result['success'] = False
+        result['response_time_ms'] = duration_ms
+        result['error'] = f'Request timed out after {timeout}s'
+
+    except http_requests.ConnectionError as e:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        result['success'] = False
+        result['response_time_ms'] = duration_ms
+        result['error'] = f'Connection error: {str(e)[:200]}'
+
+    except Exception as e:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        result['success'] = False
+        result['response_time_ms'] = duration_ms
+        result['error'] = f'Error: {str(e)[:200]}'
+
+    return jsonify(result)

--- a/templates/plugins_settings.html
+++ b/templates/plugins_settings.html
@@ -1,0 +1,352 @@
+<!-- Custom Layer Builder Tab (Issue #186) -->
+{# Included in settings.html via include 'plugins_settings.html' #}
+
+<div class="row">
+    <div class="col-lg-8">
+        <!-- Layer List -->
+        <div class="card mb-3">
+            <div class="card-header py-2 d-flex justify-content-between align-items-center">
+                <span>
+                    <i class="bi bi-plug"></i> Custom API Sources
+                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">Add your own book metadata APIs as processing layers. Each source queries an HTTP endpoint and maps the response into the book profile system.</span></span>
+                </span>
+                <button type="button" class="btn btn-sm btn-outline-primary py-0" onclick="openPluginWizard()">
+                    <i class="bi bi-plus-lg"></i> Add Custom API Source
+                </button>
+            </div>
+            <div class="card-body p-0">
+                <div id="plugins-list">
+                    <!-- Populated by JS -->
+                </div>
+                <div id="plugins-empty" class="text-center text-muted py-4" style="display: none;">
+                    <i class="bi bi-plug" style="font-size: 2rem;"></i>
+                    <p class="mt-2 mb-0">No custom API sources configured</p>
+                    <small>Add a custom layer to query your own book metadata APIs</small>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-lg-4">
+        <!-- How It Works -->
+        <div class="card mb-3">
+            <div class="card-header py-2">
+                <i class="bi bi-lightbulb"></i> How Custom Layers Work
+            </div>
+            <div class="card-body py-2" style="font-size: 0.8rem;">
+                <p class="mb-2">Custom API sources plug into the processing pipeline. When a book needs metadata, your API is queried alongside built-in sources.</p>
+                <ol class="mb-2 ps-3">
+                    <li>Your API receives book title &amp; author</li>
+                    <li>Response fields are extracted via JSONPath</li>
+                    <li>Extracted data feeds into the book profile with your chosen confidence weight</li>
+                </ol>
+                <hr class="my-2">
+                <p class="mb-1"><strong>URL Template Variables:</strong></p>
+                <code>{{"{{"}}title{{"}}"}}</code>,
+                <code>{{"{{"}}author{{"}}"}}</code>,
+                <code>{{"{{"}}narrator{{"}}"}}</code>,
+                <code>{{"{{"}}isbn{{"}}"}}</code>,
+                <code>{{"{{"}}path{{"}}"}}</code>
+                <hr class="my-2">
+                <p class="mb-1"><strong>JSONPath Examples:</strong></p>
+                <code>$.title</code> - top-level field<br>
+                <code>$.results[0].author</code> - first array item<br>
+                <code>$.data.book.name</code> - nested field
+            </div>
+        </div>
+
+        <!-- Source Weight Guide -->
+        <div class="card mb-3">
+            <div class="card-header py-2">
+                <i class="bi bi-speedometer2"></i> Confidence Weights
+            </div>
+            <div class="card-body py-2" style="font-size: 0.8rem;">
+                <p class="mb-2 text-muted">Higher weight = more trusted. Multiple sources agreeing boosts confidence.</p>
+                <table class="table table-sm table-dark mb-0" style="font-size: 0.75rem;">
+                    <thead><tr><th>Source</th><th>Weight</th></tr></thead>
+                    <tbody>
+                        <tr><td>Audio analysis</td><td>85</td></tr>
+                        <tr><td>ID3 tags</td><td>80</td></tr>
+                        <tr><td>JSON metadata</td><td>75</td></tr>
+                        <tr><td>BookDB / Audnexus</td><td>65</td></tr>
+                        <tr><td>AI verification</td><td>60</td></tr>
+                        <tr class="text-info"><td><strong>Custom layers</strong></td><td><strong>55 (default)</strong></td></tr>
+                        <tr><td>Path parsing</td><td>40</td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Plugin Wizard Modal (4-step) -->
+<div class="modal fade" id="pluginWizardModal" tabindex="-1" data-bs-backdrop="static">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content bg-dark">
+            <div class="modal-header">
+                <h5 class="modal-title" id="pluginWizardTitle"><i class="bi bi-plug"></i> Add Custom API Source</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <!-- Step indicators -->
+                <div class="d-flex justify-content-center mb-4">
+                    <div class="d-flex align-items-center">
+                        <span class="badge rounded-pill bg-primary plugin-step-badge" id="plugin-step-badge-1">1</span>
+                        <small class="ms-1 me-3 text-muted">Info</small>
+                        <i class="bi bi-chevron-right text-muted me-3"></i>
+                        <span class="badge rounded-pill bg-secondary plugin-step-badge" id="plugin-step-badge-2">2</span>
+                        <small class="ms-1 me-3 text-muted">API</small>
+                        <i class="bi bi-chevron-right text-muted me-3"></i>
+                        <span class="badge rounded-pill bg-secondary plugin-step-badge" id="plugin-step-badge-3">3</span>
+                        <small class="ms-1 me-3 text-muted">Mapping</small>
+                        <i class="bi bi-chevron-right text-muted me-3"></i>
+                        <span class="badge rounded-pill bg-secondary plugin-step-badge" id="plugin-step-badge-4">4</span>
+                        <small class="ms-1 text-muted">Test</small>
+                    </div>
+                </div>
+
+                <input type="hidden" id="plugin-edit-id" value="">
+
+                <!-- Step 1: Basic Info -->
+                <div id="plugin-step-1">
+                    <h6 class="mb-3"><i class="bi bi-info-circle"></i> Basic Information</h6>
+                    <div class="mb-3">
+                        <label class="form-label">Name <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control bg-dark text-light" id="plugin-name"
+                               placeholder="e.g. My Book Database">
+                        <small class="text-muted">A short name for this API source</small>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Description</label>
+                        <input type="text" class="form-control bg-dark text-light" id="plugin-description"
+                               placeholder="e.g. Custom metadata lookup using my private book API">
+                        <small class="text-muted">Optional description for your reference</small>
+                    </div>
+                </div>
+
+                <!-- Step 2: API Configuration -->
+                <div id="plugin-step-2" class="d-none">
+                    <h6 class="mb-3"><i class="bi bi-globe"></i> API Configuration</h6>
+                    <div class="mb-3">
+                        <label class="form-label">URL Template <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control bg-dark text-light font-monospace" id="plugin-url"
+                               placeholder="https://api.example.com/search?title={{title}}&author={{author}}">
+                        <small class="text-muted">Use <code>{{"{{"}}title{{"}}"}}</code>, <code>{{"{{"}}author{{"}}"}}</code>, <code>{{"{{"}}narrator{{"}}"}}</code>, <code>{{"{{"}}isbn{{"}}"}}</code> as placeholders. Values are URL-encoded automatically.</small>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="mb-3">
+                                <label class="form-label">HTTP Method</label>
+                                <select class="form-select bg-dark text-light" id="plugin-method">
+                                    <option value="GET">GET</option>
+                                    <option value="POST">POST</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="mb-3">
+                                <label class="form-label">Timeout (seconds)</label>
+                                <input type="number" class="form-control bg-dark text-light" id="plugin-timeout"
+                                       value="10" min="1" max="60">
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">Authentication</label>
+                        <select class="form-select bg-dark text-light" id="plugin-auth-type" onchange="togglePluginAuthFields()">
+                            <option value="none">None</option>
+                            <option value="bearer">Bearer Token</option>
+                            <option value="api_key_header">API Key Header</option>
+                            <option value="basic">Basic Auth</option>
+                        </select>
+                    </div>
+
+                    <!-- Bearer fields -->
+                    <div id="plugin-auth-bearer" class="d-none">
+                        <div class="mb-3">
+                            <label class="form-label">Secret Key Name</label>
+                            <input type="text" class="form-control bg-dark text-light" id="plugin-bearer-secret"
+                                   placeholder="e.g. my_bookdb_key">
+                            <small class="text-muted">Key name in <code>secrets.json</code> that holds the token</small>
+                        </div>
+                    </div>
+
+                    <!-- API Key Header fields -->
+                    <div id="plugin-auth-apikey" class="d-none">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label class="form-label">Header Name</label>
+                                    <input type="text" class="form-control bg-dark text-light" id="plugin-apikey-header"
+                                           placeholder="X-API-Key" value="X-API-Key">
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label class="form-label">Secret Key Name</label>
+                                    <input type="text" class="form-control bg-dark text-light" id="plugin-apikey-secret"
+                                           placeholder="e.g. my_api_key">
+                                    <small class="text-muted">Key name in <code>secrets.json</code></small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Basic Auth fields -->
+                    <div id="plugin-auth-basic" class="d-none">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label class="form-label">Username</label>
+                                    <input type="text" class="form-control bg-dark text-light" id="plugin-basic-user"
+                                           placeholder="username">
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label class="form-label">Password Secret Key</label>
+                                    <input type="text" class="form-control bg-dark text-light" id="plugin-basic-secret"
+                                           placeholder="e.g. my_api_password">
+                                    <small class="text-muted">Key name in <code>secrets.json</code></small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Step 3: Response Mapping -->
+                <div id="plugin-step-3" class="d-none">
+                    <h6 class="mb-3"><i class="bi bi-diagram-3"></i> Response Mapping</h6>
+                    <p class="text-muted small mb-3">Map API response fields to book profile fields using JSONPath expressions.</p>
+
+                    <div class="table-responsive">
+                        <table class="table table-sm table-dark mb-3">
+                            <thead>
+                                <tr>
+                                    <th style="width: 130px;">Field</th>
+                                    <th>JSONPath Expression</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><i class="bi bi-book"></i> Title</td>
+                                    <td><input type="text" class="form-control form-control-sm bg-dark text-light font-monospace" id="plugin-map-title" placeholder="$.results[0].title"></td>
+                                </tr>
+                                <tr>
+                                    <td><i class="bi bi-person"></i> Author</td>
+                                    <td><input type="text" class="form-control form-control-sm bg-dark text-light font-monospace" id="plugin-map-author" placeholder="$.results[0].author"></td>
+                                </tr>
+                                <tr>
+                                    <td><i class="bi bi-mic"></i> Narrator</td>
+                                    <td><input type="text" class="form-control form-control-sm bg-dark text-light font-monospace" id="plugin-map-narrator" placeholder="$.results[0].narrator"></td>
+                                </tr>
+                                <tr>
+                                    <td><i class="bi bi-collection"></i> Series</td>
+                                    <td><input type="text" class="form-control form-control-sm bg-dark text-light font-monospace" id="plugin-map-series" placeholder="$.results[0].series"></td>
+                                </tr>
+                                <tr>
+                                    <td><i class="bi bi-hash"></i> Series #</td>
+                                    <td><input type="text" class="form-control form-control-sm bg-dark text-light font-monospace" id="plugin-map-series_num" placeholder="$.results[0].series_number"></td>
+                                </tr>
+                                <tr>
+                                    <td><i class="bi bi-calendar"></i> Year</td>
+                                    <td><input type="text" class="form-control form-control-sm bg-dark text-light font-monospace" id="plugin-map-year" placeholder="$.results[0].year"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">Confidence Weight: <span id="plugin-weight-display" class="text-info">55</span></label>
+                        <input type="range" class="form-range" id="plugin-weight" min="0" max="100" value="55"
+                               oninput="document.getElementById('plugin-weight-display').textContent = this.value">
+                        <div class="d-flex justify-content-between" style="font-size: 0.7rem;">
+                            <span class="text-muted">Low trust (0)</span>
+                            <span class="text-muted">Path level (40)</span>
+                            <span class="text-info">Default (55)</span>
+                            <span class="text-muted">BookDB level (65)</span>
+                            <span class="text-muted">High trust (100)</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Step 4: Test & Save -->
+                <div id="plugin-step-4" class="d-none">
+                    <h6 class="mb-3"><i class="bi bi-play-circle"></i> Test & Save</h6>
+                    <p class="text-muted small mb-3">Test your API configuration with sample book data before saving.</p>
+
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label class="form-label">Test Title</label>
+                            <input type="text" class="form-control bg-dark text-light" id="plugin-test-title"
+                                   value="The Final Empire">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Test Author</label>
+                            <input type="text" class="form-control bg-dark text-light" id="plugin-test-author"
+                                   value="Brandon Sanderson">
+                        </div>
+                    </div>
+
+                    <button type="button" class="btn btn-outline-info btn-sm mb-3" onclick="testPluginLayer()" id="plugin-test-btn">
+                        <i class="bi bi-play-circle"></i> Test API
+                    </button>
+
+                    <!-- Test Results -->
+                    <div id="plugin-test-result" class="d-none">
+                        <div class="card bg-dark border-secondary">
+                            <div class="card-header py-1 d-flex justify-content-between align-items-center">
+                                <small><strong>Test Results</strong></small>
+                                <span id="plugin-test-status" class="badge bg-secondary">-</span>
+                            </div>
+                            <div class="card-body py-2">
+                                <div class="row mb-2" style="font-size: 0.8rem;">
+                                    <div class="col-4"><strong>Status:</strong> <span id="plugin-test-http-status">-</span></div>
+                                    <div class="col-4"><strong>Time:</strong> <span id="plugin-test-time">-</span></div>
+                                    <div class="col-4"><strong>URL:</strong> <span id="plugin-test-url" class="text-truncate d-inline-block" style="max-width: 200px;">-</span></div>
+                                </div>
+
+                                <!-- Mapped Fields -->
+                                <div id="plugin-test-mapped" class="mb-2 d-none">
+                                    <strong class="small">Mapped Fields:</strong>
+                                    <table class="table table-sm table-dark mb-0 mt-1" style="font-size: 0.75rem;">
+                                        <thead><tr><th>Field</th><th>Value</th></tr></thead>
+                                        <tbody id="plugin-test-mapped-body"></tbody>
+                                    </table>
+                                </div>
+
+                                <!-- Raw Response (collapsible) -->
+                                <div class="mt-2">
+                                    <a class="small text-muted" data-bs-toggle="collapse" href="#plugin-test-raw-collapse" role="button">
+                                        <i class="bi bi-code"></i> Show raw response
+                                    </a>
+                                    <div class="collapse mt-1" id="plugin-test-raw-collapse">
+                                        <pre id="plugin-test-raw" class="bg-dark border border-secondary p-2 rounded mb-0 text-light"
+                                             style="font-size: 0.7rem; max-height: 200px; overflow-y: auto; white-space: pre-wrap;"></pre>
+                                    </div>
+                                </div>
+
+                                <!-- Error -->
+                                <div id="plugin-test-error" class="text-danger small mt-2 d-none"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" id="plugin-prev-btn" onclick="pluginWizardPrev()" style="display: none;">
+                    <i class="bi bi-chevron-left"></i> Back
+                </button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="plugin-next-btn" onclick="pluginWizardNext()">
+                    Next <i class="bi bi-chevron-right"></i>
+                </button>
+                <button type="button" class="btn btn-success" id="plugin-save-btn" onclick="savePluginLayer()" style="display: none;">
+                    <i class="bi bi-check-lg"></i> Save Layer
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -128,6 +128,11 @@
                 <i class="bi bi-terminal"></i> Post-Processing
             </button>
         </li>
+        <li class="nav-item">
+            <button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-plugins" type="button">
+                <i class="bi bi-plug"></i> Plugins
+            </button>
+        </li>
     </ul>
 
     <!-- Tab Content -->
@@ -1596,6 +1601,11 @@
             {% include 'hooks_settings.html' %}
         </div>
 
+        <!-- ==================== PLUGINS TAB ==================== -->
+        <div class="tab-pane fade" id="tab-plugins">
+            {% include 'plugins_settings.html' %}
+        </div>
+
     </div>
 
     <!-- Save Button (sticky) -->
@@ -2796,5 +2806,355 @@ function runPipelineLayer(btn) {
         }
     });
 })();
+
+// ==================== CUSTOM LAYER PLUGINS (Issue #186) ====================
+
+let pluginsData = {{ config.custom_layers | default([], true) | tojson }};
+let pluginWizardStep = 1;
+
+function renderPluginsList() {
+    const list = document.getElementById('plugins-list');
+    const empty = document.getElementById('plugins-empty');
+    if (!pluginsData.length) {
+        list.innerHTML = '';
+        empty.style.display = 'block';
+        return;
+    }
+    empty.style.display = 'none';
+    list.innerHTML = pluginsData.map((layer, i) => `
+        <div class="d-flex align-items-center border-bottom border-secondary px-3 py-2">
+            <div class="form-check form-switch me-2 mb-0">
+                <input class="form-check-input" type="checkbox" ${layer.enabled !== false ? 'checked' : ''}
+                       onchange="togglePluginEnabled('${escapeHtml(layer.layer_id)}', this.checked)">
+            </div>
+            <div class="flex-grow-1">
+                <strong>${escapeHtml(layer.layer_name)}</strong>
+                <span class="badge bg-info ms-1" style="font-size: 0.65rem;">${escapeHtml(layer.method || 'GET')}</span>
+                <span class="badge bg-secondary ms-1" style="font-size: 0.65rem;">weight: ${layer.source_weight || 55}</span>
+                ${layer.description ? '<br><small class="text-muted">' + escapeHtml(layer.description) + '</small>' : ''}
+                <br><small class="text-muted font-monospace">${escapeHtml((layer.url_template || '').substring(0, 70))}${(layer.url_template || '').length > 70 ? '...' : ''}</small>
+            </div>
+            <div class="btn-group btn-group-sm ms-2">
+                <button class="btn btn-outline-secondary py-0" onclick="editPluginLayer(${i})" title="Edit"><i class="bi bi-pencil"></i></button>
+                <button class="btn btn-outline-danger py-0" onclick="deletePluginLayer('${escapeHtml(layer.layer_id)}', '${escapeHtml(layer.layer_name)}')" title="Remove"><i class="bi bi-trash"></i></button>
+            </div>
+        </div>
+    `).join('');
+}
+
+function togglePluginEnabled(layerId, enabled) {
+    fetch('/api/plugins/toggle-layer', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({layer_id: layerId, enabled: enabled})
+    }).then(r => r.json()).then(data => {
+        if (data.success) {
+            const layer = pluginsData.find(l => l.layer_id === layerId);
+            if (layer) layer.enabled = enabled;
+        } else {
+            console.error('Toggle failed:', data.error);
+        }
+    }).catch(err => console.error('Toggle error:', err));
+}
+
+function deletePluginLayer(layerId, layerName) {
+    if (!confirm('Remove custom layer "' + layerName + '"?')) return;
+    fetch('/api/plugins/layer/' + encodeURIComponent(layerId), {
+        method: 'DELETE'
+    }).then(r => r.json()).then(data => {
+        if (data.success) {
+            pluginsData = pluginsData.filter(l => l.layer_id !== layerId);
+            renderPluginsList();
+        } else {
+            alert('Failed to delete: ' + (data.error || 'Unknown error'));
+        }
+    }).catch(err => alert('Delete error: ' + err));
+}
+
+function openPluginWizard(editLayer) {
+    pluginWizardStep = 1;
+    document.getElementById('plugin-edit-id').value = '';
+    document.getElementById('plugin-name').value = '';
+    document.getElementById('plugin-description').value = '';
+    document.getElementById('plugin-url').value = '';
+    document.getElementById('plugin-method').value = 'GET';
+    document.getElementById('plugin-timeout').value = '10';
+    document.getElementById('plugin-auth-type').value = 'none';
+    document.getElementById('plugin-bearer-secret').value = '';
+    document.getElementById('plugin-apikey-header').value = 'X-API-Key';
+    document.getElementById('plugin-apikey-secret').value = '';
+    document.getElementById('plugin-basic-user').value = '';
+    document.getElementById('plugin-basic-secret').value = '';
+    document.getElementById('plugin-map-title').value = '';
+    document.getElementById('plugin-map-author').value = '';
+    document.getElementById('plugin-map-narrator').value = '';
+    document.getElementById('plugin-map-series').value = '';
+    document.getElementById('plugin-map-series_num').value = '';
+    document.getElementById('plugin-map-year').value = '';
+    document.getElementById('plugin-weight').value = '55';
+    document.getElementById('plugin-weight-display').textContent = '55';
+    document.getElementById('plugin-test-title').value = 'The Final Empire';
+    document.getElementById('plugin-test-author').value = 'Brandon Sanderson';
+    document.getElementById('plugin-test-result').classList.add('d-none');
+    document.getElementById('pluginWizardTitle').innerHTML = '<i class="bi bi-plug"></i> Add Custom API Source';
+
+    if (editLayer) {
+        document.getElementById('plugin-edit-id').value = editLayer.layer_id || '';
+        document.getElementById('plugin-name').value = editLayer.layer_name || '';
+        document.getElementById('plugin-description').value = editLayer.description || '';
+        document.getElementById('plugin-url').value = editLayer.url_template || '';
+        document.getElementById('plugin-method').value = editLayer.method || 'GET';
+        document.getElementById('plugin-timeout').value = editLayer.timeout || 10;
+        document.getElementById('plugin-weight').value = editLayer.source_weight || 55;
+        document.getElementById('plugin-weight-display').textContent = editLayer.source_weight || 55;
+        document.getElementById('pluginWizardTitle').innerHTML = '<i class="bi bi-pencil"></i> Edit Custom API Source';
+
+        // Auth
+        const auth = editLayer.auth || {};
+        const authType = auth.type || 'none';
+        document.getElementById('plugin-auth-type').value = authType;
+        if (authType === 'bearer') {
+            document.getElementById('plugin-bearer-secret').value = auth.token_secret_key || '';
+        } else if (authType === 'api_key_header') {
+            document.getElementById('plugin-apikey-header').value = auth.header_name || 'X-API-Key';
+            document.getElementById('plugin-apikey-secret').value = auth.token_secret_key || '';
+        } else if (authType === 'basic') {
+            document.getElementById('plugin-basic-user').value = auth.username || '';
+            document.getElementById('plugin-basic-secret').value = auth.token_secret_key || '';
+        }
+
+        // Response mapping
+        const mapping = editLayer.response_mapping || {};
+        document.getElementById('plugin-map-title').value = mapping.title || '';
+        document.getElementById('plugin-map-author').value = mapping.author || '';
+        document.getElementById('plugin-map-narrator').value = mapping.narrator || '';
+        document.getElementById('plugin-map-series').value = mapping.series || '';
+        document.getElementById('plugin-map-series_num').value = mapping.series_num || '';
+        document.getElementById('plugin-map-year').value = mapping.year || '';
+    }
+
+    togglePluginAuthFields();
+    updatePluginWizardUI();
+    new bootstrap.Modal(document.getElementById('pluginWizardModal')).show();
+}
+
+function editPluginLayer(index) {
+    openPluginWizard(pluginsData[index]);
+}
+
+function updatePluginWizardUI() {
+    // Show/hide steps
+    for (let i = 1; i <= 4; i++) {
+        const step = document.getElementById('plugin-step-' + i);
+        const badge = document.getElementById('plugin-step-badge-' + i);
+        if (i === pluginWizardStep) {
+            step.classList.remove('d-none');
+            badge.classList.remove('bg-secondary');
+            badge.classList.add('bg-primary');
+        } else {
+            step.classList.add('d-none');
+            if (i < pluginWizardStep) {
+                badge.classList.remove('bg-secondary');
+                badge.classList.add('bg-primary');
+            } else {
+                badge.classList.remove('bg-primary');
+                badge.classList.add('bg-secondary');
+            }
+        }
+    }
+    // Show/hide buttons
+    document.getElementById('plugin-prev-btn').style.display = pluginWizardStep > 1 ? '' : 'none';
+    document.getElementById('plugin-next-btn').style.display = pluginWizardStep < 4 ? '' : 'none';
+    document.getElementById('plugin-save-btn').style.display = pluginWizardStep === 4 ? '' : 'none';
+}
+
+function pluginWizardNext() {
+    // Validate current step
+    if (pluginWizardStep === 1) {
+        const name = document.getElementById('plugin-name').value.trim();
+        if (!name) { alert('Please enter a layer name'); return; }
+    }
+    if (pluginWizardStep === 2) {
+        const url = document.getElementById('plugin-url').value.trim();
+        if (!url) { alert('Please enter a URL template'); return; }
+    }
+    if (pluginWizardStep < 4) {
+        pluginWizardStep++;
+        updatePluginWizardUI();
+    }
+}
+
+function pluginWizardPrev() {
+    if (pluginWizardStep > 1) {
+        pluginWizardStep--;
+        updatePluginWizardUI();
+    }
+}
+
+function togglePluginAuthFields() {
+    const authType = document.getElementById('plugin-auth-type').value;
+    document.getElementById('plugin-auth-bearer').classList.toggle('d-none', authType !== 'bearer');
+    document.getElementById('plugin-auth-apikey').classList.toggle('d-none', authType !== 'api_key_header');
+    document.getElementById('plugin-auth-basic').classList.toggle('d-none', authType !== 'basic');
+}
+
+function buildPluginLayerConfig() {
+    const name = document.getElementById('plugin-name').value.trim();
+    const editId = document.getElementById('plugin-edit-id').value.trim();
+
+    const layer = {
+        layer_id: editId || '',
+        layer_name: name,
+        description: document.getElementById('plugin-description').value.trim(),
+        url_template: document.getElementById('plugin-url').value.trim(),
+        method: document.getElementById('plugin-method').value,
+        timeout: parseInt(document.getElementById('plugin-timeout').value) || 10,
+        source_weight: parseInt(document.getElementById('plugin-weight').value) || 55,
+        enabled: true,
+        order: 35,
+        on_error: 'skip',
+        request_fields: ['title', 'author'],
+        circuit_breaker: {max_failures: 3, cooldown: 300},
+    };
+
+    // Auth
+    const authType = document.getElementById('plugin-auth-type').value;
+    if (authType === 'none') {
+        layer.auth = {type: 'none'};
+    } else if (authType === 'bearer') {
+        layer.auth = {
+            type: 'bearer',
+            token_secret_key: document.getElementById('plugin-bearer-secret').value.trim()
+        };
+    } else if (authType === 'api_key_header') {
+        layer.auth = {
+            type: 'api_key_header',
+            header_name: document.getElementById('plugin-apikey-header').value.trim() || 'X-API-Key',
+            token_secret_key: document.getElementById('plugin-apikey-secret').value.trim()
+        };
+    } else if (authType === 'basic') {
+        layer.auth = {
+            type: 'basic',
+            username: document.getElementById('plugin-basic-user').value.trim(),
+            token_secret_key: document.getElementById('plugin-basic-secret').value.trim()
+        };
+    }
+
+    // Response mapping (only include non-empty fields)
+    const mapping = {};
+    const fields = ['title', 'author', 'narrator', 'series', 'series_num', 'year'];
+    fields.forEach(f => {
+        const val = document.getElementById('plugin-map-' + f).value.trim();
+        if (val) mapping[f] = val;
+    });
+    layer.response_mapping = mapping;
+
+    return layer;
+}
+
+function testPluginLayer() {
+    const layer = buildPluginLayerConfig();
+    const testTitle = document.getElementById('plugin-test-title').value.trim() || 'The Final Empire';
+    const testAuthor = document.getElementById('plugin-test-author').value.trim() || 'Brandon Sanderson';
+
+    const btn = document.getElementById('plugin-test-btn');
+    btn.disabled = true;
+    btn.innerHTML = '<i class="bi bi-hourglass-split"></i> Testing...';
+
+    const resultDiv = document.getElementById('plugin-test-result');
+    resultDiv.classList.remove('d-none');
+
+    fetch('/api/plugins/test-layer', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({layer: layer, test_title: testTitle, test_author: testAuthor})
+    }).then(r => r.json()).then(data => {
+        btn.disabled = false;
+        btn.innerHTML = '<i class="bi bi-play-circle"></i> Test API';
+
+        // Status badge
+        const statusBadge = document.getElementById('plugin-test-status');
+        if (data.success) {
+            statusBadge.textContent = 'SUCCESS';
+            statusBadge.className = 'badge bg-success';
+        } else {
+            statusBadge.textContent = 'FAILED';
+            statusBadge.className = 'badge bg-danger';
+        }
+
+        // HTTP status and time
+        document.getElementById('plugin-test-http-status').textContent = data.status_code || '-';
+        document.getElementById('plugin-test-time').textContent = data.response_time_ms ? data.response_time_ms + 'ms' : '-';
+        document.getElementById('plugin-test-url').textContent = data.url || '-';
+        document.getElementById('plugin-test-url').title = data.url || '';
+
+        // Mapped fields
+        const mappedDiv = document.getElementById('plugin-test-mapped');
+        const mappedBody = document.getElementById('plugin-test-mapped-body');
+        if (data.mapped_fields && Object.keys(data.mapped_fields).length > 0) {
+            mappedDiv.classList.remove('d-none');
+            mappedBody.innerHTML = Object.entries(data.mapped_fields).map(([field, value]) => {
+                const badge = value !== null
+                    ? '<span class="text-success">' + escapeHtml(String(value)) + '</span>'
+                    : '<span class="text-danger">null (path not found)</span>';
+                return `<tr><td>${escapeHtml(field)}</td><td>${badge}</td></tr>`;
+            }).join('');
+        } else {
+            mappedDiv.classList.add('d-none');
+        }
+
+        // Raw response
+        document.getElementById('plugin-test-raw').textContent = data.raw_response || '(no response body)';
+
+        // Error
+        const errorDiv = document.getElementById('plugin-test-error');
+        if (data.error) {
+            errorDiv.classList.remove('d-none');
+            errorDiv.textContent = data.error;
+        } else {
+            errorDiv.classList.add('d-none');
+        }
+
+    }).catch(err => {
+        btn.disabled = false;
+        btn.innerHTML = '<i class="bi bi-play-circle"></i> Test API';
+        alert('Test error: ' + err);
+    });
+}
+
+function savePluginLayer() {
+    const layer = buildPluginLayerConfig();
+
+    if (!layer.layer_name) { alert('Please enter a layer name'); return; }
+    if (!layer.url_template) { alert('Please enter a URL template'); return; }
+
+    fetch('/api/plugins/save-layer', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({layer: layer})
+    }).then(r => r.json()).then(data => {
+        if (data.success) {
+            // Refresh the list from server
+            fetch('/api/plugins/layers').then(r => r.json()).then(listData => {
+                if (listData.success) {
+                    pluginsData = listData.layers;
+                    renderPluginsList();
+                }
+            });
+            bootstrap.Modal.getInstance(document.getElementById('pluginWizardModal')).hide();
+        } else {
+            alert('Failed to save: ' + (data.error || 'Unknown error'));
+        }
+    }).catch(err => alert('Save error: ' + err));
+}
+
+// Load plugins on tab show
+document.querySelector('[data-bs-target="#tab-plugins"]')?.addEventListener('shown.bs.tab', function() {
+    renderPluginsList();
+});
+
+// Initial render
+if (pluginsData.length) renderPluginsList();
+else document.getElementById('plugins-empty') && (document.getElementById('plugins-empty').style.display = 'block');
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
Adds a "Plugins" tab to Settings with a 4-step wizard for creating custom API layers — no code required.

- **Plugins tab** with layer list (enabled toggle, edit, delete) and "How It Works" sidebar
- **4-step wizard modal**: Basic Info → API Config → Response Mapping → Test & Save
- **Server-side test endpoint** (`POST /api/plugins/test-layer`) proxies API calls and returns mapped fields, timing, raw response
- **Full CRUD API**: list, save, delete, toggle custom layers
- **Auth support**: None, Bearer, API Key Header, Basic — conditional fields show/hide
- **Auto-slugified layer IDs** from name
- **Follows existing patterns**: Same Blueprint/card/modal patterns as hooks system

### New Files
- `library_manager/plugins.py` — Flask Blueprint with 5 API endpoints
- `templates/plugins_settings.html` — Included template with wizard modal

### Modified Files
- `app.py` — Register plugins Blueprint, version bump to beta.140
- `templates/settings.html` — Plugins tab + all wizard JS
- `README.md` / `CHANGELOG.md` — Updated

## Test plan
- [ ] Settings page loads with new "Plugins" tab
- [ ] "Add Custom API Source" opens 4-step wizard
- [ ] Step navigation works (Next/Back/step indicator badges)
- [ ] Auth fields show/hide based on auth type selection
- [ ] Test button makes server-side proxy call and displays results
- [ ] Save creates entry in config.json custom_layers array
- [ ] Layer appears in list with toggle/edit/delete
- [ ] Delete removes from config
- [ ] Toggle enables/disables
- [ ] 290/290 code checks pass, ruff clean

Closes #186