### PR TITLE
fix: Undo parent mkdir and sanitize false positive (#225, #226)

### DIFF
--- a/app.py
+++ b/app.py
@@ -8750,6 +8750,9 @@ def api_undo(history_id):
             logger.warning(f"Could not restore tags during undo: {tag_err}")
             tags_message = " (Tags could not be restored)"
 
+        # Ensure parent directory exists (may have been cleaned up)
+        Path(old_path).parent.mkdir(parents=True, exist_ok=True)
+
         # Rename back to original
         shutil.move(new_path, old_path)
         logger.info(f"Undo: Renamed '{new_path}' back to '{old_path}'")

--- a/library_manager/utils/path_safety.py
+++ b/library_manager/utils/path_safety.py
@@ -283,7 +283,8 @@ def sanitize_path_component(name):
         return None
 
     # Block directory traversal attempts
-    if '..' in name or name.startswith('/') or name.startswith('\\'):
+    # Only block if the component IS ".." exactly (not substrings like "What If..?")
+    if name.strip() == '..' or name.startswith('/') or name.startswith('\\'):
         logger.warning(f"BLOCKED dangerous path component: {name}")
         return None
 


### PR DESCRIPTION
## Summary
- **#225**: Add `Path(old_path).parent.mkdir(parents=True, exist_ok=True)` before `shutil.move` in `api_undo()` so undo works even when the original parent directory was cleaned up
- **#226**: Change `'..' in name` to `name.strip() == '..'` in `sanitize_path_component()` — stops blocking legitimate titles containing consecutive dots (e.g., "What If..?") while still blocking actual directory traversal

## Test plan
- [ ] Verify undo works when original parent folder no longer exists
- [ ] Verify books with `..` in title (e.g., "What If..?") get rename proposals
- [ ] Verify actual `..` traversal is still blocked

Closes #225, closes #226