### PR TITLE
[codex] clarify Skaldleita API key requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.151] - 2026-06-05
+
+### Changed
+
+- **Skaldleita API key requirement copy** — Updated Settings text so users can see that Skaldleita now requires an API key for metadata and audio identification before enabling or configuring the source.
+
+---
+
 ## [0.9.0-beta.150] - 2026-05-14
 
 ### Fixed

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.150"
+APP_VERSION = "0.9.0-beta.151"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -519,7 +519,7 @@
                                     <i class="bi bi-cloud text-info"></i> <strong>Layer 1: Database Lookups</strong>
                                     <span class="badge bg-success">Free</span>
                                     <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.layer_1 }}</span></span>
-                                    <br><small class="text-muted">Skaldleita, Audnexus, OpenLibrary, Google Books</small>
+                                    <br><small class="text-muted">Skaldleita (API key required), Audnexus, OpenLibrary, Google Books</small>
                                 </label>
                             </div>
 
@@ -555,7 +555,7 @@
                                     <i class="bi bi-cloud-arrow-up text-primary"></i> Use Skaldleita for Audio ID
                                     <span class="badge bg-success">Recommended</span>
                                     <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.skaldleita }}</span></span>
-                                    <br><small class="text-muted">GPU Whisper + 50M book database (faster, no rate limits). Disable to use your own AI/Whisper.</small>
+                                    <br><small class="text-muted">GPU Whisper + 50M book database. Requires a Skaldleita API key. Disable to use your own AI/Whisper.</small>
                                 </label>
                             </div>
 
@@ -760,7 +760,7 @@
                             <div class="mb-3">
                                 <label class="form-label">
                                     <i class="bi bi-book text-primary"></i> Skaldleita API Key
-                                    <span class="badge bg-secondary ms-1">Optional</span>
+                                    <span class="badge bg-warning text-dark ms-1">Required</span>
                                 </label>
 
                                 <!-- Instance ID display -->
@@ -798,7 +798,7 @@
                                     </div>
                                     <div class="card-body">
                                         <p class="small text-muted mb-2">
-                                            API key gives you 1000 requests/hour (vs 500 without).
+                                            Skaldleita now requires an API key for metadata and audio identification.
                                             Your key will be emailed to you and automatically applied.
                                         </p>
                                         <div class="mb-2">
@@ -815,7 +815,7 @@
                                 {% endif %}
 
                                 <small class="text-muted d-block mt-1">
-                                    Higher rate limits (1000/hr). Already have a key? Paste it above and save settings.
+                                    Required to use Skaldleita. Already have a key? Paste it above and save settings.
                                 </small>
                             </div>
 


### PR DESCRIPTION
## Summary

Clarifies in Settings that Skaldleita now requires an API key for metadata and audio identification.

## Changes

- Labels Skaldleita as requiring an API key in the database lookup source list.
- Updates the Skaldleita audio ID helper text to mention the API key requirement.
- Changes the Skaldleita API key badge from Optional to Required and updates the registration helper copy.

## Impact

Users can see before enabling or configuring Skaldleita that they need to request or paste an API key.

## Validation

- Ran `git diff --check -- templates/settings.html`.
- No full test suite run; this is a text-only template copy change.