### PR TITLE
fix: Prevent books from getting stuck in pipeline (#228, #229)

### DIFF
--- a/library_manager/pipeline/layer_ai_queue.py
+++ b/library_manager/pipeline/layer_ai_queue.py
@@ -692,6 +692,16 @@ def process_queue(
                     else:
                         # Standard mode - block the change
                         logger.warning(f"BLOCKED (verification failed): {row['current_author']} -> {new_author}")
+                        # Issue #228: Create history entry so user can see and act on the book
+                        insert_history_entry(
+                            c, row['book_id'], row['current_author'], row['current_title'],
+                            new_author, new_title, str(old_path), str(new_path), 'pending_fix',
+                            error_message=f"Verification failed: AI could not confirm change",
+                            new_narrator=new_narrator, new_series=new_series,
+                            new_series_num=str(new_series_num) if new_series_num else None,
+                            new_year=str(new_year) if new_year else None,
+                            new_edition=new_edition, new_variant=new_variant
+                        )
                         c.execute('UPDATE books SET status = ? WHERE id = ?', ('pending_fix', row['book_id']))
                         c.execute('DELETE FROM queue WHERE id = ?', (row['queue_id'],))
                         processed += 1

--- a/library_manager/pipeline/layer_api.py
+++ b/library_manager/pipeline/layer_api.py
@@ -332,12 +332,11 @@ def process_layer_1_api(
             logger.info(action['log_message'])
 
         if action['type'] == 'trust_sl':
-            # SL audio ID was high confidence - mark as resolved, skip Layer 2 (AI)
-            # Advance to Layer 4 for final verification/fix application
+            # Issue #229: SL audio ID was high confidence - skip Layer 2 (AI), advance to Layer 4
+            # Keep queue entry so Layer 4 can pick up the book (deleting it orphans the book)
             c.execute('''UPDATE books SET verification_layer = 4,
                         max_layer_reached = MAX(COALESCE(max_layer_reached, 0), 4)
                         WHERE id = ?''', (action['book_id'],))
-            c.execute('DELETE FROM queue WHERE id = ?', (action['queue_id'],))
             resolved += 1
         elif action['type'] == 'verified':
             # Save profile and mark as verified


### PR DESCRIPTION
## Summary
- **#228**: When `verify_drastic_change()` returns None (failure) in standard mode, now creates a history entry before setting `pending_fix` status — books are visible in the UI instead of silently vanishing
- **#229**: Removes erroneous `DELETE FROM queue` in the `trust_sl` handler — Layer 4 needs the queue entry to find the book. High-confidence Skaldleita identifications were being permanently orphaned.

## Test plan
- [ ] Process a book where AI verification fails — verify it appears in history as pending_fix
- [ ] Process a book that gets trust_sl from Skaldleita — verify it advances to Layer 4 and completes
- [ ] Verify normal pipeline flow still works end-to-end

Closes #228, closes #229