### PR TITLE
fix: Persist watch_folder_processed + honor Skaldleita server_notice (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.148] - 2026-04-17
+
+### Fixed
+
+- **Issue #208: Watch-folder retry loop survives restarts** — The watch-folder
+  worker used an in-memory `set()` to remember which files it had already
+  processed. Every LM restart wiped the set, so whenever a file couldn't be
+  processed (unknown author, ambiguous match, move failure, mtime churn), the
+  worker would re-submit it on every scan forever. Server-side evidence showed
+  one LM instance generating ~48% of all Skaldleita `/match` traffic — 2,840
+  requests in a single day on the same filename. Fix:
+  - New `watch_folder_processed` SQLite table (`path`, `processed_at`,
+    `outcome`, `error_message`) persists dedup across restarts. `outcome`
+    values: `moved`, `move_failed`, `aborted_by_server`.
+  - Added `watch_folder_is_processed()` / `watch_folder_mark_processed()`
+    helpers in `library_manager/database.py`; watch worker switched from
+    `set()` ops to these helpers.
+- **Issue #208: Skaldleita `server_notice` handler** — Skaldleita responses
+  can now carry a `server_notice` block (severity/code/message/action/
+  upgrade_url). `library_manager/providers/bookdb.py` logs every notice
+  (with upgrade URL) and, on `action=abort_task`, stashes it in a
+  `threading.local()` slot. The watch-folder worker reads that slot after
+  each identify attempt and, if an abort was signalled, marks the item as
+  `aborted_by_server` and skips the rest of the pipeline — no 30-second
+  retry loop.
+
+---
+
 ## [0.9.0-beta.147] - 2026-04-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.147-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.148-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
@@ -15,6 +15,10 @@
 ---
 
 ## Recent Changes (stable)
