### PR TITLE
Add a read-only Music identity inspection API

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,6 +39,7 @@ from datetime import datetime, timedelta
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
 from flask import Flask, render_template, request, jsonify, redirect, url_for, send_file, session
+from library_manager.music.api import music_api_bp
 from flask_babel import Babel, gettext as _, lazy_gettext as _l
 from audio_tagging import embed_tags_for_path, build_metadata_for_embedding
 
@@ -565,6 +566,7 @@ app = Flask(__name__)
 app.secret_key = 'library-manager-secret-key-2024'
 app.register_blueprint(hooks_bp)
 app.register_blueprint(plugins_bp)
+app.register_blueprint(music_api_bp)
 
 # ============== INTERNATIONALIZATION (i18n) ==============
 # Flask-Babel for UI translations - book metadata (author/title) is NOT translated

--- a/docs/music-inspection-api.md
+++ b/docs/music-inspection-api.md
@@ -1,0 +1,39 @@
+# Music inspection API
+
+`POST /api/v1/music/inspect` is a read-only identity and filesystem evidence
+surface. It never searches a provider, changes tags, renames a file, or organizes a
+library. Callers supply stable MusicBrainz and Lidarr foreign identifiers; titles
+alone are not identity.
+
+The configured `music_library_roots` entries have an opaque `id` and an absolute
+local `path`. Requests name the opaque root and a normalized relative album path.
+The scanner rejects traversal, symlinks, mount/device changes, file replacement,
+unsupported schemas, and scans over 500 supported audio files. Responses expose
+root-relative paths and opaque subjects, never the configured host root.
+
+The result state is `complete` only when every supported file has readable tags,
+stable artist/album-or-release-group/recording identity, consistent album identity,
+truthful duration/codec/sample-rate/channel evidence, and matches supplied identity.
+Unknown codecs are not inferred from extensions; missing or conflicting evidence is `partial`.
+Invalid requests and inaccessible or unsafe filesystem state are `unavailable`.
+These states are observations only and grant no authority to move or edit files.
+
+Request schema:
+
+```json
+{
+  "schema": "music.inspection.request.v1",
+  "root_id": "music-primary",
+  "relative_path": "Artist/Album",
+  "identity": {
+    "musicbrainz_artist_id": "...",
+    "musicbrainz_album_id": "...",
+    "musicbrainz_release_group_id": "...",
+    "lidarr_foreign_artist_id": "...",
+    "lidarr_foreign_album_id": "..."
+  }
+}
+```
+
+All five identity keys are required by the schema; unknown values are represented
+by an empty string. At least one stable identifier must be present.

