### PR TITLE
fix: Watch-folder DB inserts silently failed on phantom added_at column (#211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.149] - 2026-04-17
+
+### Fixed
+
+- **Issue #211: Watch-folder failure tracking silently dropped** — Three
+  `INSERT` statements in `process_watch_folder` (`app.py:6906`, `6914`,
+  `6944`) referenced `added_at` on the `books` table, but the schema column
+  is `created_at`. Every insert raised `sqlite3.OperationalError: table
+  books has no column named added_at`. Two `except` blocks caught it with
+  `logger.debug`, hiding the error at default log levels. Effects:
+  - Successful watch-folder moves never produced a `pending` or
+    `needs_attention` row in the books table.
+  - Failed watch-folder moves never produced a `watch_folder_error` row —
+    users had no UI surface for the failure, only a log line.
+  - Fix: renamed `added_at` to `created_at` in all three INSERTs;
+    raised both swallow-except blocks from `logger.debug` to
+    `logger.warning(..., exc_info=True)` so the same class of silent
+    failure can't rot unnoticed again.
+  - Surfaced during live testing of #209. Bug has existed since the
+    watch-folder feature was introduced.
+
+---
+
 ## [0.9.0-beta.148] - 2026-04-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.148-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.149-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
@@ -15,6 +15,10 @@
 ---
 
 ## Recent Changes (stable)
+
+> **beta.149** - **Fix: Watch-Folder Move Failures Now Appear in the UI** (Issue #211)
+> - Three `INSERT` statements in the watch-folder worker referenced a phantom `added_at` column on the `books` table (the real column is `created_at`). Every insert silently raised `OperationalError`, caught by a `logger.debug` that hid the error. Result: watch-folder move failures never produced a `watch_folder_error` row — the UI never showed the failure, users only saw it in logs.
+> - Fixed the column name and raised the swallow-except log level to `warning` with full traceback so future DB errors don't rot silently.
 
 > **beta.148** - **Fix: Watch-Folder Retry Loop Across Restarts + Skaldleita server_notice** (Issue #208)
 > - **Persistent watch-folder dedup** - `watch_folder_processed` is now a SQLite table instead of an in-memory `set()`. Restarts no longer wipe it, killing the retry loop that had one LM instance hammering Skaldleita's `/match` every 30 seconds on the same file for days.

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.148"
+APP_VERSION = "0.9.0-beta.149"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:
@@ -6903,7 +6903,7 @@ def process_watch_folder(config: dict) -> int:
                         # Unknown author - requires user intervention before processing
                         # Issue #57: Include source_type for watch folder tracking
                         c.execute('''INSERT OR REPLACE INTO books
-                                     (path, current_author, current_title, status, error_message, source_type, added_at, updated_at)
+                                     (path, current_author, current_title, status, error_message, source_type, created_at, updated_at)
                                      VALUES (?, ?, ?, 'needs_attention', ?, 'watch_folder', datetime('now'), datetime('now'))''',
                                   (new_path, author, title, 'Watch folder: Could not determine author - please review and correct'))
                         logger.info(f"Watch folder: Flagged for attention (unknown author): {title}")
@@ -6911,7 +6911,7 @@ def process_watch_folder(config: dict) -> int:
                         # Known author - normal processing
                         # Issue #57: Include source_type for watch folder tracking
                         c.execute('''INSERT OR REPLACE INTO books
-                                     (path, current_author, current_title, status, source_type, added_at, updated_at)
+                                     (path, current_author, current_title, status, source_type, created_at, updated_at)
                                      VALUES (?, ?, ?, 'pending', 'watch_folder', datetime('now'), datetime('now'))''',
                                   (new_path, author, title))
                         # Issue #126: Auto-enqueue for full pipeline processing
@@ -6923,7 +6923,8 @@ def process_watch_folder(config: dict) -> int:
                         logger.info(f"Watch folder: Auto-enqueued for processing: {author}/{title}")
                     conn.commit()
                 except Exception as e:
-                    logger.debug(f"Watch folder: Could not add to books table: {e}")
+                    # Issue #211: was logger.debug which hid the real exception.
+                    logger.warning(f"Watch folder: Could not add to books table: {e}", exc_info=True)
             else:
                 logger.error(f"Watch folder: Failed to move {item.name}: {error}")
                 # Issue #49: Track failed items in the database so user can see and fix them
@@ -6941,13 +6942,15 @@ def process_watch_folder(config: dict) -> int:
                     else:
                         # Insert new record for the failed item
                         c.execute('''INSERT INTO books
-                                     (path, current_author, current_title, status, error_message, source_type, added_at, updated_at)
+                                     (path, current_author, current_title, status, error_message, source_type, created_at, updated_at)
                                      VALUES (?, ?, ?, 'watch_folder_error', ?, 'watch_folder', datetime('now'), datetime('now'))''',
                                   (item_path, author, title, f'Watch folder: {error}'))
                     conn.commit()
                     logger.info(f"Watch folder: Tracked failure for user review: {item.name}")
                 except Exception as db_err:
-                    logger.debug(f"Watch folder: Could not track failure in DB: {db_err}")
+                    # Issue #211: was logger.debug which hid the real exception; raise level
+                    # so failures surface in normal operation instead of rotting silently.
+                    logger.warning(f"Watch folder: Could not track failure in DB: {db_err}", exc_info=True)
 
         except Exception as e:
             logger.error(f"Watch folder: Error processing {item_path}: {e}")


### PR DESCRIPTION
Closes #211

## Summary

Three \`INSERT\` statements in the watch-folder worker targeted a phantom column \`added_at\` on the \`books\` table. The real column is \`created_at\` — only the \`queue\` table has \`added_at\`. Every insert raised \`sqlite3.OperationalError\` which two separate \`except\` blocks caught with \`logger.debug\`, hiding the error at default log levels.

Bug has existed since the watch-folder feature was introduced. Surfaced during live testing of #209 when I noticed a watch-folder failure produced no UI row despite clean log output.

## Effects before this fix

- Successful watch-folder moves never produced a \`pending\` or \`needs_attention\` row in the \`books\` table.
- Failed watch-folder moves never produced a \`watch_folder_error\` row — the UI had no surface for the failure; only the log showed it.
- The root cause was masked by \`logger.debug\` at default log levels.

## Changes

### \`app.py\`
- Renamed \`added_at\` → \`created_at\` in three books-table INSERTs:
  - Line 6906 (INSERT OR REPLACE for \`needs_attention\` — watch folder unknown author)
  - Line 6914 (INSERT OR REPLACE for \`pending\` — watch folder known author success)
  - Line 6944 (INSERT for \`watch_folder_error\` — watch folder move failure)
- Raised swallow-except log level from \`logger.debug\` → \`logger.warning(..., exc_info=True)\` in both watch-folder DB blocks (lines 6926 and 6950). Same class of silent failure can't rot unnoticed again.

## Verification

- Schema confirmed: \`.schema books\` on production DB has \`created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\`, no \`added_at\`. The \`queue\` table has \`added_at\` which is where the remaining legitimate references live.
- All other \`added_at\` references in \`app.py\` target the \`queue\` table — verified with \`grep -n 'added_at' app.py\`.

## Test plan

- [x] \`python3 -m py_compile app.py\` → SYNTAX OK
- [x] \`ruff check app.py --select=F821,E9,F63,F7,F82\` → All checks passed
- [x] \`venv/bin/python test-env/test-naming-issues.py\` → 290 passed, 0 failed
- [ ] Live test on maintainer LM: drop a file in watch that fails to move (cross-fs hardlinks per #209 scenario), verify \`SELECT status, error_message FROM books WHERE status='watch_folder_error'\` returns the item with the full error message.
- [ ] Live test happy path: drop a processable file, verify a \`pending\` (or \`needs_attention\` if author unknown) row appears in books.

## References

- Surfaced during live testing of #209 (hardlink data-safety fix)
- Follow-up for #208 (watch-folder persistence), which now records dedup in its own table; this PR fixes the separate \`books\` table tracking