### PR TITLE
Release 0.9.0-beta.152

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.150-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.152-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 

--- a/app.py
+++ b/app.py
@@ -8759,6 +8759,9 @@ def api_undo(history_id):
             logger.warning(f"Could not restore tags during undo: {tag_err}")
             tags_message = " (Tags could not be restored)"
 
+        # Ensure parent directory exists (may have been cleaned up)
+        Path(old_path).parent.mkdir(parents=True, exist_ok=True)
+
         # Rename back to original
         shutil.move(new_path, old_path)
         logger.info(f"Undo: Renamed '{new_path}' back to '{old_path}'")

--- a/app.py
+++ b/app.py
@@ -7284,6 +7284,7 @@ def settings_page():
         config['ebook_library_mode'] = request.form.get('ebook_library_mode', 'merge')
         # Verification layer settings (added beta.43)
         config['enable_api_lookups'] = 'enable_api_lookups' in request.form
+        config['enable_isbn_lookup'] = 'enable_isbn_lookup' in request.form
         config['enable_ai_verification'] = 'enable_ai_verification' in request.form
         config['enable_audio_analysis'] = 'enable_audio_analysis' in request.form
         config['enable_content_analysis'] = 'enable_content_analysis' in request.form  # Issue #65: Layer 4
@@ -7293,6 +7294,7 @@ def settings_page():
         use_sl = 'use_skaldleita_for_audio' in request.form or 'use_bookdb_for_audio' in request.form
         config['use_skaldleita_for_audio'] = use_sl
         config.pop('use_bookdb_for_audio', None)  # Remove deprecated key
+        config['sl_trust_mode'] = request.form.get('sl_trust_mode', 'full')
         config['enable_voice_id'] = 'enable_voice_id' in request.form  # Skaldleita narrator voice ID
         config['deep_scan_mode'] = 'deep_scan_mode' in request.form
         config['profile_confidence_threshold'] = int(request.form.get('profile_confidence_threshold', 85))

--- a/app.py
+++ b/app.py
@@ -7964,6 +7964,15 @@ def api_delete_corrupt():
 @app.route('/api/process', methods=['POST'])
 def api_process():
     """Process the queue using layered processing."""
+    global _bg_processing_active
+
+    # Re-entrancy guard - don't start if background processing is already running
+    if _bg_processing_active:
+        return jsonify({
+            'success': False,
+            'message': 'Processing is already running in the background'
+        })
+
     config = load_config()
     data = request.json if request.is_json else {}
     process_all = data.get('all', False)

--- a/app.py
+++ b/app.py
@@ -6127,12 +6127,17 @@ def apply_fix(history_id):
     conn = get_db()
     c = conn.cursor()
 
+    # Issue #220: Atomic status guard — claim the row before doing any work.
+    # If another caller already claimed it, rowcount will be 0.
+    c.execute("UPDATE history SET status = 'applying' WHERE id = ? AND status = 'pending_fix'",
+              (history_id,))
+    conn.commit()
+    if c.rowcount == 0:
+        conn.close()
+        return False, "Fix not found or already being applied"
+
     c.execute('SELECT * FROM history WHERE id = ?', (history_id,))
     fix = c.fetchone()
-
-    if not fix:
-        conn.close()
-        return False, "Fix not found"
 
     # Issue #69: Handle history entries with missing paths
     # Some older code paths created history entries without old_path/new_path
@@ -6145,6 +6150,8 @@ def apply_fix(history_id):
         c.execute('SELECT path FROM books WHERE id = ?', (book_id,))
         book_row = c.fetchone()
         if not book_row or not book_row['path']:
+            c.execute("UPDATE history SET status = 'pending_fix' WHERE id = ?", (history_id,))
+            conn.commit()
             conn.close()
             return False, "Cannot determine source path - book not found"
         old_path = Path(book_row['path'])
@@ -6157,6 +6164,8 @@ def apply_fix(history_id):
         config = load_config()
         library_paths = config.get('library_paths', [])
         if not library_paths:
+            c.execute("UPDATE history SET status = 'pending_fix' WHERE id = ?", (history_id,))
+            conn.commit()
             conn.close()
             return False, "Cannot determine destination - no library paths configured"
 
@@ -6178,6 +6187,8 @@ def apply_fix(history_id):
             config=config
         )
         if not new_path:
