### PR TITLE
fix: Attach API key to remaining keyless Skaldleita call sites (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.154] - 2026-07-14
+
+### Fixed
+- **#264: Auth headers on all Skaldleita API calls** — Added signed headers + API key to 4 call sites that previously sent keyless requests to the Skaldleita API: `api_book_detail`, `api_author_detail`, `api_series_detail`, and `identify_ebook_from_filename`. These endpoints now require authentication after the gate was changed to key-or-401.
+
 ## [0.9.0-beta.153] - 2026-06-12
 
 ### Security

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.153"
+APP_VERSION = "0.9.0-beta.154"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:
@@ -2295,9 +2295,14 @@ def identify_ebook_from_filename(filename, folder_path, config):
         search_query = f"{author} {title}" if author else title
         logger.debug(f"[EBOOK] Searching BookDB for: {search_query}")
 
+        api_key = config.get('bookdb_api_key') or BOOKDB_PUBLIC_KEY
+        headers = get_signed_headers() or {}
+        headers['X-API-Key'] = api_key
+
         resp = requests.get(
             f"{BOOKDB_API_URL}/search",
             params={'q': search_query[:100]},  # Limit query length
+            headers=headers,
             timeout=10
         )
 
@@ -11902,11 +11907,14 @@ def api_book_detail(book_id):
     """
     Get full book details from BookBucket + ABS status.
     Used for hover cards and detail modals.
-    Uses public endpoint - no API key required.
     """
     try:
         # Fetch full book details from BookBucket
-        resp = requests.get(f"{BOOKDB_API_URL}/book/{book_id}", timeout=10)
+        secrets = load_secrets()
+        api_key = secrets.get('bookdb_api_key') or BOOKDB_PUBLIC_KEY
+        headers = get_signed_headers() or {}
+        headers['X-API-Key'] = api_key
+        resp = requests.get(f"{BOOKDB_API_URL}/book/{book_id}", headers=headers, timeout=10)
 
         if resp.status_code != 200:
             return jsonify({'error': f'Book not found (status {resp.status_code})'})
@@ -11977,10 +11985,13 @@ def api_author_detail(author_id):
     """
     Get author details from BookBucket.
     Used for hover cards on author search results.
-    Uses public endpoint - no API key required.
     """
     try:
-        resp = requests.get(f"{BOOKDB_API_URL}/author/{author_id}", timeout=10)
+        secrets = load_secrets()
+        api_key = secrets.get('bookdb_api_key') or BOOKDB_PUBLIC_KEY
+        headers = get_signed_headers() or {}
+        headers['X-API-Key'] = api_key
+        resp = requests.get(f"{BOOKDB_API_URL}/author/{author_id}", headers=headers, timeout=10)
 
         if resp.status_code != 200:
             return jsonify({'error': f'Author not found (status {resp.status_code})'})
@@ -12000,10 +12011,13 @@ def api_series_detail(series_id):
     """
     Get series details from BookBucket.
     Used for hover cards on series search results.
-    Uses public endpoint - no API key required.
     """
     try:
-        resp = requests.get(f"{BOOKDB_API_URL}/series/{series_id}", timeout=10)
+        secrets = load_secrets()
+        api_key = secrets.get('bookdb_api_key') or BOOKDB_PUBLIC_KEY
+        headers = get_signed_headers() or {}
+        headers['X-API-Key'] = api_key
+        resp = requests.get(f"{BOOKDB_API_URL}/series/{series_id}", headers=headers, timeout=10)
 
         if resp.status_code != 200:
             return jsonify({'error': f'Series not found (status {resp.status_code})'})


### PR DESCRIPTION
Closes the remaining half of #264. The auto-inject work shipped in beta.152 covered the main request paths, but four call sites still sent keyless requests and got guaranteed 401s from Skaldleita's key-or-401 gate:

- `api_book_detail` → `GET /book/{id}`
- `api_author_detail` → `GET /author/{id}`
- `api_series_detail` → `GET /series/{id}`
- `identify_ebook_from_filename` → `GET /search`

Each now resolves the API key exactly the way sibling code does (`config.get('bookdb_api_key')` / `load_secrets()` with `BOOKDB_PUBLIC_KEY` fallback) and sends `get_signed_headers()` + `X-API-Key`. No new patterns, no refactoring. APP_VERSION bumped to 0.9.0-beta.154 to match the CHANGELOG entry.

## Verification
- test-env/test-naming-issues.py: **290/290** pass (re-run independently after review)
- test-env/test-precog.py: **10/10** pass
- `ruff --select=F821`: clean (all referenced helpers resolve)
- Diff reviewed line-by-line: additive header changes only; stale 'no API key required' docstring lines removed

Written by OpenCode in an isolated worktree; reviewed and independently verified before submission.