### PR TITLE
fix: Add missing rate limits, circuit breakers, and process guard (#222, #223, #224)

### DIFF
--- a/app.py
+++ b/app.py
@@ -7964,6 +7964,15 @@ def api_delete_corrupt():
 @app.route('/api/process', methods=['POST'])
 def api_process():
     """Process the queue using layered processing."""
+    global _bg_processing_active
+
+    # Re-entrancy guard - don't start if background processing is already running
+    if _bg_processing_active:
+        return jsonify({
+            'success': False,
+            'message': 'Processing is already running in the background'
+        })
+
     config = load_config()
     data = request.json if request.is_json else {}
     process_all = data.get('all', False)

--- a/library_manager/providers/audnexus.py
+++ b/library_manager/providers/audnexus.py
@@ -150,11 +150,11 @@ def lookup_audnexus_by_asin(asin, region='us'):
 
         resp = requests.get(url, timeout=10, headers={'Accept': 'application/json'})
 
-        record_api_success('audnexus')
-
         if resp.status_code != 200:
             logger.debug(f"Audnexus: ASIN lookup returned status {resp.status_code}")
             return None
+
+        record_api_success('audnexus')
 
         data = resp.json()
         if not data or not data.get('title'):

--- a/library_manager/providers/bookdb.py
+++ b/library_manager/providers/bookdb.py
@@ -520,6 +520,8 @@ def contribute_to_bookdb(title, author=None, narrator=None, series=None,
 
     url = bookdb_url or BOOKDB_API_URL
 
+    rate_limit_wait('bookdb')
+
     try:
         payload = {
             "title": title.strip(),
@@ -583,7 +585,14 @@ def lookup_community_consensus(title, author=None, bookdb_url=None):
     if not title or len(title.strip()) < 2:
         return None
 
+    # Check circuit breaker - skip if we've been rate limited too much
+    if is_circuit_open('bookdb'):
+        logger.debug("[SKALDLEITA COMMUNITY] Circuit open, skipping")
+        return None
+
     url = bookdb_url or BOOKDB_API_URL
+
+    rate_limit_wait('bookdb')
 
     try:
         params = {"title": title.strip()}

--- a/library_manager/providers/gemini.py
+++ b/library_manager/providers/gemini.py
@@ -347,6 +347,11 @@ def detect_audio_language(audio_file, config, extract_audio_sample_fn=None, pars
     Returns:
         dict with 'language' (ISO 639-1 code), 'language_name', and 'confidence', or None
     """
+    # Check circuit breaker before doing any work
+    if is_circuit_open('gemini'):
+        logger.debug("[GEMINI AUDIO] Circuit breaker open, skipping language detection")
+        return None
+
     api_key = config.get('gemini_api_key')
     if not api_key:
         logger.debug("No Gemini API key for audio language detection")

--- a/library_manager/providers/openrouter.py
+++ b/library_manager/providers/openrouter.py
@@ -240,6 +240,10 @@ def identify_book_from_transcript(transcript, config):
         logger.warning("[LAYER 4] No OpenRouter API key for transcript identification")
         return None
 
+    # Check circuit breaker - skip if we've hit daily limits
+    if is_circuit_open('openrouter'):
+        return None
+
     # Respect free tier rate limits (20 req/min + daily limits)
     rate_limit_wait('openrouter')
 


### PR DESCRIPTION
## Summary
- **#222**: Add `rate_limit_wait('bookdb')` to `contribute_to_bookdb()` and `lookup_community_consensus()`. Add circuit breaker check to consensus lookup.
- **#223**: Add circuit breaker checks to `identify_book_from_transcript()` (openrouter) and `detect_audio_language()` (gemini). Fix `lookup_audnexus_by_asin()` to only record success after 200 status.
- **#224**: Add `_bg_processing_active` re-entrancy guard to `/api/process` endpoint, matching the existing pattern in `/api/process_background`.

## Test plan
- [ ] Verify processing still works end-to-end
- [ ] Verify clicking Process multiple times doesn't spawn concurrent runs
- [ ] Verify Skaldleita/Gemini calls respect rate limits

Closes #222, closes #223, closes #224