+            c.execute("UPDATE history SET status = 'pending_fix' WHERE id = ?", (history_id,))
+            conn.commit()
             conn.close()
             return False, "Cannot build destination path - invalid author/title"
         new_path = Path(new_path)

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.151"
+APP_VERSION = "0.9.0-beta.152"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:
@@ -8538,6 +8538,12 @@ def api_undo_all_drastic():
                  WHERE status = 'fixed' AND old_path != new_path''')
     items = c.fetchall()
 
+    # Issue #219: Pre-compute library boundaries for validation
+    config = load_config()
+    library_paths = [Path(p).resolve() for p in config.get('library_paths', [])]
+    watch_folder = config.get('watch_folder', '').strip()
+    watch_output_folder = config.get('watch_output_folder', '').strip()
+
     undone = 0
     errors = 0
 
@@ -8547,6 +8553,53 @@ def api_undo_all_drastic():
 
         old_path = item['old_path']
         new_path = item['new_path']
+
+        # Issue #219: Validate both paths are inside library boundary
+        old_in_library = False
+        new_in_library = False
+        for lib in library_paths:
+            try:
+                Path(old_path).resolve().relative_to(lib)
+                old_in_library = True
+            except ValueError:
+                pass
+            try:
+                Path(new_path).resolve().relative_to(lib)
+                new_in_library = True
+            except ValueError:
+                pass
+        if watch_folder:
+            watch_resolved = Path(watch_folder).resolve()
+            if not old_in_library:
+                try:
+                    Path(old_path).resolve().relative_to(watch_resolved)
+                    old_in_library = True
+                except ValueError:
+                    pass
+            if not new_in_library:
+                try:
+                    Path(new_path).resolve().relative_to(watch_resolved)
+                    new_in_library = True
+                except ValueError:
+                    pass
+        if watch_output_folder:
+            watch_out_resolved = Path(watch_output_folder).resolve()
+            if not old_in_library:
+                try:
+                    Path(old_path).resolve().relative_to(watch_out_resolved)
+                    old_in_library = True
+                except ValueError:
+                    pass
+            if not new_in_library:
+                try:
+                    Path(new_path).resolve().relative_to(watch_out_resolved)
+                    new_in_library = True
+                except ValueError:
+                    pass
+        if not old_in_library or not new_in_library:
+            errors += 1
+            logger.error(f"SAFETY BLOCK in undo_all_drastic: Path outside library! old={old_path}, new={new_path}")
+            continue
 
         # Check if paths exist correctly
         if not os.path.exists(new_path):
@@ -8614,9 +8667,65 @@ def api_undo(history_id):
             'error': f'Original path already exists: {old_path}'
         }), 409
 
+    # Issue #219: Validate paths are inside library boundary before any file operations
+    config = load_config()
+    library_paths = [Path(p).resolve() for p in config.get('library_paths', [])]
+    watch_folder = config.get('watch_folder', '').strip()
+    watch_output_folder = config.get('watch_output_folder', '').strip()
+
+    old_in_library = False
+    new_in_library = False
+    for lib in library_paths:
+        try:
+            Path(old_path).resolve().relative_to(lib)
+            old_in_library = True
+        except ValueError:
+            pass
+        try:
+            Path(new_path).resolve().relative_to(lib)
+            new_in_library = True
+        except ValueError:
+            pass
+    if watch_folder:
+        watch_resolved = Path(watch_folder).resolve()
+        if not old_in_library:
+            try:
+                Path(old_path).resolve().relative_to(watch_resolved)
+                old_in_library = True
+            except ValueError:
+                pass
+        if not new_in_library:
+            try:
+                Path(new_path).resolve().relative_to(watch_resolved)
+                new_in_library = True
+            except ValueError:
+                pass
+    if watch_output_folder:
+        watch_out_resolved = Path(watch_output_folder).resolve()
+        if not old_in_library:
+            try:
+                Path(old_path).resolve().relative_to(watch_out_resolved)
+                old_in_library = True
+            except ValueError:
+                pass
+        if not new_in_library:
+            try:
+                Path(new_path).resolve().relative_to(watch_out_resolved)
+                new_in_library = True
+            except ValueError:
+                pass
+
+    if not old_in_library or not new_in_library:
+        conn.close()
+        logger.error(f"SAFETY BLOCK in undo: Path outside library! old_in_lib={old_in_library}, new_in_lib={new_in_library}")
+        return jsonify({
+            'success': False,
+            'error': 'Safety block: path is outside library boundary'
+        }), 403
+
     try:
         new_path_obj = Path(new_path)
-        
+
         # Determine folder for sidecar (if new_path is a file, parent has sidecar)
         if new_path_obj.is_file():
             sidecar_folder = new_path_obj.parent
@@ -8703,6 +8812,41 @@ def api_remove_duplicate(history_id):
     old_path = record['old_path']  # This is the duplicate to remove
     new_path = record['new_path']  # This is the properly named copy to keep
 
+    # Issue #219: Validate paths are inside library boundary before any file operations
+    config = load_config()
+    library_paths = [Path(p).resolve() for p in config.get('library_paths', [])]
+    watch_folder = config.get('watch_folder', '').strip()
+    watch_output_folder = config.get('watch_output_folder', '').strip()
+
+    old_in_library = False
+    for lib in library_paths:
+        try:
+            Path(old_path).resolve().relative_to(lib)
+            old_in_library = True
+            break
+        except ValueError:
+            continue
+    if watch_folder and not old_in_library:
+        try:
+            Path(old_path).resolve().relative_to(Path(watch_folder).resolve())
+            old_in_library = True
+        except ValueError:
+            pass
+    if watch_output_folder and not old_in_library:
+        try:
+            Path(old_path).resolve().relative_to(Path(watch_output_folder).resolve())
+            old_in_library = True
+        except ValueError:
+            pass
+
+    if not old_in_library:
+        conn.close()
+        logger.error(f"SAFETY BLOCK in remove_duplicate: old_path outside library: {old_path}")
+        return jsonify({
+            'success': False,
+            'error': 'Safety block: path is outside library boundary'
+        }), 403
+
     # Safety checks
     if not os.path.exists(old_path):
         # Already removed - just update status
@@ -8788,6 +8932,62 @@ def api_replace_corrupt(history_id):
     old_path = record['old_path']  # Valid source
     new_path = record['new_path']  # Corrupt destination
 
+    # Issue #219: Validate paths are inside library boundary before any file operations
+    config = load_config()
+    library_paths = [Path(p).resolve() for p in config.get('library_paths', [])]
+    watch_folder = config.get('watch_folder', '').strip()
+    watch_output_folder = config.get('watch_output_folder', '').strip()
+
+    old_in_library = False
+    new_in_library = False
+    for lib in library_paths:
+        try:
+            Path(old_path).resolve().relative_to(lib)
+            old_in_library = True
+        except ValueError:
+            pass
+        try:
+            Path(new_path).resolve().relative_to(lib)
+            new_in_library = True
+        except ValueError:
+            pass
+    if watch_folder:
+        watch_resolved = Path(watch_folder).resolve()
+        if not old_in_library:
+            try:
+                Path(old_path).resolve().relative_to(watch_resolved)
+                old_in_library = True
+            except ValueError:
+                pass
+        if not new_in_library:
+            try:
+                Path(new_path).resolve().relative_to(watch_resolved)
+                new_in_library = True
+            except ValueError:
+                pass
+    if watch_output_folder:
+        watch_out_resolved = Path(watch_output_folder).resolve()
+        if not old_in_library:
+            try:
+                Path(old_path).resolve().relative_to(watch_out_resolved)
+                old_in_library = True
+            except ValueError:
+                pass
+        if not new_in_library:
+            try:
+                Path(new_path).resolve().relative_to(watch_out_resolved)
+                new_in_library = True
+            except ValueError:
+                pass
+
+    if not old_in_library or not new_in_library:
+        conn.close()
+        logger.error(f"SAFETY BLOCK in replace_corrupt: Path outside library! old_in_lib={old_in_library}, new_in_lib={new_in_library}")
+        return jsonify({
+            'success': False,
+            'error': 'Safety block: path is outside library boundary'
+        }), 403
+
     # Safety checks
     if not os.path.exists(old_path):
         conn.close()
@@ -8858,6 +9058,12 @@ def api_remove_all_duplicates():
         conn.close()
         return jsonify({'success': True, 'message': 'No duplicates to remove', 'removed': 0})
 
+    # Issue #219: Pre-compute library boundaries for validation
+    config = load_config()
+    library_paths = [Path(p).resolve() for p in config.get('library_paths', [])]
+    watch_folder = config.get('watch_folder', '').strip()
+    watch_output_folder = config.get('watch_output_folder', '').strip()
+
     removed = 0
     skipped = 0
     errors = []
@@ -8866,6 +9072,33 @@ def api_remove_all_duplicates():
     for record in duplicates:
         old_path = record['old_path']
         new_path = record['new_path']
+
+        # Issue #219: Validate both paths are inside library boundary
+        old_in_library = False
+        for lib in library_paths:
+            try:
+                Path(old_path).resolve().relative_to(lib)
+                old_in_library = True
+                break
+            except ValueError:
+                continue
+        if watch_folder and not old_in_library:
+            try:
+                Path(old_path).resolve().relative_to(Path(watch_folder).resolve())
+                old_in_library = True
+            except ValueError:
+                pass
+        if watch_output_folder and not old_in_library:
+            try:
+                Path(old_path).resolve().relative_to(Path(watch_output_folder).resolve())
+                old_in_library = True
+            except ValueError:
+                pass
+        if not old_in_library:
+            skipped += 1
+            logger.error(f"SAFETY BLOCK in remove_all_duplicates: old_path outside library: {old_path}")
+            errors.append(f"Skipped {old_path}: path outside library boundary")
+            continue
 
         # Skip if already removed
         if not os.path.exists(old_path):

--- a/library_manager/folder_triage.py
+++ b/library_manager/folder_triage.py
@@ -41,6 +41,12 @@ GARBAGE_PATTERNS: List[str] = [
     r'^Unknown\s*(Artist|Author|Album)?$',  # Generic unknowns
 ]
 
+# Famous numeric titles that are valid book names, not garbage
+# Shared with book_profile.py is_valid_title() - keep in sync
+FAMOUS_NUMERIC_TITLES = {
+    '1984', '2001', '2010', '1776', '1066', '1421', '1491', '1493', '11/22/63',
+}
+
 # Compiled patterns for performance (compiled once at import time)
 _MESSY_COMPILED = [re.compile(p, re.IGNORECASE) for p in MESSY_PATTERNS]
 _GARBAGE_COMPILED = [re.compile(p, re.IGNORECASE) for p in GARBAGE_PATTERNS]
@@ -59,6 +65,10 @@ def triage_folder(folder_name: str) -> str:
         return 'garbage'
 
     folder_name = folder_name.strip()
+
+    # Skip garbage check for famous numeric book titles (e.g. "1984")
+    if folder_name in FAMOUS_NUMERIC_TITLES:
+        return 'clean'
 
     # Check garbage first (most restrictive)
     for pattern in _GARBAGE_COMPILED:

--- a/library_manager/models/book_profile.py
+++ b/library_manager/models/book_profile.py
@@ -166,6 +166,7 @@ class FieldValue:
     confidence: int = 0
     sources: List[str] = field(default_factory=list)
     raw_values: Dict[str, Any] = field(default_factory=dict)  # source -> raw value
+    source_weights: Dict[str, int] = field(default_factory=dict)  # source -> weight override
 
     def add_source(self, source: str, value: Any, weight: int = None):
         """Add evidence from a source."""
@@ -174,16 +175,24 @@ class FieldValue:
         if weight is None:
             weight = SOURCE_WEIGHTS.get(source, 30)
         self.raw_values[source] = value
+        self.source_weights[source] = weight
         if source not in self.sources:
             self.sources.append(source)
 
+    def _get_weight(self, source: str) -> int:
+        """Get weight for a source, preferring stored override."""
+        return self.source_weights.get(source, SOURCE_WEIGHTS.get(source, 30))
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to JSON-serializable dictionary."""
-        return {
+        d = {
             'value': self.value,
             'confidence': self.confidence,
             'sources': self.sources
         }
+        if self.source_weights:
+            d['source_weights'] = self.source_weights
+        return d
 
 
 @dataclass
@@ -257,7 +266,7 @@ class BookProfile:
             normalized = normalize(value)
             if normalized not in value_groups:
                 value_groups[normalized] = []
-            weight = SOURCE_WEIGHTS.get(source, 30)
+            weight = fv._get_weight(source)
             value_groups[normalized].append((source, value, weight))
 
         if not value_groups:
@@ -347,7 +356,7 @@ class BookProfile:
                 continue  # Skip the corrupt value
             if normalized not in value_groups:
                 value_groups[normalized] = []
-            weight = SOURCE_WEIGHTS.get(source, 30)
+            weight = self.author._get_weight(source)
             value_groups[normalized].append((source, value, weight))
 
         if not value_groups:
@@ -414,7 +423,8 @@ class BookProfile:
                 fv = FieldValue(
                     value=fd.get('value'),
                     confidence=fd.get('confidence', 0),
-                    sources=fd.get('sources', [])
+                    sources=fd.get('sources', []),
+                    source_weights=fd.get('source_weights', {})
                 )
                 setattr(profile, field_name, fv)
         profile.overall_confidence = data.get('overall_confidence', 0)

--- a/library_manager/pipeline/layer_ai_queue.py
+++ b/library_manager/pipeline/layer_ai_queue.py
@@ -692,6 +692,16 @@ def process_queue(
                     else:
                         # Standard mode - block the change
                         logger.warning(f"BLOCKED (verification failed): {row['current_author']} -> {new_author}")
+                        # Issue #228: Create history entry so user can see and act on the book
+                        insert_history_entry(
+                            c, row['book_id'], row['current_author'], row['current_title'],
+                            new_author, new_title, str(old_path), str(new_path), 'pending_fix',
+                            error_message=f"Verification failed: AI could not confirm change",
+                            new_narrator=new_narrator, new_series=new_series,
+                            new_series_num=str(new_series_num) if new_series_num else None,
+                            new_year=str(new_year) if new_year else None,
+                            new_edition=new_edition, new_variant=new_variant
+                        )
                         c.execute('UPDATE books SET status = ? WHERE id = ?', ('pending_fix', row['book_id']))
                         c.execute('DELETE FROM queue WHERE id = ?', (row['queue_id'],))
                         processed += 1

--- a/library_manager/pipeline/layer_api.py
+++ b/library_manager/pipeline/layer_api.py
@@ -332,12 +332,11 @@ def process_layer_1_api(
             logger.info(action['log_message'])
 
         if action['type'] == 'trust_sl':
-            # SL audio ID was high confidence - mark as resolved, skip Layer 2 (AI)
-            # Advance to Layer 4 for final verification/fix application
+            # Issue #229: SL audio ID was high confidence - skip Layer 2 (AI), advance to Layer 4
+            # Keep queue entry so Layer 4 can pick up the book (deleting it orphans the book)
             c.execute('''UPDATE books SET verification_layer = 4,
                         max_layer_reached = MAX(COALESCE(max_layer_reached, 0), 4)
                         WHERE id = ?''', (action['book_id'],))
-            c.execute('DELETE FROM queue WHERE id = ?', (action['queue_id'],))
             resolved += 1
         elif action['type'] == 'verified':
             # Save profile and mark as verified

--- a/library_manager/pipeline/layer_audio_id.py
+++ b/library_manager/pipeline/layer_audio_id.py
@@ -720,6 +720,12 @@ def process_layer_1_audio(
                 if series_num:
                     profile['series_num'] = {'value': str(series_num), 'source': sl_source, 'confidence': 75}
 
+                # Issue #227: Save original author/title BEFORE updating the DB.
+                # If validation fails later, we must revert these to prevent
+                # garbage values from persisting permanently.
+                original_author = row['current_author']
+                original_title = row['current_title']
+
                 # Phase 5: Track SL requeue suggestion for future re-verification
                 # After nightly merge, the book should be re-checked against main DB
                 if result.get('requeue_suggested'):
@@ -770,10 +776,12 @@ def process_layer_1_audio(
                 # Validate before creating pending_fix (Issue #92: prevent garbage recommendations)
                 if not is_valid_author_for_recommendation(author):
                     logger.warning(f"[LAYER 1/AUDIO] Rejected garbage author: '{author}' for {row['current_title']}")
+                    # Issue #227: Revert current_author/current_title corrupted by the UPDATE above
                     # Don't create garbage pending_fix - advance to Layer 2 instead
-                    c.execute('''UPDATE books SET verification_layer = 2,
+                    c.execute('''UPDATE books SET current_author = ?, current_title = ?,
+                                verification_layer = 2,
                                 status = CASE WHEN status = 'needs_attention' THEN 'pending' ELSE status END
-                                WHERE id = ?''', (row['book_id'],))
+                                WHERE id = ?''', (original_author, original_title, row['book_id']))
                     c.execute('DELETE FROM queue WHERE id = ?', (row['queue_id'],))
                     conn.commit()
                     conn.close()
@@ -781,10 +789,12 @@ def process_layer_1_audio(
 
                 if not is_valid_title_for_recommendation(title):
                     logger.warning(f"[LAYER 1/AUDIO] Rejected garbage title: '{title}' for {row['current_author']}")
+                    # Issue #227: Revert current_author/current_title corrupted by the UPDATE above
                     # Don't create garbage pending_fix - advance to Layer 2 instead
-                    c.execute('''UPDATE books SET verification_layer = 2,
+                    c.execute('''UPDATE books SET current_author = ?, current_title = ?,
+                                verification_layer = 2,
                                 status = CASE WHEN status = 'needs_attention' THEN 'pending' ELSE status END
-                                WHERE id = ?''', (row['book_id'],))
+                                WHERE id = ?''', (original_author, original_title, row['book_id']))
                     c.execute('DELETE FROM queue WHERE id = ?', (row['queue_id'],))
                     conn.commit()
                     conn.close()

--- a/library_manager/pipeline/layer_audio_id.py
+++ b/library_manager/pipeline/layer_audio_id.py
@@ -591,10 +591,17 @@ def process_layer_1_audio(
             elif bookdb_result and bookdb_result.get('author') and bookdb_result.get('title'):
                 # Skaldleita got a full identification - validate against path first
                 sl_source = bookdb_result.get('sl_source', 'audio')
-                # Safely parse confidence - Skaldleita may return float, string, or garbage
+                # Safely parse confidence - Skaldleita may return 0-1 float or 0-100 int
                 raw_confidence = bookdb_result.get('confidence', 0.8)
                 try:
-                    sl_confidence = int(float(raw_confidence) * 100) if isinstance(raw_confidence, (int, float)) else 80
+                    conf_float = float(raw_confidence) if isinstance(raw_confidence, (int, float, str)) else 0.8
+                    # Scale detection: values > 1.0 are already percentages
+                    if conf_float > 1.0:
+                        sl_confidence = int(conf_float)
+                    else:
+                        sl_confidence = int(conf_float * 100)
+                    # Clamp to valid range
+                    sl_confidence = min(100, max(0, sl_confidence))
                 except (ValueError, TypeError):
                     sl_confidence = 80  # Default if parsing fails
                 set_current_provider("Skaldleita", f"Identified from {sl_source}", is_free=True)

--- a/library_manager/plugins.py
+++ b/library_manager/plugins.py
@@ -3,11 +3,14 @@
 Flask Blueprint providing CRUD, test, and health monitoring endpoints for custom HTTP
 API layers. These layers let users add their own book metadata sources without writing code.
 """
+import ipaddress
 import json
 import logging
 import re
+import socket
 import sqlite3
 import time
+from urllib.parse import urlparse
 
 import requests as http_requests
 from flask import Blueprint, request, jsonify
@@ -42,6 +45,54 @@ def _save_config_safe(config):
     config_only = {k: v for k, v in config.items() if k not in SECRETS_KEYS}
     with open(CONFIG_PATH, 'w') as f:
         json.dump(config_only, f, indent=2)
+
+
+def _validate_url(url):
+    """Validate a URL to prevent SSRF attacks.
+
+    Checks that the URL uses http/https and that the resolved IP address
+    is not in a private or reserved range (localhost, LAN, link-local, etc.).
+
+    Returns:
+        (True, None) if the URL is safe to request.
+        (False, error_message) if the URL is blocked.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False, 'Invalid URL'
+
+    if parsed.scheme not in ('http', 'https'):
+        return False, f'URL scheme "{parsed.scheme}" is not allowed (only http/https)'
+
+    hostname = parsed.hostname
+    if not hostname:
+        return False, 'URL has no hostname'
+
+    # Resolve hostname to IP address(es)
+    try:
+        addr_infos = socket.getaddrinfo(hostname, parsed.port or 80,
+                                        proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        return False, f'Cannot resolve hostname "{hostname}"'
+
+    if not addr_infos:
+        return False, f'Cannot resolve hostname "{hostname}"'
+
+    for addr_info in addr_infos:
+        ip_str = addr_info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            return False, f'Invalid IP address resolved: {ip_str}'
+
+        if ip.is_private or ip.is_reserved or ip.is_loopback or ip.is_link_local:
+            return False, (
+                f'URL resolves to private/reserved address {ip_str} '
+                f'- requests to internal networks are blocked'
+            )
+
+    return True, None
 
 
 # ============== PLUGIN METRICS DATABASE ==============
@@ -194,6 +245,16 @@ def api_plugins_save():
     layer['timeout'] = max(1, min(int(layer.get('timeout', 10)), 60))
     layer['source_weight'] = max(0, min(int(layer.get('source_weight', 55)), 100))
 
+    # Validate URL template to prevent SSRF
+    test_context = {
+        'title': 'test', 'author': 'test', 'narrator': '',
+        'path': '/test', 'isbn': '',
+    }
+    test_url = _substitute_url_template(layer['url_template'], test_context)
+    url_ok, url_error = _validate_url(test_url)
+    if not url_ok:
+        return jsonify({'success': False, 'error': url_error}), 400
+
     try:
         config = load_config()
         custom_layers = config.get('custom_layers', [])
@@ -306,6 +367,11 @@ def api_plugins_test():
 
     # Substitute URL template
     url = _substitute_url_template(url_template, context)
+
+    # Validate URL to prevent SSRF
+    url_ok, url_error = _validate_url(url)
+    if not url_ok:
+        return jsonify({'success': False, 'error': url_error}), 400
 
     # Build auth headers
     secrets = load_secrets()

--- a/library_manager/providers/audnexus.py
+++ b/library_manager/providers/audnexus.py
@@ -150,11 +150,11 @@ def lookup_audnexus_by_asin(asin, region='us'):
 
         resp = requests.get(url, timeout=10, headers={'Accept': 'application/json'})
 
-        record_api_success('audnexus')
-
         if resp.status_code != 200:
             logger.debug(f"Audnexus: ASIN lookup returned status {resp.status_code}")
             return None
+
+        record_api_success('audnexus')
 
         data = resp.json()
         if not data or not data.get('title'):

--- a/library_manager/providers/bookdb.py
+++ b/library_manager/providers/bookdb.py
@@ -520,6 +520,8 @@ def contribute_to_bookdb(title, author=None, narrator=None, series=None,
 
     url = bookdb_url or BOOKDB_API_URL
 
+    rate_limit_wait('bookdb')
+
     try:
         payload = {
             "title": title.strip(),
@@ -583,7 +585,14 @@ def lookup_community_consensus(title, author=None, bookdb_url=None):
     if not title or len(title.strip()) < 2:
         return None
 
+    # Check circuit breaker - skip if we've been rate limited too much
+    if is_circuit_open('bookdb'):
+        logger.debug("[SKALDLEITA COMMUNITY] Circuit open, skipping")
+        return None
+
     url = bookdb_url or BOOKDB_API_URL
+
+    rate_limit_wait('bookdb')
 
     try:
         params = {"title": title.strip()}

--- a/library_manager/providers/gemini.py
+++ b/library_manager/providers/gemini.py
@@ -347,6 +347,11 @@ def detect_audio_language(audio_file, config, extract_audio_sample_fn=None, pars
     Returns:
         dict with 'language' (ISO 639-1 code), 'language_name', and 'confidence', or None
     """
+    # Check circuit breaker before doing any work
+    if is_circuit_open('gemini'):
+        logger.debug("[GEMINI AUDIO] Circuit breaker open, skipping language detection")
+        return None
+
     api_key = config.get('gemini_api_key')
     if not api_key:
         logger.debug("No Gemini API key for audio language detection")

--- a/library_manager/providers/openrouter.py
+++ b/library_manager/providers/openrouter.py
@@ -240,6 +240,10 @@ def identify_book_from_transcript(transcript, config):
         logger.warning("[LAYER 4] No OpenRouter API key for transcript identification")
         return None
 
+    # Check circuit breaker - skip if we've hit daily limits
+    if is_circuit_open('openrouter'):
+        return None
+
     # Respect free tier rate limits (20 req/min + daily limits)
     rate_limit_wait('openrouter')
 

--- a/library_manager/utils/path_safety.py
+++ b/library_manager/utils/path_safety.py
@@ -283,7 +283,8 @@ def sanitize_path_component(name):
         return None
 
     # Block directory traversal attempts
-    if '..' in name or name.startswith('/') or name.startswith('\\'):
+    # Only block if the component IS ".." exactly (not substrings like "What If..?")
+    if name.strip() == '..' or name.startswith('/') or name.startswith('\\'):
         logger.warning(f"BLOCKED dangerous path component: {name}")
         return None
 

--- a/library_manager/worker.py
+++ b/library_manager/worker.py
@@ -275,6 +275,8 @@ def process_all_queue(
         layer1_processed = 0
         layer1_resolved = 0
         while True:
+            if not _worker_running:
+                break
             # Issue #74: Check if Skaldleita circuit breaker is open - wait instead of skipping
             if is_circuit_open('bookdb'):
                 cb = get_circuit_breaker('bookdb')
@@ -310,6 +312,8 @@ def process_all_queue(
         layer2_resolved = 0
         circuit_wait_count = 0
         while True:
+            if not _worker_running:
+                break
             # Check if Gemini circuit breaker is open - wait instead of skipping
             if is_circuit_open('gemini'):
                 cb = get_circuit_breaker('gemini')
@@ -379,6 +383,8 @@ def process_all_queue(
         _processing_status["last_activity_time"] = time.time()
         layer3_processed = 0
         while True:
+            if not _worker_running:
+                break
             processed, resolved = process_layer_1_api(config)  # Existing API lookup
             if processed == 0:
                 break
@@ -405,6 +411,8 @@ def process_all_queue(
     layer4_fixed = 0
 
     while True:
+        if not _worker_running:
+            break
         config = load_config()
 
         allowed, calls_made, max_calls = check_rate_limit(config)

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -10,9 +10,12 @@
  */
 function escapeHtml(text) {
     if (text === null || text === undefined) return '';
-    var div = document.createElement('div');
-    div.textContent = String(text);
-    return div.innerHTML;
+    return String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
 }
 
 /**

--- a/templates/history.html
+++ b/templates/history.html
@@ -480,6 +480,9 @@ function saveEdit() {
 function unlockBook(bookId) {
     if (!confirm('Unlock this book?\n\nThis will allow the system to re-process it on future scans. Your current settings will remain until the system finds a different match.')) return;
 
+    const btn = event.currentTarget;
+    btn.disabled = true;
+
     fetch(`/api/unlock_book/${bookId}`, {method: 'POST'})
         .then(r => r.json())
         .then(data => {
@@ -490,7 +493,8 @@ function unlockBook(bookId) {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 // escapeHtml provided by common.js
@@ -498,6 +502,9 @@ function unlockBook(bookId) {
 // ===== EXISTING FUNCTIONS =====
 function applyFix(historyId) {
     if (!confirm('Apply this fix? The folder will be renamed.')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch(`/api/apply_fix/${historyId}`, {method: 'POST'})
         .then(r => r.json())
@@ -508,11 +515,15 @@ function applyFix(historyId) {
             } else {
                 alert('Error: ' + data.message);
             }
-        });
+        })
+        .finally(() => { btn.disabled = false; });
 }
 
 function undoFix(historyId) {
     if (!confirm('Undo this fix? The folder will be renamed back to its original name.')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch(`/api/undo/${historyId}`, {method: 'POST'})
         .then(r => r.json())
@@ -524,11 +535,15 @@ function undoFix(historyId) {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function rejectFix(historyId) {
     if (!confirm('Reject this fix? It will be deleted and the book will be marked as OK.')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch(`/api/reject_fix/${historyId}`, {method: 'POST'})
         .then(r => r.json())
@@ -540,11 +555,15 @@ function rejectFix(historyId) {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function dismissError(historyId) {
     if (!confirm('Dismiss this error entry? It will be removed from history.')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch(`/api/dismiss_error/${historyId}`, {method: 'POST'})
         .then(r => r.json())
@@ -555,11 +574,15 @@ function dismissError(historyId) {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function removeDuplicate(historyId) {
     if (!confirm('Remove this duplicate?\n\nThis will DELETE the misnamed copy and keep the properly-named version.\n\nThis cannot be undone!')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch(`/api/remove_duplicate/${historyId}`, {method: 'POST'})
         .then(r => r.json())
@@ -571,11 +594,15 @@ function removeDuplicate(historyId) {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function removeAllDuplicates() {
     if (!confirm('Remove ALL confirmed duplicates?\n\nThis will DELETE all misnamed copies and keep the properly-named versions.\n\nThis cannot be undone!')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch('/api/remove_all_duplicates', {method: 'POST'})
         .then(r => r.json())
@@ -594,11 +621,15 @@ function removeAllDuplicates() {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function replaceCorrupt(historyId) {
     if (!confirm('Replace corrupt destination with valid source?\n\nThis will:\n1. Delete the corrupt destination folder\n2. Move the valid source to the correct location\n\nThis cannot be undone!')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch(`/api/replace_corrupt/${historyId}`, {method: 'POST'})
         .then(r => r.json())
@@ -610,11 +641,15 @@ function replaceCorrupt(historyId) {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function clearAllErrors() {
     if (!confirm('Clear all error entries from history?\n\nThis will remove all error records. The actual files are not affected.')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch('/api/clear_all_errors', {method: 'POST'})
         .then(r => r.json())
@@ -626,11 +661,15 @@ function clearAllErrors() {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function applyAllPending() {
     if (!confirm('Apply ALL pending fixes?\n\nThis will rename all folders according to the AI suggestions.\nMake sure you have reviewed them first!')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch('/api/apply_all_pending', {method: 'POST'})
         .then(r => r.json())
@@ -642,11 +681,15 @@ function applyAllPending() {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 
 function rejectAllPending() {
     if (!confirm('Reject ALL pending fixes?\n\nThis will mark all pending items as OK without making any changes.')) return;
+
+    const btn = event.currentTarget;
+    btn.disabled = true;
 
     fetch('/api/reject_all_pending', {method: 'POST'})
         .then(r => r.json())
@@ -658,7 +701,8 @@ function rejectAllPending() {
                 alert('Error: ' + (data.error || 'Unknown error'));
             }
         })
-        .catch(e => alert('Error: ' + e));
+        .catch(e => alert('Error: ' + e))
+        .finally(() => { btn.disabled = false; });
 }
 </script>
 {% endblock %}

--- a/templates/queue.html
+++ b/templates/queue.html
@@ -1219,7 +1219,7 @@ async function saveAllMultiEdits() {
     let saved = 0;
     for (const item of modified) {
         try {
-            const resp = await fetch('/api/queue/manual_match', {
+            const resp = await fetch('/api/manual_match', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -953,23 +953,7 @@
                                 <li><strong>Hardcover</strong> - Indie/modern books</li>
                                 <li><strong>AI Fallback</strong> - When APIs fail</li>
                             </ol>
-                            <div class="mb-0">
-                                <label class="form-label small">Google Books API Key <span class="text-muted">(optional)</span></label>
-                                <div class="input-group input-group-sm">
-                                    <input type="password" class="form-control bg-dark text-light" name="google_books_api_key" id="google_books_api_key"
-                                           value="{{ config.google_books_api_key or '' }}" placeholder="For higher rate limits"
-                                           data-has-key="{{ 'true' if config.google_books_api_key else 'false' }}">
-                                    <button class="btn btn-outline-secondary" type="button" onclick="togglePasswordVisibility('google_books_api_key')" title="Show/hide key">
-                                        <i class="bi bi-eye"></i>
-                                    </button>
-                                    {% if config.google_books_api_key %}
-                                    <span class="input-group-text bg-success text-white" id="google-books-key-check"><i class="bi bi-check"></i></span>
-                                    <button class="btn btn-outline-danger" type="button" onclick="clearApiKey('google_books_api_key')" title="Remove key">
-                                        <i class="bi bi-trash"></i>
-                                    </button>
-                                    {% endif %}
-                                </div>
-                            </div>
+                            <p class="text-muted small mb-0">Google Books API key can be configured in the AI Setup tab above.</p>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary

Security and stability release — 18 issues fixed across 11 PRs from a deep codebase audit.

### Security
- **SSRF prevention** on custom plugin endpoints (#236)
- **XSS fix** — escapeHtml now covers all 5 HTML entities including single quotes (#237)
- **Library boundary enforcement** on undo/replace/remove file operations (#219)

### File Safety
- **Atomic status guard** on apply_fix prevents race condition double-renames (#220)
- **Undo creates parent dirs** before moving files back (#225)
- **Path sanitize fix** — no longer false-positives on ".." substrings like "Mc..Donald" (#226)
- **L1 preserves original metadata** on validation failure instead of corrupting it (#227)

### API Stability
- **Rate limits + circuit breakers** added to BookDB contribute, community consensus, Gemini language detect, OpenRouter identify (#222, #223)
- **Audnexus** no longer records success before checking status code (#223)
- **Process endpoint re-entrancy guard** prevents overlapping background runs (#224)
- **Worker stop checks** in all 4 legacy batch loops (#221)

### Pipeline
- **Books no longer get stuck** — L3 trust_sl no longer deletes queue entry before L4, AI verify creates history on null drastic check (#228, #229)
- **Custom source weights** now actually used in confidence calculations instead of being ignored (#230)
- **Confidence scale normalization** — handles both 0-1 and 0-100 scales (#235)

### UI
- **Fixed broken route** in queue multi-edit modal (#231)
- **Settings save** now persists sl_trust_mode and enable_isbn_lookup (#232)
- **Removed duplicate** google_books_api_key field in settings (#232)
- **Double-click prevention** on all 11 history page action buttons (#233)
- **Famous numeric titles** (1984, 2001, etc.) no longer flagged as garbage (#234)

### Files Changed
18 files, +483 / -55 lines

### Test Plan
- [x] E2E browser testing on local instance (port 5758)
- [x] Dashboard loads with correct version (0.9.0-beta.152)
- [x] History page double-click prevention verified
- [x] Queue page manual_match route fixed
- [x] Settings sl_trust_mode/enable_isbn_lookup persist, no duplicate fields
- [x] escapeHtml escapes all 5 entities (verified with O'Brien test)
- [x] SSRF blocks 169.254.x, 127.0.0.1, 10.x with clear errors
- [x] Process endpoint responds correctly
- [x] Undo endpoint handles invalid IDs gracefully
- [x] Code checks pass (ruff, test-naming-issues.py)