### PR TITLE
fix: Fix broken route, settings save, and XSS (#231, #232, #237)

### DIFF
--- a/app.py
+++ b/app.py
@@ -7284,6 +7284,7 @@ def settings_page():
         config['ebook_library_mode'] = request.form.get('ebook_library_mode', 'merge')
         # Verification layer settings (added beta.43)
         config['enable_api_lookups'] = 'enable_api_lookups' in request.form
+        config['enable_isbn_lookup'] = 'enable_isbn_lookup' in request.form
         config['enable_ai_verification'] = 'enable_ai_verification' in request.form
         config['enable_audio_analysis'] = 'enable_audio_analysis' in request.form
         config['enable_content_analysis'] = 'enable_content_analysis' in request.form  # Issue #65: Layer 4
@@ -7293,6 +7294,7 @@ def settings_page():
         use_sl = 'use_skaldleita_for_audio' in request.form or 'use_bookdb_for_audio' in request.form
         config['use_skaldleita_for_audio'] = use_sl
         config.pop('use_bookdb_for_audio', None)  # Remove deprecated key
+        config['sl_trust_mode'] = request.form.get('sl_trust_mode', 'full')
         config['enable_voice_id'] = 'enable_voice_id' in request.form  # Skaldleita narrator voice ID
         config['deep_scan_mode'] = 'deep_scan_mode' in request.form
         config['profile_confidence_threshold'] = int(request.form.get('profile_confidence_threshold', 85))

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -10,9 +10,12 @@
  */
 function escapeHtml(text) {
     if (text === null || text === undefined) return '';
-    var div = document.createElement('div');
-    div.textContent = String(text);
-    return div.innerHTML;
+    return String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
 }
 
 /**

--- a/templates/queue.html
+++ b/templates/queue.html
@@ -1219,7 +1219,7 @@ async function saveAllMultiEdits() {
     let saved = 0;
     for (const item of modified) {
         try {
-            const resp = await fetch('/api/queue/manual_match', {
+            const resp = await fetch('/api/manual_match', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -953,23 +953,7 @@
                                 <li><strong>Hardcover</strong> - Indie/modern books</li>
                                 <li><strong>AI Fallback</strong> - When APIs fail</li>
                             </ol>
-                            <div class="mb-0">
-                                <label class="form-label small">Google Books API Key <span class="text-muted">(optional)</span></label>
-                                <div class="input-group input-group-sm">
-                                    <input type="password" class="form-control bg-dark text-light" name="google_books_api_key" id="google_books_api_key"
-                                           value="{{ config.google_books_api_key or '' }}" placeholder="For higher rate limits"
-                                           data-has-key="{{ 'true' if config.google_books_api_key else 'false' }}">
-                                    <button class="btn btn-outline-secondary" type="button" onclick="togglePasswordVisibility('google_books_api_key')" title="Show/hide key">
-                                        <i class="bi bi-eye"></i>
-                                    </button>
-                                    {% if config.google_books_api_key %}
-                                    <span class="input-group-text bg-success text-white" id="google-books-key-check"><i class="bi bi-check"></i></span>
-                                    <button class="btn btn-outline-danger" type="button" onclick="clearApiKey('google_books_api_key')" title="Remove key">
-                                        <i class="bi bi-trash"></i>
-                                    </button>
-                                    {% endif %}
-                                </div>
-                            </div>
+                            <p class="text-muted small mb-0">Google Books API key can be configured in the AI Setup tab above.</p>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- **#231**: Fix broken multi-edit route `/api/queue/manual_match` → `/api/manual_match`
- **#232**: Add missing `sl_trust_mode` and `enable_isbn_lookup` reads to settings POST handler. Remove duplicate `google_books_api_key` field.
- **#237**: Replace DOM-based `escapeHtml()` with string-replace chain that handles all 5 HTML entities including single quotes — fixes XSS in onclick attributes and functional breakage on names with apostrophes (O'Brien etc.)

## Test plan
- [ ] Multi-edit modal on queue page — verify save works (was returning 404)
- [ ] Settings page — change sl_trust_mode and enable_isbn_lookup, save, reload — verify values persist
- [ ] Library page — verify books with apostrophes in author names have working edit buttons

Closes #231, closes #232, closes #237