--- a/library_manager/config.py
+++ b/library_manager/config.py
@@ -61,6 +61,7 @@ SECRETS_PATH = DATA_DIR / 'secrets.json'
 
 DEFAULT_CONFIG = {
     "library_paths": [],  # Empty by default - user configures via Settings
+    "music_library_roots": [],  # [{"id": opaque stable name, "path": configured root}]
     "ai_provider": "gemini",  # "gemini", "openrouter", or "ollama"
     "openrouter_model": "",  # Populated from OpenRouter's live model list in Settings
     "gemini_model": "",  # Populated from Gemini's live model list in Settings

--- a/library_manager/models/music_profile.py
+++ b/library_manager/models/music_profile.py
@@ -1,0 +1,47 @@
+"""Read-only, stable identity records for music library inspection."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class TrackIdentity:
+    subject: str
+    relative_path: str
+    artist: str = ""
+    title: str = ""
+    album: str = ""
+    album_artist: str = ""
+    disc: Optional[int] = None
+    track: Optional[int] = None
+    musicbrainz_artist_id: str = ""
+    musicbrainz_album_id: str = ""
+    musicbrainz_release_group_id: str = ""
+    musicbrainz_recording_id: str = ""
+    duration_seconds: Optional[float] = None
+    codec: str = ""
+    sample_rate: Optional[int] = None
+    channels: Optional[int] = None
+    errors: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class MusicProfile:
+    root_id: str
+    subject: str
+    state: str
+    artist: str = ""
+    album: str = ""
+    musicbrainz_artist_id: str = ""
+    musicbrainz_album_id: str = ""
+    musicbrainz_release_group_id: str = ""
+    lidarr_foreign_artist_id: str = ""
+    lidarr_foreign_album_id: str = ""
+    tracks: tuple[TrackIdentity, ...] = ()
+    errors: tuple[str, ...] = ()
+    evidence_digest: str = ""
+    schema: str = "music.inspection.v1"
+
+    def as_dict(self) -> dict:
+        return asdict(self)

--- a/library_manager/music/__init__.py
+++ b/library_manager/music/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only music identity inspection."""

--- a/library_manager/music/api.py
+++ b/library_manager/music/api.py
@@ -1,0 +1,20 @@
+"""Versioned read-only HTTP surface for music inspection."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from library_manager.config import load_config
+from library_manager.music.inspect import inspect_payload
+
+music_api_bp = Blueprint("music_api", __name__)
+
+
+@music_api_bp.post("/api/v1/music/inspect")
+def inspect_music():
+    if not request.is_json:
+        return jsonify({"schema": "music.inspection.error.v1", "state": "unavailable",
+                        "error": "json_required"}), 415
+    config = load_config()
+    roots = config.get("music_library_roots", [])
+    payload, status = inspect_payload(request.get_json(silent=True), roots)
+    return jsonify(payload), status

--- a/library_manager/music/inspect.py
+++ b/library_manager/music/inspect.py
@@ -1,0 +1,352 @@
+"""Bounded, read-only inspection of configured music roots."""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import stat
+from pathlib import Path, PurePosixPath
+from typing import Callable, Optional
+
+from library_manager.models.music_profile import MusicProfile, TrackIdentity
+
+AUDIO_EXTENSIONS = frozenset({".flac", ".mp3", ".m4a", ".ogg", ".opus", ".wav"})
+MAX_FILES = 500
+MAX_RELATIVE_BYTES = 1024
+_ROOT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_UUID = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")
+
+
+class InspectionUnavailable(Exception):
+    pass
+
+
+def _one(tags: dict, *names: str) -> str:
+    for name in names:
+        value = tags.get(name)
+        if isinstance(value, (list, tuple)):
+            value = value[0] if value else ""
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _number(value: str) -> Optional[int]:
+    try:
+        number = int(str(value).split("/", 1)[0])
+        return number if number > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _default_tags(fileobj, _relative: str) -> tuple[dict, dict]:
+    from mutagen import File
+    media = File(fileobj, easy=True)
+    if media is None:
+        raise ValueError("unreadable_tags")
+    tags = dict(media.tags or {})
+    fileobj.seek(0)
+    raw = File(fileobj, easy=False)
+    raw_tags = dict(getattr(raw, "tags", {}) or {})
+    for key, value in raw_tags.items():
+        name = str(key).lower()
+        if "musicbrainz" in name:
+            tags.setdefault(name, value)
+    info = getattr(media, "info", None)
+    technical = {
+        "duration_seconds": getattr(info, "length", None),
+        "codec": _codec(info),
+        "sample_rate": getattr(info, "sample_rate", None),
+        "channels": getattr(info, "channels", None),
+    }
+    return tags, technical
+
+
+def _codec(info: object) -> str:
+    if info is None:
+        return ""
+    explicit = getattr(info, "codec", "")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip().lower()
+    return {
+        "mpeginfo": "mp3", "streaminfo": "flac", "oggvorbisinfo": "vorbis",
+        "oggopusinfo": "opus", "wavestreaminfo": "pcm",
+    }.get(type(info).__name__.lower(), "")
+
+
+def _safe_relative(value: object) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise InspectionUnavailable("relative_path_invalid")
+    if len(value.encode("utf-8")) > MAX_RELATIVE_BYTES:
+        raise InspectionUnavailable("relative_path_too_long")
+    pure = PurePosixPath(value.replace("\\", "/"))
+    if pure.is_absolute() or any(part in ("", ".", "..") for part in pure.parts):
+        raise InspectionUnavailable("relative_path_invalid")
+    return pure.as_posix()
+
+
+def _root(configured_roots: list[dict], root_id: object) -> tuple[str, int, os.stat_result]:
+    if not isinstance(root_id, str) or not _ROOT_ID.fullmatch(root_id):
+        raise InspectionUnavailable("root_id_invalid")
+    if not isinstance(configured_roots, list):
+        raise InspectionUnavailable("root_config_invalid")
+    matches = [r for r in configured_roots if isinstance(r, dict) and r.get("id") == root_id]
+    if len(matches) != 1 or set(matches[0]) != {"id", "path"}:
+        raise InspectionUnavailable("root_unavailable")
+    if not isinstance(matches[0]["path"], (str, os.PathLike)):
+        raise InspectionUnavailable("root_config_invalid")
+    path = os.path.abspath(os.fspath(matches[0]["path"]))
+    root_fd = None
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        root_fd = os.open(path, flags)
+        before = os.fstat(root_fd)
+    except (OSError, TypeError, ValueError) as exc:
+        if root_fd is not None:
+            os.close(root_fd)
+        raise InspectionUnavailable("root_unavailable") from exc
+    if not stat.S_ISDIR(before.st_mode):
+        os.close(root_fd)
+        raise InspectionUnavailable("root_unsafe")
+    return path, root_fd, before
+
+
+def _open_target(root_fd: int, relative: str, device: int) -> int:
+    current = os.dup(root_fd)
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        for component in PurePosixPath(relative).parts:
+            next_fd = os.open(component, flags, dir_fd=current)
+            os.close(current)
+            current = next_fd
+            current_stat = os.fstat(current)
+            if not stat.S_ISDIR(current_stat.st_mode) or current_stat.st_dev != device:
+                raise InspectionUnavailable("target_device_mismatch")
+        return current
+    except InspectionUnavailable:
+        os.close(current)
+        raise
+    except OSError as exc:
+        os.close(current)
+        raise InspectionUnavailable("target_unsafe") from exc
+
+
+def _technical(values: object) -> tuple[dict, bool]:
+    if not isinstance(values, dict) or set(values) != {
+            "duration_seconds", "codec", "sample_rate", "channels"}:
+        return {"duration_seconds": None, "codec": "", "sample_rate": None,
+                "channels": None}, False
+    duration, codec = values["duration_seconds"], values["codec"]
+    sample_rate, channels = values["sample_rate"], values["channels"]
+    valid = (isinstance(duration, (int, float)) and not isinstance(duration, bool)
+             and math.isfinite(duration) and duration > 0
+             and isinstance(codec, str) and 0 < len(codec) <= 32
+             and isinstance(sample_rate, int) and not isinstance(sample_rate, bool)
+             and 1000 <= sample_rate <= 768000
+             and isinstance(channels, int) and not isinstance(channels, bool)
+             and 1 <= channels <= 64)
+    return values if valid else {"duration_seconds": None, "codec": "",
+                                  "sample_rate": None, "channels": None}, valid
+
+
+def _track(root_id: str, relative: str, tags: object, technical: dict,
+           track_errors: list[str]) -> TrackIdentity:
+    if not isinstance(tags, dict):
+        tags = {}
+        track_errors.append("tags_unavailable")
+    mb_artist = _one(tags, "musicbrainz_artistid", "musicbrainz artist id",
+                     "----:com.apple.itunes:musicbrainz artist id")
+    mb_album = _one(tags, "musicbrainz_albumid", "musicbrainz album id",
+                    "----:com.apple.itunes:musicbrainz album id")
+    mb_group = _one(tags, "musicbrainz_releasegroupid", "musicbrainz release group id",
+                    "----:com.apple.itunes:musicbrainz release group id")
+    mb_recording = _one(tags, "musicbrainz_trackid", "musicbrainz recording id",
+                        "----:com.apple.itunes:musicbrainz track id")
+    ids = (mb_artist, mb_album, mb_group, mb_recording)
+    if (not mb_artist or not (mb_album or mb_group) or not mb_recording
+            or any(value and not _UUID.fullmatch(value) for value in ids)):
+        track_errors.append("stable_identity_missing")
+    return TrackIdentity(
+        subject=_subject(root_id, relative), relative_path=relative,
+        artist=_one(tags, "artist"), title=_one(tags, "title"), album=_one(tags, "album"),
+        album_artist=_one(tags, "albumartist", "album artist"),
+        disc=_number(_one(tags, "discnumber")), track=_number(_one(tags, "tracknumber")),
+        musicbrainz_artist_id=mb_artist, musicbrainz_album_id=mb_album,
+        musicbrainz_release_group_id=mb_group, musicbrainz_recording_id=mb_recording,
+        duration_seconds=technical["duration_seconds"], codec=technical["codec"],
+        sample_rate=technical["sample_rate"], channels=technical["channels"],
+        errors=tuple(sorted(set(track_errors))))
+
+
+def _subject(root_id: str, relative: str) -> str:
+    return hashlib.sha256(f"{root_id}\0{relative}".encode()).hexdigest()
+
+
+def _stable(value: str) -> str:
+    return value.strip().lower()
+
+
+def inspect_album(request: dict, configured_roots: list[dict], *,
+                  tag_reader: Callable[[object, str], tuple[dict, dict]] = _default_tags,
+                  before_finish: Optional[Callable[[], None]] = None,
+                  max_files: int = MAX_FILES) -> MusicProfile:
+    allowed = {"schema", "root_id", "relative_path", "identity"}
+    if not isinstance(request, dict) or set(request) != allowed:
+        raise ValueError("request_schema_invalid")
+    if request.get("schema") != "music.inspection.request.v1":
+        raise ValueError("request_version_unsupported")
+    identity = request.get("identity")
+    identity_keys = {"musicbrainz_artist_id", "musicbrainz_album_id",
+                     "musicbrainz_release_group_id", "lidarr_foreign_artist_id",
+                     "lidarr_foreign_album_id"}
+    if not isinstance(identity, dict) or set(identity) != identity_keys:
+        raise ValueError("identity_schema_invalid")
+    if not any(identity.values()) or any(not isinstance(v, str) or (v and not _UUID.fullmatch(v))
+                                         for v in identity.values()):
+        raise ValueError("identity_invalid")
+    if (identity["lidarr_foreign_artist_id"] and identity["musicbrainz_artist_id"]
+            and _stable(identity["lidarr_foreign_artist_id"]) !=
+            _stable(identity["musicbrainz_artist_id"])):
+        raise ValueError("lidarr_artist_identity_mismatch")
+    if (identity["lidarr_foreign_album_id"] and identity["musicbrainz_release_group_id"]
+            and _stable(identity["lidarr_foreign_album_id"]) !=
+            _stable(identity["musicbrainz_release_group_id"])):
+        raise ValueError("lidarr_album_identity_mismatch")
+    relative = _safe_relative(request.get("relative_path"))
+    root, root_fd, root_before = _root(configured_roots, request.get("root_id"))
+    try:
+        target_fd = _open_target(root_fd, relative, root_before.st_dev)
+        target_stat = os.fstat(target_fd)
+        errors = []
+        tracks = []
+        count = 0
+        try:
+            for current, dirs, files, directory_fd in os.fwalk(
+                    ".", topdown=True, follow_symlinks=False, dir_fd=target_fd):
+                dirs.sort()
+                files.sort()
+                safe_dirs = []
+                for name in dirs:
+                    try:
+                        entry = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+                    except OSError as exc:
+                        raise InspectionUnavailable("filesystem_unavailable") from exc
+                    if stat.S_ISLNK(entry.st_mode) or entry.st_dev != root_before.st_dev:
+                        errors.append("unsafe_entry")
+                    else:
+                        safe_dirs.append(name)
+                dirs[:] = safe_dirs
+                for name in files:
+                    if Path(name).suffix.lower() not in AUDIO_EXTENSIONS:
+                        continue
+                    count += 1
+                    if count > max_files:
+                        raise InspectionUnavailable("scan_limit_exceeded")
+                    file_fd = None
+                    try:
+                        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+                        file_fd = os.open(name, flags, dir_fd=directory_fd)
+                        before = os.fstat(file_fd)
+                    except OSError as exc:
+                        if file_fd is not None:
+                            os.close(file_fd)
+                        raise InspectionUnavailable("filesystem_unavailable") from exc
+                    if not stat.S_ISREG(before.st_mode) or before.st_dev != root_before.st_dev:
+                        os.close(file_fd)
+                        errors.append("unsafe_entry")
+                        continue
+                    rel_dir = "" if current == "." else current[2:].replace(os.sep, "/")
+                    rel = "/".join(part for part in (relative, rel_dir, name) if part)
+                    track_errors = []
+                    try:
+                        with os.fdopen(os.dup(file_fd), "rb") as media_file:
+                            tags, raw_technical = tag_reader(media_file, rel)
+                        after = os.fstat(file_fd)
+                        if ((after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns) !=
+                                (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)):
+                            raise InspectionUnavailable("file_changed_during_scan")
+                    except InspectionUnavailable:
+                        raise
+                    except Exception:
+                        tags, raw_technical = {}, {}
+                        track_errors.append("tags_unavailable")
+                    finally:
+                        os.close(file_fd)
+                    technical, technical_valid = _technical(raw_technical)
+                    if not technical_valid:
+                        track_errors.append("technical_evidence_invalid")
+                    tracks.append(_track(request["root_id"], rel, tags, technical, track_errors))
+        finally:
+            os.close(target_fd)
+        if before_finish:
+            before_finish()
+        root_after = os.fstat(root_fd)
+        check_fd = _open_target(root_fd, relative, root_before.st_dev)
+        try:
+            target_after = os.fstat(check_fd)
+        finally:
+            os.close(check_fd)
+        if ((root_after.st_dev, root_after.st_ino) != (root_before.st_dev, root_before.st_ino)
+                or (target_after.st_dev, target_after.st_ino) !=
+                (target_stat.st_dev, target_stat.st_ino)):
+            raise InspectionUnavailable("root_changed_during_scan")
+    except InspectionUnavailable:
+        raise
+    except (OSError, TypeError, ValueError) as exc:
+        raise InspectionUnavailable("filesystem_unavailable") from exc
+    finally:
+        os.close(root_fd)
+    if not tracks:
+        errors.append("no_supported_audio")
+
+    album_ids = {_stable(t.musicbrainz_album_id) for t in tracks if t.musicbrainz_album_id}
+    group_ids = {_stable(t.musicbrainz_release_group_id) for t in tracks if t.musicbrainz_release_group_id}
+    artist_ids = {_stable(t.musicbrainz_artist_id) for t in tracks if t.musicbrainz_artist_id}
+    albums = {_stable(t.album) for t in tracks if t.album}
+    album_artists = {_stable(t.album_artist) for t in tracks if t.album_artist}
+    if any(len(values) > 1 for values in (album_ids, group_ids, albums, album_artists)):
+        errors.append("album_identity_conflict")
+    requested = {
+        "musicbrainz_artist_id": artist_ids,
+        "musicbrainz_album_id": album_ids,
+        "musicbrainz_release_group_id": group_ids,
+        "lidarr_foreign_artist_id": artist_ids,
+        "lidarr_foreign_album_id": group_ids,
+    }
+    for key, observed in requested.items():
+        if identity[key] and _stable(identity[key]) not in observed:
+            errors.append("requested_identity_mismatch")
+    errors.extend(error for track in tracks for error in track.errors)
+    errors = sorted(set(errors))
+    state = "complete" if tracks and not errors else "partial"
+    evidence = {
+        "root_id": request["root_id"], "relative_path": relative, "identity": identity,
+        "tracks": [track.__dict__ for track in tracks], "errors": errors,
+    }
+    digest = hashlib.sha256(json.dumps(evidence, sort_keys=True, separators=(",", ":"),
+                                       default=str).encode()).hexdigest()
+    first = tracks[0] if tracks else None
+    return MusicProfile(
+        root_id=request["root_id"], subject=_subject(request["root_id"], relative), state=state,
+        artist=(first.album_artist or first.artist) if first else "", album=first.album if first else "",
+        musicbrainz_artist_id=first.musicbrainz_artist_id if first else "",
+        musicbrainz_album_id=first.musicbrainz_album_id if first else "",
+        musicbrainz_release_group_id=first.musicbrainz_release_group_id if first else "",
+        lidarr_foreign_artist_id=identity["lidarr_foreign_artist_id"],
+        lidarr_foreign_album_id=identity["lidarr_foreign_album_id"],
+        tracks=tuple(tracks), errors=tuple(errors), evidence_digest=digest)
+
+
+def inspect_payload(body: object, configured_roots: list[dict], **kwargs) -> tuple[dict, int]:
+    """Framework-neutral API contract, kept testable without starting Flask."""
+    try:
+        profile = inspect_album(body, configured_roots, **kwargs)
+    except ValueError as exc:
+        return {"schema": "music.inspection.error.v1", "state": "unavailable",
+                "error": str(exc)}, 400
+    except InspectionUnavailable as exc:
+        return {"schema": "music.inspection.error.v1", "state": "unavailable",
+                "error": str(exc)}, 503
+    return profile.as_dict(), 200

--- a/test-env/test-music-inspection.py
+++ b/test-env/test-music-inspection.py
@@ -1,0 +1,290 @@
+"""Fixture-only acceptance tests for the read-only Music inspection API."""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from library_manager.music.inspect import InspectionUnavailable, _codec, inspect_album, inspect_payload
+
+fails = []
+ARTIST_A = "11111111-1111-4111-8111-111111111111"
+ARTIST_B = "22222222-2222-4222-8222-222222222222"
+RELEASE_A = "33333333-3333-4333-8333-333333333333"
+GROUP_A = "44444444-4444-4444-8444-444444444444"
+DELUXE = "55555555-5555-4555-8555-555555555555"
+
+
+def check(label, condition, detail=""):
+    if not condition:
+        fails.append(f"{label}: {detail}")
+
+
+def request(root_id="music", relative="Artist/Album", **identity):
+    values = {
+        "musicbrainz_artist_id": ARTIST_A,
+        "musicbrainz_album_id": RELEASE_A,
+        "musicbrainz_release_group_id": GROUP_A,
+        "lidarr_foreign_artist_id": ARTIST_A,
+        "lidarr_foreign_album_id": GROUP_A,
+    }
+    values.update(identity)
+    return {"schema": "music.inspection.request.v1", "root_id": root_id,
+            "relative_path": relative, "identity": values}
+
+
+def reader(_fileobj, relative):
+    stem = Path(relative).stem
+    disc, track = stem.split("-")[:2]
+    tags = {
+        "artist": ["Artist A"], "albumartist": ["Artist A"], "album": ["Album A"],
+        "title": [f"Song {track}"], "discnumber": [disc], "tracknumber": [track],
+        "musicbrainz_artistid": [ARTIST_A], "musicbrainz_albumid": [RELEASE_A],
+        "musicbrainz_releasegroupid": [GROUP_A],
+        "musicbrainz_trackid": [f"66666666-6666-4666-8666-{int(disc):02d}{int(track):02d}66666666"],
+    }
+    return tags, {"duration_seconds": 123.5, "codec": Path(relative).suffix[1:],
+                  "sample_rate": 48000, "channels": 2}
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    root = Path(tmp) / "root"
+    album = root / "Artist" / "Album"
+    album.mkdir(parents=True)
+    formats = ("flac", "mp3", "m4a", "ogg", "opus", "wav")
+    for number, ext in enumerate(formats, 1):
+        (album / f"1-{number}.{ext}").write_bytes(b"fixture")
+    roots = [{"id": "music", "path": str(root)}]
+
+    profile = inspect_album(request(), roots, tag_reader=reader)
+    check("complete stable album", profile.state == "complete", profile.errors)
+    check("all supported formats", [t.codec for t in profile.tracks] == list(formats))
+    check("multidisc fields are typed", profile.tracks[0].disc == 1 and profile.tracks[0].track == 1)
+    check("paths are relative", all(not os.path.isabs(t.relative_path) for t in profile.tracks))
+    check("opaque subjects hide paths", all("Artist" not in t.subject for t in profile.tracks))
+    check("deterministic output", profile == inspect_album(request(), roots, tag_reader=reader))
+    class MP4Info:
+        codec = "alac"
+    class OggOpusInfo:
+        pass
+    class UnknownInfo:
+        pass
+    MPEGInfo = type("MPEGInfo", (), {})
+    StreamInfo = type("StreamInfo", (), {})
+    WaveStreamInfo = type("WaveStreamInfo", (), {})
+    check("codec evidence uses explicit stream codec", _codec(MP4Info()) == "alac")
+    check("codec evidence has conservative known mappings", _codec(OggOpusInfo()) == "opus")
+    check("Mutagen MP3 class maps truthfully", _codec(MPEGInfo()) == "mp3")
+    check("Mutagen FLAC class maps truthfully", _codec(StreamInfo()) == "flac")
+    check("Mutagen WAV class maps truthfully", _codec(WaveStreamInfo()) == "pcm")
+    check("unknown info type never invents codec", _codec(UnknownInfo()) == "")
+
+    try:
+        inspect_album(request(relative="../elsewhere"), roots, tag_reader=reader)
+        check("traversal refuses", False)
+    except InspectionUnavailable as exc:
+        check("traversal refuses", str(exc) == "relative_path_invalid", exc)
+
+    outside = Path(tmp) / "outside"
+    outside.mkdir()
+    (outside / "1-1.flac").write_bytes(b"fixture")
+    (root / "link").symlink_to(outside, target_is_directory=True)
+    try:
+        inspect_album(request(relative="link"), roots, tag_reader=reader)
+        check("symlink target refuses", False)
+    except InspectionUnavailable as exc:
+        check("symlink target refuses", str(exc) == "target_unsafe", exc)
+
+    (root / "Alias").symlink_to(root / "Artist", target_is_directory=True)
+    try:
+        inspect_album(request(relative="Alias/Album"), roots, tag_reader=reader)
+        check("intermediate symlink refuses", False)
+    except InspectionUnavailable as exc:
+        check("intermediate symlink refuses", str(exc) == "target_unsafe", exc)
+
+    original_fstat = os.fstat
+    root_inode = os.stat(root).st_ino
+    calls = {"root": 0}
+    def device_swap(fd):
+        result = original_fstat(fd)
+        if result.st_ino == root_inode:
+            calls["root"] += 1
+            if calls["root"] > 1:
+                values = list(result)
+                values[2] += 1
+                return os.stat_result(values)
+        return result
+    saved = os.fstat
+    os.fstat = device_swap
+    try:
+        try:
+            inspect_album(request(), roots, tag_reader=reader)
+            check("root device swap refuses", False)
+        except InspectionUnavailable as exc:
+            check("root device swap refuses", str(exc) == "root_changed_during_scan", exc)
+    finally:
+        os.fstat = saved
+
+    changed = {"done": False}
+    def mutate():
+        if not changed["done"]:
+            changed["done"] = True
+            os.replace(album, root / "Artist" / "old")
+            album.mkdir()
+    try:
+        inspect_album(request(), roots, tag_reader=reader, before_finish=mutate)
+        check("target replacement refuses", False)
+    except InspectionUnavailable as exc:
+        check("target replacement refuses", str(exc) == "root_changed_during_scan", exc)
+    os.replace(root / "Artist" / "old", album)
+
+    def malformed(_fileobj, _relative):
+        raise ValueError("bad tags")
+    partial = inspect_album(request(), roots, tag_reader=malformed)
+    check("malformed tags are partial", partial.state == "partial" and
+          set(partial.errors) == {"requested_identity_mismatch", "stable_identity_missing",
+                                  "tags_unavailable", "technical_evidence_invalid"}, partial.errors)
+
+    def homonym(fileobj, relative):
+        tags, technical = reader(fileobj, relative)
+        tags["musicbrainz_artistid"] = [ARTIST_B]
+        return tags, technical
+    wrong = inspect_album(request(), roots, tag_reader=homonym)
+    check("artist homonym refuses complete", wrong.state == "partial" and
+          "requested_identity_mismatch" in wrong.errors, wrong.errors)
+
+    def edition(fileobj, relative):
+        tags, technical = reader(fileobj, relative)
+        if Path(relative).stem.endswith("2"):
+            tags["musicbrainz_albumid"] = [DELUXE]
+        return tags, technical
+    mixed = inspect_album(request(), roots, tag_reader=edition)
+    check("mixed editions are partial", mixed.state == "partial" and
+          "album_identity_conflict" in mixed.errors, mixed.errors)
+
+    def compilation(fileobj, relative):
+        tags, technical = reader(fileobj, relative)
+        tags["albumartist"] = ["Various Artists"]
+        tags["musicbrainz_artistid"] = [ARTIST_A if Path(relative).stem.endswith("1") else ARTIST_B]
+        return tags, technical
+    compilation_profile = inspect_album(
+        request(musicbrainz_artist_id=""), roots, tag_reader=compilation)
+    check("compilation permits track artists", compilation_profile.state == "complete",
+          compilation_profile.errors)
+
+    def invalid_technical(fileobj, relative):
+        tags, _ = reader(fileobj, relative)
+        return tags, {"duration_seconds": float("nan"), "codec": "flac",
+                      "sample_rate": "48000", "channels": -1}
+    invalid = inspect_album(request(), roots, tag_reader=invalid_technical)
+    check("invalid technical evidence is partial and sanitized",
+          invalid.state == "partial" and "technical_evidence_invalid" in invalid.errors
+          and invalid.tracks[0].duration_seconds is None, invalid.errors)
+
+    try:
+        inspect_album({**request(), "extra": True}, roots, tag_reader=reader)
+        check("unknown request field refuses", False)
+    except ValueError as exc:
+        check("unknown request field refuses", str(exc) == "request_schema_invalid", exc)
+    bad_version = request()
+    bad_version["schema"] = "music.inspection.request.v2"
+    try:
+        inspect_album(bad_version, roots, tag_reader=reader)
+        check("unknown version refuses", False)
+    except ValueError as exc:
+        check("unknown version refuses", str(exc) == "request_version_unsupported", exc)
+    try:
+        inspect_album(request(root_id="missing"), roots, tag_reader=reader)
+        check("configured root outage refuses", False)
+    except InspectionUnavailable as exc:
+        check("configured root outage refuses", str(exc) == "root_unavailable", exc)
+    for malformed_roots in (None, [{"id": "music", "path": None}]):
+        payload, status = inspect_payload(request(), malformed_roots, tag_reader=reader)
+        check("malformed root config is unavailable", status == 503 and
+              payload["state"] == "unavailable", (payload, status))
+
+    # A failure after open must not leak one descriptor per retry.
+    descriptor_dir = Path("/proc/self/fd")
+    if descriptor_dir.exists():
+        baseline = len(list(descriptor_dir.iterdir()))
+        original_fstat = os.fstat
+        def fail_audio_fstat(fd):
+            result = original_fstat(fd)
+            if stat.S_ISREG(result.st_mode):
+                raise OSError("fixture outage")
+            return result
+        os.fstat = fail_audio_fstat
+        try:
+            for _ in range(5):
+                payload, status = inspect_payload(request(), roots, tag_reader=reader)
+                check("post-open outage is unavailable", status == 503 and
+                      payload["state"] == "unavailable", (payload, status))
+        finally:
+            os.fstat = original_fstat
+        check("post-open outage leaks no descriptors",
+              len(list(descriptor_dir.iterdir())) == baseline,
+              (baseline, len(list(descriptor_dir.iterdir()))))
+
+        baseline = len(list(descriptor_dir.iterdir()))
+        calls = {"count": 0}
+        def fail_root_fstat(fd):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise OSError("fixture root outage")
+            return original_fstat(fd)
+        os.fstat = fail_root_fstat
+        try:
+            payload, status = inspect_payload(request(), roots, tag_reader=reader)
+            check("root post-open outage is unavailable", status == 503 and
+                  payload["state"] == "unavailable", (payload, status))
+        finally:
+            os.fstat = original_fstat
+        check("root post-open outage leaks no descriptors",
+              len(list(descriptor_dir.iterdir())) == baseline,
+              (baseline, len(list(descriptor_dir.iterdir()))))
+    unrelated = request(musicbrainz_artist_id="", musicbrainz_album_id="",
+                        musicbrainz_release_group_id="",
+                        lidarr_foreign_artist_id="", lidarr_foreign_album_id=DELUXE)
+    profile = inspect_album(unrelated, roots, tag_reader=reader)
+    check("Lidarr album identity is checked against release group",
+          profile.state == "partial" and "requested_identity_mismatch" in profile.errors,
+          profile.errors)
+    try:
+        inspect_album(request(), roots, tag_reader=reader, max_files=1)
+        check("bounded scan refuses overflow", False)
+    except InspectionUnavailable as exc:
+        check("bounded scan refuses overflow", str(exc) == "scan_limit_exceeded", exc)
+
+    payload, status = inspect_payload(request(), roots, tag_reader=reader)
+    check("versioned API contract complete", status == 200 and
+          payload["schema"] == "music.inspection.v1")
+    payload, status = inspect_payload({"schema": "wrong"}, roots, tag_reader=reader)
+    check("API schema failure deterministic", status == 400 and
+          payload["state"] == "unavailable")
+
+    # Capability proof: inspection owns no filesystem mutation verb.
+    forbidden = []
+    saved_rename, saved_replace, saved_unlink, saved_remove = (
+        os.rename, os.replace, os.unlink, os.remove)
+    def mutation(*args, **kwargs):
+        forbidden.append((args, kwargs))
+        raise AssertionError("mutation attempted")
+    os.rename = os.replace = os.unlink = os.remove = mutation
+    try:
+        check("inspection has no mutation side effect",
+              inspect_album(request(), roots, tag_reader=reader).state == "complete"
+              and not forbidden)
+    finally:
+        os.rename, os.replace, os.unlink, os.remove = (
+            saved_rename, saved_replace, saved_unlink, saved_remove)
+
+if fails:
+    print(f"FAILED {len(fails)}")
+    for failure in fails:
+        print(" -", failure)
+    raise SystemExit(1)
+print("All music-inspection tests passed.")


### PR DESCRIPTION
## What changed

- adds immutable MusicProfile and TrackIdentity contracts
- adds strict `POST /api/v1/music/inspect` request, response, and error schemas
- binds canonical MusicBrainz artist/release-group IDs to Lidarr foreign identity
- inspects configured root-relative album paths using bounded descriptor-based `O_NOFOLLOW` traversal
- returns deterministic complete, partial, or unavailable evidence for supported audio formats
- exposes no organization, rename, move, delete, or write verb

## Why

Gus issue #46 requires Music-first media departments backed by Library Manager rather than duplicating identity and filesystem rules. The current missing-album path can only compare titles and service responses; it cannot distinguish missing files, stranded disk content, edition conflicts, or provider outage safely.

## Validation

- independent adversarial review: signed off
- music inspection suite: pass
- existing video identify suite: pass
- existing video naming suite: pass
- Python compilation: pass
- diff check: clean
- adversarial coverage includes homonyms, editions, compilations, multidisc, six formats, traversal, symlink/device/inode swaps, malformed tags/config, outage, descriptor leaks, schema/version/unknown fields, invalid technical evidence, determinism, privacy, scan cap, and mutation sentinels

This is intentionally read-only. Organization proposal/apply/undo remains blocked for a later reviewed phase.