### PR TITLE
docs: release beta.156 documentation sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to Library Manager will be documented in this file.
 ### Changed
 - **License restored to MIT** - Replaced AGPL-3.0 with the project's original MIT license and updated README and contribution terms to match.
 
+### Documentation
+- Synchronized the published version, provider lists, Skaldleita credential guidance, multilingual-provider notes, and configured request-rate defaults with beta.155 behavior.
+
 ## [0.9.0-beta.155] - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to Library Manager will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.0-beta.156] - 2026-07-15
+
 ### Changed
 - **License restored to MIT** - Replaced AGPL-3.0 with the project's original MIT license and updated README and contribution terms to match.
 
 ### Documentation
-- Synchronized the published version, provider lists, Skaldleita credential guidance, multilingual-provider notes, and configured request-rate defaults with beta.155 behavior.
+- Synchronized the published version, provider lists, Skaldleita credential guidance, multilingual-provider notes, and configured request-rate defaults with current behavior.
 
 ## [0.9.0-beta.155] - 2026-07-15
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.153-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.155-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.155-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.156-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE)
 
@@ -15,6 +15,10 @@
 ---
 
 ## Recent Changes (stable)
+
+> **beta.156** - **MIT License and Documentation Sync**
+> - Restored the project's MIT license and aligned contribution terms.
+> - Synchronized provider, Skaldleita credential, multilingual model, and request-rate guidance with current behavior.
 
 > **beta.155** - **Local AI Is Provider-Agnostic**
 > - Added llama.cpp and generic OpenAI-compatible API support with live `/v1/models` discovery.

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama, OpenAI-compatible APIs)
 """
 
-APP_VERSION = "0.9.0-beta.155"
+APP_VERSION = "0.9.0-beta.156"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -100,7 +100,7 @@ When "Backup Tags" is enabled, original tags are saved to `.library-manager.tags
 | OpenRouter | Varies by model |
 | Ollama / local compatible API | Self-hosted |
 
-The app defaults to 2000 calls/hour to stay well under limits.
+Library Manager defaults to 200 requests/hour and allows a configured range of 10-500 requests/hour. Provider-specific backoff and circuit breakers apply when a service returns rate-limit responses.
 
 ## Config Files
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -33,10 +33,7 @@ Just renames folders. Files inside stay exactly where they are - only the folder
 
 ### What APIs does it use?
 
-1. Audnexus (Audible data)
-2. OpenLibrary (Internet Archive)
-3. Google Books
-4. Hardcover
+Metadata can come from Skaldleita, Audnexus, OpenLibrary, Google Books, and Hardcover. Optional AI verification uses the configured Gemini, OpenRouter, Ollama, or OpenAI-compatible provider.
 
 ### Why Gemini over GPT-4?
 

--- a/docs/FEATURE-language-preference.md
+++ b/docs/FEATURE-language-preference.md
@@ -151,6 +151,7 @@ def get_localized_metadata(book_info, target_language):
 - Gemini: Excellent multilingual (100+ languages)
 - GPT-4/OpenRouter: Strong multilingual support
 - Ollama (local): Depends on model, Llama 3 has decent multilingual
+- llama.cpp/OpenAI-compatible: Depends on the model loaded by the user's server
 
 ### Audio Language Detection
 
@@ -200,7 +201,7 @@ Use cases:
 - Audio detection uses existing Gemini integration (no new dependencies)
 - Language codes follow ISO 639-1 standard
 - Default behavior unchanged for existing users (`en`, preserve=true)
-- **AI Translation Strategy**: All AI providers (Gemini, OpenRouter, Ollama) support multilingual prompts
+- **AI Translation Strategy**: All configured AI paths (Gemini, OpenRouter, Ollama, and OpenAI-compatible servers) accept multilingual prompts; result quality depends on the selected model
   - Add language instruction to existing prompts: "Respond in {language}"
   - Titles returned should match user's preferred language when official translations exist
   - AI handles translation automatically - no external translation API needed

--- a/library_manager/config.py
+++ b/library_manager/config.py
@@ -157,7 +157,7 @@ DEFAULT_SECRETS = {
     "openrouter_api_key": "",
     "gemini_api_key": "",
     "openai_compatible_api_key": "",
-    "bookdb_api_key": "",  # Optional API key for Skaldleita (not required for public endpoints)
+    "bookdb_api_key": "",  # Optional personal key; the bundled shared key is used when empty
     "abs_api_token": "",
     "webhook_secret": ""   # Shared secret for webhook authentication (referenced as {{webhook_secret}} in hook headers)
 }

--- a/library_manager/hints.py
+++ b/library_manager/hints.py
@@ -6,7 +6,7 @@ Provides contextual help text for UI tooltips and hover explanations.
 HINTS = {
     # === Identification Layers ===
     'layer_1': 'Database Lookups: Searches Skaldleita, Audnexus, OpenLibrary, Google Books, and Hardcover for metadata matches. Free, fast, no API key needed.',
-    'layer_2': 'AI Verification: When databases return uncertain matches, AI (Gemini, OpenRouter, or Ollama) cross-checks the results. Uses your configured AI provider.',
+    'layer_2': 'AI Verification: When databases return uncertain matches, your configured provider (Gemini, OpenRouter, Ollama, or an OpenAI-compatible server) cross-checks the results.',
     'layer_3': 'Audio Analysis: Extracts the first 90 seconds of audio to identify the book from narrator intros and title announcements. Can use Skaldleita GPU or your own Gemini API.',
     'layer_4': 'Content Analysis: Last resort. Transcribes story text with Whisper and sends it to AI to identify the book. Slowest but catches edge cases other layers miss.',
 
@@ -15,6 +15,7 @@ HINTS = {
     'gemini': 'Google Gemini AI. Free tier offers 14,400 calls/day with Gemma 3 models. Handles both text verification and native audio analysis.',
     'openrouter': 'API gateway to multiple AI models. Free models available (Llama, Gemma). Used as fallback when Gemini is unavailable or for Layer 4 content analysis.',
     'ollama': 'Self-hosted AI. Run models locally with no API costs or rate limits. Requires separate Ollama installation.',
+    'openai_compatible': 'User-configured local or remote AI server with OpenAI-compatible model and chat-completions endpoints, including llama.cpp, LM Studio, vLLM, and LocalAI.',
 
     # === Confidence & Verification ===
     'confidence_threshold': 'Minimum confidence percentage before a book is considered identified. Higher values mean more certainty but slower processing. Lower values accept weaker matches faster.',
@@ -59,7 +60,7 @@ HINTS = {
     'openai_compatible_api_key': 'Optional bearer token for a user-configured OpenAI-compatible AI server.',
     'openai_compatible_url': 'API base URL for llama.cpp, LM Studio, vLLM, LocalAI, or another OpenAI-compatible server.',
     'openai_compatible_model': 'Model ID loaded from the configured server. Manual model IDs are also accepted.',
-    'bookdb_api_key': 'Optional Skaldleita API key. Increases your rate limit from 500 to 1000 requests per hour. Free to register.',
+    'bookdb_api_key': 'Optional personal Skaldleita API key. When empty, Library Manager uses its bundled shared credential for authenticated metadata and audio requests.',
     'google_books_api_key': 'Optional Google Books API key for higher rate limits on book lookups.',
     'ai_provider': 'Which AI to try first for text verification. Falls back to other configured providers automatically if the primary fails.',
     'provider_chain': 'Order in which providers are tried. If the first one fails or is unavailable, the next one is used automatically.',


### PR DESCRIPTION
## Summary

- release the documentation and MIT-license synchronization as beta.156
- update the README version badge and recent changes
- include llama.cpp and OpenAI-compatible servers throughout provider guidance
- correct Skaldleita credential and request-rate documentation
- record the documentation synchronization in the changelog

## Why

The beta.155 provider implementation was merged, but several current documentation and help-text locations still described beta.153, omitted the generic provider, or listed retired rate limits. Repository CI requires a version bump because configuration/help Python modules changed.

## Validation

- `test-env/test-naming-issues.py` (290 passed)
- `test-env/test-ai-providers.py` (11 passed)
- `test-env/test-ai-provider-integration.py` (4 passed)
- `python -m compileall -q app.py library_manager`
- `git diff --check`
- added-line scans for credential-shaped values and AI attribution
- GitHub lint, test, version-check, and container-build jobs passed
