### PR TITLE
feat: Use sl_source to differentiate BookDB trust weighting (#254)

### DIFF
--- a/library_manager/models/book_profile.py
+++ b/library_manager/models/book_profile.py
@@ -18,7 +18,10 @@ SOURCE_WEIGHTS = {
     'id3': 80,          # Embedded by producer/publisher
     'json': 75,         # Explicit metadata file
     'nfo': 70,          # Release info files
-    'bookdb': 65,       # Verified database match
+    'bookdb': 65,        # Verified database match
+    'bookdb_audio': 65,  # BookDB database match (same as bookdb)
+    'bookdb_transcript': 55,  # BookDB Whisper transcript only (unverified)
+    'bookdb_scrape': 45,     # BookDB live web scrape (unreliable)
     'ai': 60,           # AI verification
     'audnexus': 55,     # Audible data
     'googlebooks': 50,  # Google Books API

--- a/library_manager/pipeline/layer_audio_id.py
+++ b/library_manager/pipeline/layer_audio_id.py
@@ -714,18 +714,20 @@ def process_layer_1_audio(
                 c = conn.cursor()
 
                 # Update book with audio-identified info
-                sl_source = result.get('sl_source', 'audio_transcription')
+                # Use the mapped source name (bookdb_audio/bookdb_transcript/bookdb_scrape)
+                # for proper trust weighting in BookProfile, falling back to sl_source
+                profile_source = result.get('source', result.get('sl_source', 'audio_transcription'))
                 base_confidence = 85 if confidence == 'high' else 70
                 profile = {
-                    'author': {'value': author, 'source': sl_source, 'confidence': base_confidence},
-                    'title': {'value': title, 'source': sl_source, 'confidence': base_confidence},
+                    'author': {'value': author, 'source': profile_source, 'confidence': base_confidence},
+                    'title': {'value': title, 'source': profile_source, 'confidence': base_confidence},
                 }
                 if narrator:
-                    profile['narrator'] = {'value': narrator, 'source': sl_source, 'confidence': 80}
+                    profile['narrator'] = {'value': narrator, 'source': profile_source, 'confidence': 80}
                 if series:
-                    profile['series'] = {'value': series, 'source': sl_source, 'confidence': 75}
+                    profile['series'] = {'value': series, 'source': profile_source, 'confidence': 75}
                 if series_num:
-                    profile['series_num'] = {'value': str(series_num), 'source': sl_source, 'confidence': 75}
+                    profile['series_num'] = {'value': str(series_num), 'source': profile_source, 'confidence': 75}
 
                 # Issue #227: Save original author/title BEFORE updating the DB.
                 # If validation fails later, we must revert these to prevent

--- a/library_manager/providers/bookdb.py
+++ b/library_manager/providers/bookdb.py
@@ -448,14 +448,23 @@ def identify_audio_with_bookdb(audio_file, extract_seconds=90, bookdb_url=None):
             sl_source = data.get('source', 'audio')  # 'database', 'audio', or 'live_scrape'
             requeue_suggested = data.get('requeue_suggested', False)
 
+            # Map sl_source to differentiated source names for trust weighting
+            # database = verified DB match (highest), audio = Whisper only, live_scrape = web scraping
+            source_map = {
+                'database': 'bookdb_audio',
+                'audio': 'bookdb_transcript',
+                'live_scrape': 'bookdb_scrape',
+            }
+            mapped_source = source_map.get(sl_source, 'bookdb_audio')
+
             result = {
                 'author': data.get('author') or (best_match.get('author_name') if best_match else None),
                 'title': data.get('title') or (best_match.get('title') if best_match else None),
                 'narrator': data.get('narrator'),
                 'series': best_match.get('series_name') if best_match else None,
                 'series_num': best_match.get('series_position') if best_match else None,
-                'source': 'bookdb_audio',
-                'sl_source': sl_source,  # Where SL got the data: 'database' or 'audio'
+                'source': mapped_source,
+                'sl_source': sl_source,  # Where SL got the data: 'database', 'audio', or 'live_scrape'
                 'requeue_suggested': requeue_suggested,  # True if LM should retry later
                 'confidence': 'high' if best_match or sl_source == 'database' else 'medium',
                 'transcript': transcript[:500],
@@ -468,7 +477,7 @@ def identify_audio_with_bookdb(audio_file, extract_seconds=90, bookdb_url=None):
 
             if transcript:
                 logger.info(f"[SKALDLEITA] No match but got transcript ({len(transcript)} chars) - returning for AI fallback")
-                return {'transcript': transcript, 'source': 'bookdb_audio'}
+                return {'transcript': transcript, 'source': mapped_source}
 
             logger.warning(f"[SKALDLEITA] No identification and no transcript returned")
             return None


### PR DESCRIPTION
## Summary
- Map BookDB's `sl_source` field to differentiated source names: `bookdb_audio` (database match), `bookdb_transcript` (Whisper only), `bookdb_scrape` (web scraping)
- Add new SOURCE_WEIGHTS: `bookdb_transcript: 55`, `bookdb_scrape: 45`
- Pass differentiated source through pipeline so confidence calculations reflect actual match quality

Closes #254

## Test plan
- [x] 290/290 pattern tests pass
- [x] ruff F821 clean
- [ ] E2E: verify BookProfile confidence varies by sl_source