+
+> **beta.148** - **Fix: Watch-Folder Retry Loop Across Restarts + Skaldleita server_notice** (Issue #208)
+> - **Persistent watch-folder dedup** - `watch_folder_processed` is now a SQLite table instead of an in-memory `set()`. Restarts no longer wipe it, killing the retry loop that had one LM instance hammering Skaldleita's `/match` every 30 seconds on the same file for days.
+> - **Honors Skaldleita's abort signal** - When the server detects a retry loop it sends a `server_notice` in the response. LM now logs it (with an upgrade URL) and, on `action=abort_task`, stops retrying that file immediately.
 
 > **beta.147** - **Critical Fix: Hard Link Safety** (Issue #209)
 > - **Stop silent copy+delete** - When "Use hard links" was enabled and the watch folder / library sat on different filesystems, LM used to copy every file and delete the originals. That broke torrent seeding and doubled disk use. Now LM fails fast with a clear error and leaves source files untouched.

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.147"
+APP_VERSION = "0.9.0-beta.148"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:
@@ -52,7 +52,8 @@ from library_manager.config import (
 from library_manager.database import (
     init_db, get_db, set_db_path, cleanup_garbage_entries,
     cleanup_duplicate_history_entries, insert_history_entry,
-    should_requeue_book
+    should_requeue_book,
+    watch_folder_is_processed, watch_folder_mark_processed
 )
 from library_manager.models.book_profile import (
     SOURCE_WEIGHTS, FIELD_WEIGHTS, FieldValue, BookProfile,
@@ -6432,8 +6433,8 @@ def process_all_queue(config):
 # WATCH FOLDER FUNCTIONALITY
 # ============================================================================
 
-# Track processed watch folder items to avoid reprocessing
-watch_folder_processed = set()
+# Issue #208: watch-folder dedup now lives in the watch_folder_processed
+# SQLite table (see library_manager.database) so restarts don't reset state.
 watch_folder_last_scan = 0
 
 def get_watch_folder_items(watch_folder: str, min_age_seconds: int = 30) -> list:
@@ -6456,8 +6457,8 @@ def get_watch_folder_items(watch_folder: str, min_age_seconds: int = 30) -> list
     for item in watch_path.iterdir():
         item_path = str(item.resolve())
 
-        # Skip if already processed
-        if item_path in watch_folder_processed:
+        # Skip if already processed (persisted in SQLite, Issue #208)
+        if watch_folder_is_processed(item_path):
             continue
 
         # Check if folder contains audio files or is an audio file
@@ -6668,7 +6669,7 @@ def process_watch_folder(config: dict) -> int:
     Process items in the watch folder.
     Returns number of items processed.
     """
-    global watch_folder_processed, watch_folder_last_scan
+    global watch_folder_last_scan
 
     watch_folder = config.get('watch_folder', '').strip()
     output_folder = config.get('watch_output_folder', '').strip()
@@ -6828,6 +6829,18 @@ def process_watch_folder(config: dict) -> int:
             except Exception as e:
                 logger.debug(f"Watch folder: API lookup failed, using path analysis: {e}")
 
+            # Issue #208: Skaldleita may have signalled 'abort_task' during the
+            # lookup above (retry-loop protection). Stop retrying this item and
+            # persist it so future scans skip it until the user upgrades / fixes
+            # the source. The warning + upgrade URL are already in the logs.
+            from library_manager.providers.bookdb import get_and_clear_server_abort
+            server_abort = get_and_clear_server_abort()
+            if server_abort:
+                abort_msg = server_abort.get('message', 'Skaldleita requested task abort')
+                logger.warning(f"Watch folder: Aborting '{item.name}' per Skaldleita server notice")
+                watch_folder_mark_processed(item_path, 'aborted_by_server', abort_msg)
+                continue
+
             # Issue #57: Verify drastic author changes before accepting
             if needs_verification and api_author and api_title:
                 try:
@@ -6880,7 +6893,7 @@ def process_watch_folder(config: dict) -> int:
 
             if success:
                 logger.info(f"Watch folder: Moved to {new_path}")
-                watch_folder_processed.add(item_path)
+                watch_folder_mark_processed(item_path, 'moved')
                 processed += 1
 
                 # Add to books table
@@ -6914,8 +6927,8 @@ def process_watch_folder(config: dict) -> int:
             else:
                 logger.error(f"Watch folder: Failed to move {item.name}: {error}")
                 # Issue #49: Track failed items in the database so user can see and fix them
-                # Add to watch_folder_processed to prevent infinite retry loop
-                watch_folder_processed.add(item_path)
+                # Issue #208: persist dedup so the retry loop dies across restarts too
+                watch_folder_mark_processed(item_path, 'move_failed', error)
                 try:
                     # Check if this item is already tracked
                     c.execute('SELECT id FROM books WHERE path = ?', (item_path,))

--- a/library_manager/database.py
+++ b/library_manager/database.py
@@ -175,6 +175,17 @@ def init_db(db_path=None):
         api_calls INTEGER DEFAULT 0
     )''')
 
+    # Issue #208: Persistent watch-folder dedup
+    # Was an in-memory set(), wiped on restart, which caused the watch worker
+    # to re-submit the same failing file every cycle (ate ~48% of Skaldleita
+    # traffic from a single LM instance before server-side cache absorbed it).
+    c.execute('''CREATE TABLE IF NOT EXISTS watch_folder_processed (
+        path TEXT PRIMARY KEY,
+        processed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        outcome TEXT,
+        error_message TEXT
+    )''')
+
     conn.commit()
     conn.close()
 
@@ -185,6 +196,48 @@ def init_db(db_path=None):
     # Initialize plugin metrics table (Issue #189)
     from library_manager.plugins import init_plugin_metrics_table
     init_plugin_metrics_table(path)
+
+
+def watch_folder_is_processed(path, db_path=None):
+    """Return True if the watch-folder path has already been handled.
+
+    Issue #208: replaces the in-memory set. Survives restarts so the worker
+    doesn't re-submit the same failing file every scan cycle.
+    """
+    p = db_path or _db_path
+    if not p:
+        return False
+    conn = sqlite3.connect(p, timeout=30)
+    try:
+        c = conn.execute(
+            'SELECT 1 FROM watch_folder_processed WHERE path = ? LIMIT 1',
+            (path,)
+        )
+        return c.fetchone() is not None
+    finally:
+        conn.close()
+
+
+def watch_folder_mark_processed(path, outcome, error_message=None, db_path=None):
+    """Record that a watch-folder path has been handled.
+
+    outcome: 'moved' | 'move_failed' | 'unknown_author' | 'aborted_by_server'
+    Issue #208.
+    """
+    p = db_path or _db_path
+    if not p:
+        return
+    conn = sqlite3.connect(p, timeout=30)
+    try:
+        conn.execute(
+            '''INSERT OR REPLACE INTO watch_folder_processed
+               (path, processed_at, outcome, error_message)
+               VALUES (?, CURRENT_TIMESTAMP, ?, ?)''',
+            (path, outcome, error_message)
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def cleanup_garbage_entries(db_path=None):

--- a/library_manager/providers/bookdb.py
+++ b/library_manager/providers/bookdb.py
@@ -15,6 +15,7 @@ import time
 import logging
 import subprocess
 import tempfile
+import threading
 import requests
 from pathlib import Path
 
@@ -32,6 +33,22 @@ from library_manager.utils.voice_embedding import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Issue #208: Skaldleita can signal "stop retrying this task" via a server_notice
+# in the JSON response. We stash the notice in a thread-local so the caller
+# (e.g. the watch-folder worker) can pick it up and mark the item as aborted
+# without a 30-second retry loop. Thread-local keeps the signal scoped to the
+# thread that issued the matching request.
+_abort_state = threading.local()
+
+
+def get_and_clear_server_abort():
+    """Return (and clear) the last server_notice with action=abort_task seen
+    on this thread, or None. Safe to call when none was set."""
+    notice = getattr(_abort_state, 'notice', None)
+    if notice is not None:
+        _abort_state.notice = None
+    return notice
 
 # Skaldleita API endpoint (our metadata service, legacy name: BookDB)
 BOOKDB_API_URL = "https://bookdb.deucebucket.com"  # URL unchanged for backwards compatibility
@@ -167,6 +184,21 @@ def search_bookdb(title, author=None, api_key=None, retry_count=0, bookdb_url=No
             API_CIRCUIT_BREAKER['bookdb']['failures'] = 0
 
         data = resp.json()
+
+        # Issue #208: honor Skaldleita server_notice. Log every notice; on
+        # action=abort_task, stash in thread-local so the watch-folder worker
+        # can stop retrying instead of hammering /match every 30s.
+        notice = data.get('server_notice')
+        if notice:
+            code = notice.get('code', 'unknown')
+            msg = notice.get('message', '')
+            upgrade_url = notice.get('upgrade_url')
+            severity = notice.get('severity', 'info')
+            logger.warning(f"[SKALDLEITA] server notice ({severity}) [{code}]: {msg}")
+            if upgrade_url:
+                logger.warning(f"[SKALDLEITA] upgrade: {upgrade_url}")
+            if notice.get('action') == 'abort_task':
+                _abort_state.notice = notice
 
         # Check confidence threshold
         if data.get('confidence', 0) < 0.5:


### PR DESCRIPTION
Closes #208

## Summary

Two related fixes that stop the watch-folder retry loop that had one LM instance generating ~48% of Skaldleita \`/match\` traffic for days.

**1. \`watch_folder_processed\` is now persistent** — was an in-memory \`set()\`, wiped on every restart, so any file that couldn't move (unknown author, ambiguous match, move failure, mtime churn) got re-submitted every scan cycle forever.

**2. LM now honors Skaldleita's \`server_notice\` field** (added in deucebucket/skaldleita#129). When the server detects a retry loop it sends \`{severity, code, message, action: abort_task, upgrade_url}\`. LM logs it, and on \`action=abort_task\` stops retrying that file immediately.

## Changes

### \`library_manager/database.py\`
- New \`watch_folder_processed\` table: \`path\` PK, \`processed_at\`, \`outcome\`, \`error_message\`. Created in \`init_db()\` so existing DBs auto-migrate on next startup.
- \`watch_folder_is_processed(path)\` — \`SELECT 1 ... LIMIT 1\` existence check.
- \`watch_folder_mark_processed(path, outcome, error_message=None)\` — \`INSERT OR REPLACE\`. \`outcome\` values: \`moved\`, \`move_failed\`, \`aborted_by_server\`.

### \`app.py\`
- Removed \`watch_folder_processed = set()\`. Removed it from the \`global\` list in \`process_watch_folder\`.
- \`get_watch_folder_items\` dedup check swapped from \`if item_path in watch_folder_processed\` to \`if watch_folder_is_processed(item_path)\`.
- Success path calls \`watch_folder_mark_processed(item_path, 'moved')\`.
- Move-failure path calls \`watch_folder_mark_processed(item_path, 'move_failed', error)\`.
- New abort check after the identify chain: reads \`get_and_clear_server_abort()\`, and on hit marks the item \`aborted_by_server\` and \`continue\`s.

### \`library_manager/providers/bookdb.py\`
- Added \`threading.local()\` slot for the server-abort signal — scope stays in the thread that got the notice (watch worker vs. API endpoint vs. pipeline layer don't cross-contaminate).
- In \`search_bookdb\`, right after \`data = resp.json()\`: logs every \`server_notice\` (with severity, code, message, upgrade URL), and on \`action=abort_task\` stashes the notice in the thread-local.
- New \`get_and_clear_server_abort()\` accessor for callers.

## Behavior matrix

| Situation | Before | After |
|---|---|---|
| File fails to move, LM restarts | Loop resumes forever | File already marked; skipped |
| Unknown author flagged for review | Re-processed every scan after restart | Marked \`move_failed\` (via the \`needs_attention\` path), skipped on next scan |
| Skaldleita sends \`abort_task\` | Ignored, 30s retry loop continues | Marked \`aborted_by_server\`, loop stops immediately; upgrade URL in logs |
| Normal successful move | Worked | Works; marked \`moved\` |

## Test plan

- [x] \`python3 -m py_compile app.py library_manager/database.py library_manager/providers/bookdb.py\` → SYNTAX OK
- [x] \`ruff check app.py library_manager/database.py library_manager/providers/bookdb.py --select=F821,E9,F63,F7,F82\` → All checks passed
- [x] \`venv/bin/python test-env/test-naming-issues.py\` → 290 passed, 0 failed
- [ ] Live test on maintainer sandbox or live LM: drop a file in watch, let it process (or fail), restart LM, confirm it is not re-picked up.
- [ ] Manual verification that an existing DB auto-migrates: \`sqlite3 library.db '.schema watch_folder_processed'\` after a startup should print the new table.
- [ ] Confirm Docker \`:latest\` build still works on merge to main once this lands.

## Notes / follow-ups

- \`identify_audio_with_bookdb\` (the audio-identification path) doesn't read \`server_notice\` yet. Audio requests don't usually retry-loop the way \`/match\` did, but if we see server-side evidence of that changing we can extend the handler there too.
- UI surfacing of the \`server_notice\` (banner + upgrade link) is explicitly deferred to a separate task — the original issue called it \"low priority relative to (1) and (2)\" and I kept this PR scoped to the server/dedup fix.

## References

- Skaldleita server-side mitigation: deucebucket/skaldleita#129
- Skaldleita tracking issue: deucebucket/skaldleita#128