### PR TITLE
fix: Double-click prevention, numeric titles, confidence scale (#233, #234, #235)

### DIFF
--- a/library_manager/folder_triage.py
+++ b/library_manager/folder_triage.py
@@ -41,6 +41,12 @@ GARBAGE_PATTERNS: List[str] = [
     r'^Unknown\s*(Artist|Author|Album)?$',  # Generic unknowns
 ]
 
+# Famous numeric titles that are valid book names, not garbage
+# Shared with book_profile.py is_valid_title() - keep in sync
+FAMOUS_NUMERIC_TITLES = {
+    '1984', '2001', '2010', '1776', '1066', '1421', '1491', '1493', '11/22/63',
+}
+
 # Compiled patterns for performance (compiled once at import time)
 _MESSY_COMPILED = [re.compile(p, re.IGNORECASE) for p in MESSY_PATTERNS]
 _GARBAGE_COMPILED = [re.compile(p, re.IGNORECASE) for p in GARBAGE_PATTERNS]
@@ -59,6 +65,10 @@ def triage_folder(folder_name: str) -> str:
         return 'garbage'
 
     folder_name = folder_name.strip()
+
+    # Skip garbage check for famous numeric book titles (e.g. "1984")
+    if folder_name in FAMOUS_NUMERIC_TITLES:
+        return 'clean'
 
     # Check garbage first (most restrictive)
     for pattern in _GARBAGE_COMPILED:

--- a/library_manager/pipeline/layer_audio_id.py
+++ b/library_manager/pipeline/layer_audio_id.py
@@ -591,10 +591,17 @@ def process_layer_1_audio(
             elif bookdb_result and bookdb_result.get('author') and bookdb_result.get('title'):
                 # Skaldleita got a full identification - validate against path first
                 sl_source = bookdb_result.get('sl_source', 'audio')
-                # Safely parse confidence - Skaldleita may return float, string, or garbage
+                # Safely parse confidence - Skaldleita may return 0-1 float or 0-100 int
                 raw_confidence = bookdb_result.get('confidence', 0.8)
                 try:
-                    sl_confidence = int(float(raw_confidence) * 100) if isinstance(raw_confidence, (int, float)) else 80
+                    conf_float = float(raw_confidence) if isinstance(raw_confidence, (int, float, str)) else 0.8
+                    # Scale detection: values > 1.0 are already percentages
+                    if conf_float > 1.0:
+                        sl_confidence = int(conf_float)
+                    else:
+                        sl_confidence = int(conf_float * 100)
+                    # Clamp to valid range
+                    sl_confidence = min(100, max(0, sl_confidence))
                 except (ValueError, TypeError):
                     sl_confidence = 80  # Default if parsing fails
                 set_current_provider("Skaldleita", f"Identified from {sl_source}", is_free=True)

--- a/templates/history.html
+++ b/templates/history.html
@@ -480,6 +480,9 @@ function saveEdit() {
 function unlockBook(bookId) {
     if (!confirm('Unlock this book?\n\nThis will allow the system to re-process it on future scans. Your current settings will remain until the system finds a different match.')) return;
 
+    const btn = event.currentTarget;
+    btn.disabled = true;
+
     fetch(`/api/unlock_book/${bookId}`, {method: 'POST'})
         .then(r => r.json())
         .then(data => {
@@ -490,7 +493,8 @@ function unlockBook(bookId) {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 // escapeHtml provided by common.js
@@ -498,6 +502,9 @@ function unlockBook(bookId) {
 // ===== EXISTING FUNCTIONS =====
 function applyFix(historyId) {
     if (!confirm('Apply this fix? The folder will be renamed.')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch(`/api/apply_fix/${historyId}`, {method: 'POST'})
         .then(r => r.json())
@@ -508,11 +515,15 @@ function applyFix(historyId) {
             } else {
                 alert('Error: ' + data.message);
             }
-        });
+        })
+        .finally(() => { btn.disabled = false; });
 }
 
 function undoFix(historyId) {
     if (!confirm('Undo this fix? The folder will be renamed back to its original name.')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch(`/api/undo/${historyId}`, {method: 'POST'})
         .then(r => r.json())
@@ -524,11 +535,15 @@ function undoFix(historyId) {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function rejectFix(historyId) {
     if (!confirm('Reject this fix? It will be deleted and the book will be marked as OK.')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch(`/api/reject_fix/${historyId}`, {method: 'POST'})
         .then(r => r.json())
@@ -540,11 +555,15 @@ function rejectFix(historyId) {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function dismissError(historyId) {
     if (!confirm('Dismiss this error entry? It will be removed from history.')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch(`/api/dismiss_error/${historyId}`, {method: 'POST'})
         .then(r => r.json())
@@ -555,11 +574,15 @@ function dismissError(historyId) {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function removeDuplicate(historyId) {
     if (!confirm('Remove this duplicate?\n\nThis will DELETE the misnamed copy and keep the properly-named version.\n\nThis cannot be undone!')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch(`/api/remove_duplicate/${historyId}`, {method: 'POST'})
         .then(r => r.json())
@@ -571,11 +594,15 @@ function removeDuplicate(historyId) {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function removeAllDuplicates() {
     if (!confirm('Remove ALL confirmed duplicates?\n\nThis will DELETE all misnamed copies and keep the properly-named versions.\n\nThis cannot be undone!')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch('/api/remove_all_duplicates', {method: 'POST'})
         .then(r => r.json())
@@ -594,11 +621,15 @@ function removeAllDuplicates() {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function replaceCorrupt(historyId) {
     if (!confirm('Replace corrupt destination with valid source?\n\nThis will:\n1. Delete the corrupt destination folder\n2. Move the valid source to the correct location\n\nThis cannot be undone!')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch(`/api/replace_corrupt/${historyId}`, {method: 'POST'})
         .then(r => r.json())
@@ -610,11 +641,15 @@ function replaceCorrupt(historyId) {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function clearAllErrors() {
     if (!confirm('Clear all error entries from history?\n\nThis will remove all error records. The actual files are not affected.')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch('/api/clear_all_errors', {method: 'POST'})
         .then(r => r.json())
@@ -626,11 +661,15 @@ function clearAllErrors() {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function applyAllPending() {
     if (!confirm('Apply ALL pending fixes?\n\nThis will rename all folders according to the AI suggestions.\nMake sure you have reviewed them first!')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch('/api/apply_all_pending', {method: 'POST'})
         .then(r => r.json())
@@ -642,11 +681,15 @@ function applyAllPending() {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function rejectAllPending() {
     if (!confirm('Reject ALL pending fixes?\n\nThis will mark all pending items as OK without making any changes.')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch('/api/reject_all_pending', {method: 'POST'})
         .then(r => r.json())
@@ -658,7 +701,8 @@ function rejectAllPending() {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- **#233**: Add button-disabling during fetch to all 11 history page action functions (applyFix, undoFix, rejectFix, etc.) with `.finally()` restore — prevents double-click on destructive operations
- **#234**: Add `FAMOUS_NUMERIC_TITLES` set to `folder_triage.py` — folders named "1984", "2001", "11/22/63" etc. are now classified as `clean` instead of `garbage`
- **#235**: Fix confidence scale detection in L1 audio ID — values > 1.0 treated as already-percentage, plus 0-100 clamp. Prevents 80x inflation when Skaldleita returns integer percentages.

## Test plan
- [ ] History page — verify buttons disable during apply/undo/reject and re-enable after
- [ ] Scan a folder named "1984" — verify it's not classified as garbage in logs
- [ ] Process a book through Skaldleita — verify confidence values are sane (0-100 range)

Closes #233, closes #234, closes #235