### PR TITLE
fix: Check _worker_running in legacy L1/L2/L3/L4 batch loops (#221)

### DIFF
--- a/library_manager/worker.py
+++ b/library_manager/worker.py
@@ -275,6 +275,8 @@ def process_all_queue(
         layer1_processed = 0
         layer1_resolved = 0
         while True:
+            if not _worker_running:
+                break
             # Issue #74: Check if Skaldleita circuit breaker is open - wait instead of skipping
             if is_circuit_open('bookdb'):
                 cb = get_circuit_breaker('bookdb')
@@ -310,6 +312,8 @@ def process_all_queue(
         layer2_resolved = 0
         circuit_wait_count = 0
         while True:
+            if not _worker_running:
+                break
             # Check if Gemini circuit breaker is open - wait instead of skipping
             if is_circuit_open('gemini'):
                 cb = get_circuit_breaker('gemini')
@@ -379,6 +383,8 @@ def process_all_queue(
         _processing_status["last_activity_time"] = time.time()
         layer3_processed = 0
         while True:
+            if not _worker_running:
+                break
             processed, resolved = process_layer_1_api(config)  # Existing API lookup
             if processed == 0:
                 break
@@ -405,6 +411,8 @@ def process_all_queue(
     layer4_fixed = 0
 
     while True:
+        if not _worker_running:
+            break
         config = load_config()
 
         allowed, calls_made, max_calls = check_rate_limit(config)


### PR DESCRIPTION
## Summary
- Adds `if not _worker_running: break` at the top of all four legacy pipeline batch loops in `process_all_queue()`
- Worker stop now takes effect immediately instead of waiting for the current batch to drain

## Test plan
- [ ] Start processing, click Stop Worker — verify it stops promptly
- [ ] Verify normal processing still completes when not stopped

Closes #221