### PR TITLE
feat: language naming pack - top-level folders, emoji flags, ISO 639-2, series locks, multi-language (#278-#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.156] - 2026-08-13
+
+### Added
+- **#278: Language as top-level folder** — New `top_folder` option for `language_tag_position` builds `Language/Author/[Series/]Title` for every book with a known language (preferred language included), wrapping all naming formats including custom templates.
+- **#282: Emoji flag language tags** — New `emoji_flag` tag format and `{lang_flag}` custom template tag with an ISO 639-1 to flag emoji mapping; unmapped codes fall back to the bracketed name.
+- **#279: ISO 639-2 code output** — New `language_code_format` setting (`iso639-1`/`iso639-2`, bibliographic codes to match Skaldleita) applied to code-based tags and `{lang_code}`.
+- **#281: Per-series language override** — New `series_language_overrides` table, `/api/series-language-overrides` endpoints, and a settings card. A locked series short-circuits language detection in `_resolve_metadata_language`; `auto` keeps per-book detection.
+- **#280: Multi-language book tagging** — `BookProfile.languages` list (primary first, back-compatible), `books.languages` column with migration, `/api/books/<id>/languages` endpoints, a languages multi-select in the library edit modal, and multi-language folder tags (names joined `, `, codes `,`, flags space).
+
+### Fixed
+- **ISO 639-2 normalization** — Three-letter codes from Skaldleita (`eng`, `ger`) are now mapped to ISO 639-1 in `_normalize_language_code`, all three `_extract_detected_language` copies, and defensively in `build_new_path`. Previously they produced `ENG/` top folders and wrongly tagged preferred-language books.
+
 ## [0.9.0-beta.154] - 2026-07-14
 
 ### Fixed

--- a/app.py
+++ b/app.py
@@ -53,7 +53,10 @@ from library_manager.database import (
     init_db, get_db, set_db_path, cleanup_garbage_entries,
     cleanup_duplicate_history_entries, insert_history_entry,
     should_requeue_book,
-    watch_folder_is_processed, watch_folder_mark_processed
+    watch_folder_is_processed, watch_folder_mark_processed,
+    set_series_language_override, get_all_series_language_overrides,
+    delete_series_language_override,
+    set_book_languages, get_book_languages
 )
 from library_manager.models.book_profile import (
     SOURCE_WEIGHTS, FIELD_WEIGHTS, FieldValue, BookProfile,
@@ -1057,6 +1060,35 @@ def _extract_detected_language(result):
             if language:
                 return language
     return None
+
+
+def _extract_languages(result):
+    """Extract the full language list (primary first) from payload or profile JSON.
+
+    Issue #280: reads the serialized BookProfile 'languages' list; falls back
+    to the single detected language for older profiles.
+    """
+    if not result:
+        return []
+
+    if isinstance(result, str):
+        try:
+            parsed = json.loads(result)
+        except json.JSONDecodeError:
+            return []
+    elif isinstance(result, dict):
+        parsed = result
+    else:
+        return []
+
+    languages = parsed.get('languages')
+    if isinstance(languages, list):
+        cleaned = [str(c).strip().lower() for c in languages if c]
+        if cleaned:
+            return cleaned
+
+    primary = _extract_detected_language(parsed)
+    return [primary] if primary else []
 
 
 # ISO 639-1 language code to full name mapping
@@ -6285,6 +6317,7 @@ def apply_fix(history_id):
     # Prefer audio-detected language stored in the profile (#274), fall back to title detection
     fix_title = fix['new_title'] or fix['old_title']
     fix_lang = _extract_detected_language(book_row['profile']) if book_row else None
+    fix_languages = _extract_languages(book_row['profile']) if book_row else []
     if not fix_lang and fix_title:
         fix_lang = detect_title_language(fix_title)
     audible_url = _build_audible_url(metadata_book_id, fix_lang)
@@ -6314,6 +6347,7 @@ def apply_fix(history_id):
             edition=fix['new_edition'] if fix['new_edition'] else None,
             variant=fix['new_variant'] if fix['new_variant'] else None,
             language_code=fix_lang,
+            languages=fix_languages or None,
             config=config
         )
         if not new_path:
@@ -7543,7 +7577,105 @@ def settings_page():
     return render_template('settings.html', config=config, version=APP_VERSION,
                            pipeline_layers=pipeline_layers,
                            pipeline_order=pipeline_order,
-                           pipeline_default_order=pipeline_default_order)
+                           pipeline_default_order=pipeline_default_order,
+                           language_names=LANGUAGE_NAMES)
+
+
+# ============== SERIES LANGUAGE OVERRIDES (Issue #281) ==============
+
+@app.route('/api/series-language-overrides', methods=['GET'])
+def api_series_language_overrides_list():
+    """List all per-series language overrides."""
+    return jsonify({'success': True, 'overrides': get_all_series_language_overrides()})
+
+
+@app.route('/api/series-language-overrides', methods=['POST'])
+def api_series_language_overrides_set():
+    """Add or update a per-series language override.
+
+    POST body: {"series_name": "Mistborn", "language_code": "de"}
+    language_code 'auto' (or empty) removes the override instead.
+    """
+    data = request.get_json() or {}
+    series_name = (data.get('series_name') or '').strip()
+    language_code = (data.get('language_code') or '').strip().lower()
+
+    if not series_name:
+        return jsonify({'success': False, 'error': 'series_name is required'}), 400
+
+    if language_code in ('', 'auto'):
+        delete_series_language_override(series_name)
+        return jsonify({'success': True})
+
+    try:
+        set_series_language_override(series_name, language_code)
+    except ValueError as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+
+    log_action('series_language_override', detail=f"{series_name} -> {language_code}", result='success')
+    return jsonify({'success': True})
+
+
+@app.route('/api/series-language-overrides', methods=['DELETE'])
+def api_series_language_overrides_delete():
+    """Remove a per-series language override.
+
+    DELETE body: {"series_name": "Mistborn"}
+    """
+    data = request.get_json() or {}
+    series_name = (data.get('series_name') or '').strip()
+    if not series_name:
+        return jsonify({'success': False, 'error': 'series_name is required'}), 400
+
+    removed = delete_series_language_override(series_name)
+    return jsonify({'success': True, 'removed': removed})
+
+
+# ============== BOOK LANGUAGES (Issue #280) ==============
+
+@app.route('/api/books/<int:book_id>/languages', methods=['GET'])
+def api_book_languages_get(book_id):
+    """Return the ordered language list for a book (primary first)."""
+    conn = get_db()
+    try:
+        row = conn.execute('SELECT id FROM books WHERE id = ?', (book_id,)).fetchone()
+    finally:
+        conn.close()
+    if not row:
+        return jsonify({'success': False, 'error': 'Book not found'}), 404
+    return jsonify({'success': True, 'languages': get_book_languages(book_id)})
+
+
+@app.route('/api/books/<int:book_id>/languages', methods=['POST'])
+def api_book_languages_set(book_id):
+    """Set the secondary languages for a book (Issue #280).
+
+    POST body: {"languages": ["de", "en"]}
+    Ordered list of ISO 639-1 codes, first = primary. An empty list clears
+    the list (book falls back to single-language behavior).
+    """
+    data = request.get_json() or {}
+    languages = data.get('languages', [])
+
+    if not isinstance(languages, list):
+        return jsonify({'success': False, 'error': 'languages must be a list of ISO 639-1 codes'}), 400
+
+    conn = get_db()
+    try:
+        row = conn.execute('SELECT id FROM books WHERE id = ?', (book_id,)).fetchone()
+    finally:
+        conn.close()
+    if not row:
+        return jsonify({'success': False, 'error': 'Book not found'}), 404
+
+    try:
+        set_book_languages(book_id, languages)
+    except ValueError as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+
+    cleaned = get_book_languages(book_id)
+    log_action('book_languages', detail=f"book {book_id} -> {','.join(cleaned) or '(cleared)'}", result='success')
+    return jsonify({'success': True, 'languages': cleaned})
 
 
 # ============== PATH DIAGNOSTIC ==============

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.155"
+APP_VERSION = "0.9.0-beta.156"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/app.py
+++ b/app.py
@@ -7453,6 +7453,7 @@ def settings_page():
         config['language_tag_enabled'] = 'language_tag_enabled' in request.form
         config['language_tag_format'] = request.form.get('language_tag_format', 'bracket_full')
         config['language_tag_position'] = request.form.get('language_tag_position', 'after_title')
+        config['language_code_format'] = request.form.get('language_code_format', 'iso639-1')
         # google_books_api_key is now stored in secrets only (security fix)
         config['update_channel'] = request.form.get('update_channel', 'stable')
         config['naming_format'] = request.form.get('naming_format', 'author/title')

--- a/app.py
+++ b/app.py
@@ -1057,6 +1057,10 @@ def _extract_detected_language(result):
             language = language.get('value')
         if language:
             language = str(language).strip().lower()
+            # Map ISO 639-2 three-letter codes (eng, ger from Skaldleita) to 639-1
+            if len(language) == 3:
+                from library_manager.utils.path_safety import ISO_639_2_TO_1
+                language = ISO_639_2_TO_1.get(language, language)
             if language:
                 return language
     return None

--- a/library_manager/config.py
+++ b/library_manager/config.py
@@ -97,8 +97,9 @@ DEFAULT_CONFIG = {
     # Multi-language naming - how to name books based on their detected language
     "multilang_naming_mode": "native",      # "native" = book's language, "preferred" = user's language, "tagged" = preferred + tag
     "language_tag_enabled": False,          # Add language tag to folder names (e.g., "Title (Russian)")
-    "language_tag_format": "bracket_full",  # "code" (_pl), "full" (Polish), "bracket_code" ([pl]), "bracket_full" ((Polish))
-    "language_tag_position": "after_title", # "after_title", "before_title", "subfolder"
+    "language_tag_format": "bracket_full",  # "code" (_pl), "full" (Polish), "bracket_code" ([pl]), "bracket_full" ((Polish)), "emoji_flag" (🇵🇱)
+    "language_tag_position": "after_title", # "after_title", "before_title", "subfolder", "top_folder"
+    "language_code_format": "iso639-1",     # "iso639-1" (pl) or "iso639-2" (pol) for code-based tags and {lang_code}
     # Trust the Process mode - fully automatic verification chain
     "trust_the_process": False,  # Auto-verify drastic changes, use audio analysis as tie-breaker, only flag truly unidentifiable
     # Book Profile System settings - progressive verification with confidence scoring

--- a/library_manager/database.py
+++ b/library_manager/database.py
@@ -164,6 +164,13 @@ def init_db(db_path=None):
         except:
             pass  # Column already exists
 
+    # Issue #280: languages column - JSON array of ISO 639-1 codes
+    # (primary first) for bilingual/multi-language books
+    try:
+        c.execute('ALTER TABLE books ADD COLUMN languages TEXT')
+    except:
+        pass  # Column already exists
+
     # Stats table - daily stats
     c.execute('''CREATE TABLE IF NOT EXISTS stats (
         id INTEGER PRIMARY KEY,
@@ -184,6 +191,18 @@ def init_db(db_path=None):
         processed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         outcome TEXT,
         error_message TEXT
+    )''')
+
+    # Issue #281: Per-series language overrides ("language lock")
+    # series_key is the normalized (lowercase, whitespace-stripped) series name
+    # used for case-insensitive matching; series_name keeps the display form.
+    c.execute('''CREATE TABLE IF NOT EXISTS series_language_overrides (
+        id INTEGER PRIMARY KEY,
+        series_name TEXT,
+        series_key TEXT UNIQUE,
+        language_code TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )''')
 
     conn.commit()
@@ -489,6 +508,236 @@ def should_requeue_book(book_row, max_retries=3):
         return (True, 1)
 
 
+def _normalize_series_key(series_name):
+    """Normalize a series name for case-insensitive override matching."""
+    if not series_name:
+        return ''
+    return ' '.join(str(series_name).lower().split())
+
+
+def set_series_language_override(series_name, language_code, db_path=None):
+    """Set (or update) the language lock for a series (Issue #281).
+
+    Args:
+        series_name: Display name of the series (matched case-insensitively)
+        language_code: ISO 639-1 code from LANGUAGE_NAMES, or 'auto'/None to
+            remove the override and fall back to normal detection
+        db_path: Optional database path (defaults to the app database)
+
+    Raises:
+        ValueError: If the language code is not a known ISO 639-1 code
+    """
+    path = db_path or _db_path
+    if not path:
+        raise ValueError("Database path not set. Call set_db_path() first.")
+
+    series_name = (series_name or '').strip()
+    series_key = _normalize_series_key(series_name)
+    if not series_key:
+        raise ValueError("Series name is required")
+
+    code = (language_code or '').lower().strip()
+    if code in ('', 'auto'):
+        delete_series_language_override(series_name, db_path=db_path)
+        return
+
+    from library_manager.utils.path_safety import LANGUAGE_NAMES
+    if code not in LANGUAGE_NAMES:
+        raise ValueError(f"Unknown language code: {language_code}")
+
+    conn = sqlite3.connect(path, timeout=30)
+    try:
+        conn.execute(
+            '''INSERT INTO series_language_overrides (series_name, series_key, language_code)
+               VALUES (?, ?, ?)
+               ON CONFLICT(series_key) DO UPDATE SET
+                   series_name = excluded.series_name,
+                   language_code = excluded.language_code,
+                   updated_at = CURRENT_TIMESTAMP''',
+            (series_name, series_key, code)
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_series_language_override(series_name, db_path=None):
+    """Return the locked language code for a series, or None if unset/auto."""
+    path = db_path or _db_path
+    if not path:
+        return None
+    series_key = _normalize_series_key(series_name)
+    if not series_key:
+        return None
+    conn = sqlite3.connect(path, timeout=30)
+    try:
+        c = conn.execute(
+            'SELECT language_code FROM series_language_overrides WHERE series_key = ? LIMIT 1',
+            (series_key,)
+        )
+        row = c.fetchone()
+        return row[0] if row else None
+    except sqlite3.OperationalError:
+        return None  # Table may not exist yet on older databases
+    finally:
+        conn.close()
+
+
+def get_all_series_language_overrides(db_path=None):
+    """Return all series language overrides as a list of dicts."""
+    path = db_path or _db_path
+    if not path:
+        return []
+    conn = sqlite3.connect(path, timeout=30)
+    conn.row_factory = sqlite3.Row
+    try:
+        c = conn.execute(
+            'SELECT series_name, language_code, updated_at FROM series_language_overrides ORDER BY series_name'
+        )
+        return [dict(row) for row in c.fetchall()]
+    except sqlite3.OperationalError:
+        return []  # Table may not exist yet on older databases
+    finally:
+        conn.close()
+
+
+def delete_series_language_override(series_name, db_path=None):
+    """Remove the language override for a series. Returns True if one existed."""
+    path = db_path or _db_path
+    if not path:
+        return False
+    series_key = _normalize_series_key(series_name)
+    if not series_key:
+        return False
+    conn = sqlite3.connect(path, timeout=30)
+    try:
+        cursor = conn.execute(
+            'DELETE FROM series_language_overrides WHERE series_key = ?',
+            (series_key,)
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+    except sqlite3.OperationalError:
+        return False
+    finally:
+        conn.close()
+
+
+def _normalize_language_list(languages):
+    """Normalize an ordered language list: lowercase, deduped, order preserved."""
+    cleaned = []
+    for code in languages or []:
+        normalized = str(code).lower().strip() if code else ''
+        if normalized and normalized not in cleaned:
+            cleaned.append(normalized)
+    return cleaned
+
+
+def set_book_languages(book_id, languages, db_path=None):
+    """Set the full language list for a book (Issue #280).
+
+    Args:
+        book_id: books table row id
+        languages: Ordered list of ISO 639-1 codes, primary first. An empty
+            list clears the list (book falls back to single-language behavior).
+        db_path: Optional database path (defaults to the app database)
+
+    Raises:
+        ValueError: If any code is not a known ISO 639-1 code
+    """
+    path = db_path or _db_path
+    if not path:
+        raise ValueError("Database path not set. Call set_db_path() first.")
+
+    import json as _json
+    from library_manager.utils.path_safety import LANGUAGE_NAMES
+
+    cleaned = _normalize_language_list(languages)
+    for code in cleaned:
+        if code not in LANGUAGE_NAMES:
+            raise ValueError(f"Unknown language code: {code}")
+
+    languages_json = _json.dumps(cleaned) if cleaned else None
+
+    conn = sqlite3.connect(path, timeout=30)
+    conn.row_factory = sqlite3.Row
+    try:
+        c = conn.execute(
+            'UPDATE books SET languages = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+            (languages_json, book_id)
+        )
+        if c.rowcount == 0:
+            raise ValueError(f"Book not found: {book_id}")
+        # Keep the profile JSON in sync: primary language + full list
+        row = conn.execute('SELECT profile FROM books WHERE id = ?', (book_id,)).fetchone()
+        if row and row['profile']:
+            try:
+                profile = _json.loads(row['profile'])
+            except ValueError:
+                profile = None
+            if isinstance(profile, dict):
+                profile['languages'] = cleaned
+                lang_fv = profile.get('language')
+                if cleaned and isinstance(lang_fv, dict):
+                    lang_fv['value'] = cleaned[0]
+                conn.execute(
+                    'UPDATE books SET profile = ? WHERE id = ?',
+                    (_json.dumps(profile), book_id)
+                )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_book_languages(book_id, db_path=None):
+    """Return the ordered language list for a book (primary first).
+
+    Falls back to the primary language stored in the profile JSON for rows
+    without a languages column value. Returns [] when nothing is known.
+    """
+    path = db_path or _db_path
+    if not path:
+        return []
+    import json as _json
+    conn = sqlite3.connect(path, timeout=30)
+    conn.row_factory = sqlite3.Row
+    try:
+        try:
+            row = conn.execute('SELECT languages, profile FROM books WHERE id = ?', (book_id,)).fetchone()
+        except sqlite3.OperationalError:
+            # Older schema without the languages column
+            row = conn.execute('SELECT profile FROM books WHERE id = ?', (book_id,)).fetchone()
+        if not row:
+            return []
+        languages = row['languages'] if 'languages' in row.keys() else None
+        if languages:
+            try:
+                return _normalize_language_list(_json.loads(languages))
+            except ValueError:
+                return []
+        # Fall back to the profile JSON
+        if row['profile']:
+            try:
+                profile = _json.loads(row['profile'])
+            except ValueError:
+                return []
+            if isinstance(profile, dict):
+                listed = profile.get('languages')
+                if listed:
+                    return _normalize_language_list(listed)
+                lang = profile.get('language')
+                if isinstance(lang, dict):
+                    lang = lang.get('value')
+                if lang:
+                    return [str(lang).lower().strip()]
+        return []
+    finally:
+        conn.close()
+
+
 __all__ = ['init_db', 'get_db', 'set_db_path', 'cleanup_garbage_entries',
            'cleanup_duplicate_history_entries', 'insert_history_entry',
-           'should_requeue_book']
+           'should_requeue_book',
+           'set_series_language_override', 'get_series_language_override',
+           'get_all_series_language_overrides', 'delete_series_language_override',
+           'set_book_languages', 'get_book_languages']

--- a/library_manager/hints.py
+++ b/library_manager/hints.py
@@ -40,6 +40,7 @@ HINTS = {
     'standardize_initials': 'Normalizes author initials to a consistent format (e.g., "JRR Tolkien" and "J.R.R. Tolkien" both become "J. R. R. Tolkien"). Prevents duplicate author folders.',
     'strip_unabridged': 'Removes "(Unabridged)", "[Unabridged]", and similar markers from book titles during rename.',
     'multilang_naming': 'Controls how non-English books are named. Native keeps the original language title. Preferred translates to your language. Tagged adds a language indicator.',
+    'series_language_override': 'Locks a series to a fixed language, skipping audio/title language detection for its books. Useful when a series is consistently misdetected. Leave on Auto to detect each book normally.',
 
     # === Settings - Watch Folder ===
     'watch_folder': 'Monitors a folder for new audiobooks and automatically organizes them into your library. Great for processing downloads or imports.',

--- a/library_manager/models/book_profile.py
+++ b/library_manager/models/book_profile.py
@@ -232,6 +232,10 @@ class BookProfile:
     series: FieldValue = field(default_factory=FieldValue)
     series_num: FieldValue = field(default_factory=FieldValue)
     language: FieldValue = field(default_factory=FieldValue)
+    # Issue #280: All languages for this book (ISO 639-1 codes, primary first).
+    # `language` stays the primary for back-compat; `languages` carries the
+    # full list for bilingual/multi-language books.
+    languages: List[str] = field(default_factory=list)
     year: FieldValue = field(default_factory=FieldValue)
     edition: FieldValue = field(default_factory=FieldValue)
     variant: FieldValue = field(default_factory=FieldValue)
@@ -271,6 +275,36 @@ class BookProfile:
             return False
         self.title.add_source(source, title, weight)
         return True
+
+    def get_languages(self) -> List[str]:
+        """All languages for the book (primary first).
+
+        Falls back to the primary `language` value when no explicit list
+        has been set, so single-language books keep working unchanged.
+        """
+        if self.languages:
+            return list(self.languages)
+        if self.language.value:
+            return [self.language.value]
+        return []
+
+    def set_languages(self, codes, source: str = 'user'):
+        """Set the language list (primary first), keeping `language` in sync.
+
+        Codes are normalized (lowercase, stripped) and deduped, preserving
+        order. The first entry becomes the primary `language` value so
+        existing consumers see no behavior change.
+        """
+        cleaned = []
+        for code in codes or []:
+            normalized = str(code).lower().strip() if code else ''
+            if normalized and normalized not in cleaned:
+                cleaned.append(normalized)
+        self.languages = cleaned
+        if cleaned:
+            self.language.value = cleaned[0]
+            if source not in self.language.sources:
+                self.language.sources.append(source)
 
     def calculate_field_confidence(self, fv: FieldValue) -> tuple:
         """Calculate confidence for a field based on source agreement."""
@@ -357,6 +391,11 @@ class BookProfile:
                 self.issues.append('series_as_author')
             self.needs_attention = True
 
+        # Issue #280: make sure the primary language is represented in the
+        # languages list once detection has settled on a value
+        if self.language.value and not self.languages:
+            self.languages = [self.language.value]
+
         self.calculate_overall_confidence()
         self.last_updated = datetime.now().isoformat()
 
@@ -425,6 +464,7 @@ class BookProfile:
         for field_name in FIELD_WEIGHTS.keys():
             fv = getattr(self, field_name)
             result[field_name] = fv.to_dict()
+        result['languages'] = list(self.languages)
         result['overall_confidence'] = self.overall_confidence
         result['verification_layers_used'] = self.verification_layers_used
         result['needs_attention'] = self.needs_attention
@@ -452,6 +492,7 @@ class BookProfile:
                     source_weights=fd.get('source_weights', {})
                 )
                 setattr(profile, field_name, fv)
+        profile.languages = [str(c).lower().strip() for c in data.get('languages', []) if c]
         profile.overall_confidence = data.get('overall_confidence', 0)
         profile.verification_layers_used = data.get('verification_layers_used', [])
         profile.needs_attention = data.get('needs_attention', False)
@@ -607,10 +648,20 @@ def save_book_profile(book_id: int, profile: BookProfile):
     c = conn.cursor()
     try:
         profile_json = json.dumps(profile.to_dict())
-        c.execute('''UPDATE books
-                     SET profile = ?, confidence = ?, updated_at = CURRENT_TIMESTAMP
-                     WHERE id = ?''',
-                  (profile_json, profile.overall_confidence, book_id))
+        # Issue #280: also persist the language list in its own column so
+        # downstream tools (e.g. beets-audible) can query it without
+        # parsing the profile JSON. Tolerate older schemas without the column.
+        languages_json = json.dumps(profile.get_languages())
+        try:
+            c.execute('''UPDATE books
+                         SET profile = ?, confidence = ?, languages = ?, updated_at = CURRENT_TIMESTAMP
+                         WHERE id = ?''',
+                      (profile_json, profile.overall_confidence, languages_json, book_id))
+        except Exception:
+            c.execute('''UPDATE books
+                         SET profile = ?, confidence = ?, updated_at = CURRENT_TIMESTAMP
+                         WHERE id = ?''',
+                      (profile_json, profile.overall_confidence, book_id))
         conn.commit()
     finally:
         conn.close()

--- a/library_manager/pipeline/layer_ai_queue.py
+++ b/library_manager/pipeline/layer_ai_queue.py
@@ -127,6 +127,10 @@ def _extract_detected_language(candidate):
             language = language.get('value')
         if language:
             language = str(language).strip().lower()
+            # Map ISO 639-2 three-letter codes (eng, ger from Skaldleita) to 639-1
+            if len(language) == 3:
+                from library_manager.utils.path_safety import ISO_639_2_TO_1
+                language = ISO_639_2_TO_1.get(language, language)
             if language:
                 return language
     return None

--- a/library_manager/pipeline/layer_api.py
+++ b/library_manager/pipeline/layer_api.py
@@ -59,6 +59,10 @@ def _extract_detected_language(candidate) -> Optional[str]:
             language = language.get('value')
         if language:
             language = str(language).strip().lower()
+            # Map ISO 639-2 three-letter codes (eng, ger from Skaldleita) to 639-1
+            if len(language) == 3:
+                from library_manager.utils.path_safety import ISO_639_2_TO_1
+                language = ISO_639_2_TO_1.get(language, language)
             if language:
                 return language
     return None

--- a/library_manager/pipeline/layer_audio_id.py
+++ b/library_manager/pipeline/layer_audio_id.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Callable, Dict, Optional, Tuple
 
 from library_manager.config import use_skaldleita_for_audio
-from library_manager.database import insert_history_entry
+from library_manager.database import insert_history_entry, get_series_language_override
 from library_manager.utils.validation import (
     is_garbage_author_match, is_placeholder_author,
     is_valid_author_for_recommendation, is_valid_title_for_recommendation
@@ -76,9 +76,17 @@ def _resolve_metadata_language(
     title: Optional[str],
     config: Dict,
     detect_audio_language_fn=None,
-    language_hint: Optional[str] = None
+    language_hint: Optional[str] = None,
+    series_name: Optional[str] = None
 ):
     """Resolve metadata language using an explicit hint, configured audio detection, or title fallback."""
+    # Issue #281: A series language lock is a hard override - skip detection entirely
+    if series_name:
+        override = get_series_language_override(series_name)
+        if override:
+            logger.info(f"[LANG] Series '{series_name}' locked to language '{override}' - skipping detection")
+            return override
+
     if language_hint:
         hinted = _normalize_language_code(language_hint)
         if hinted:
@@ -531,7 +539,8 @@ def process_layer_1_audio(
                             title,
                             current_config,
                             detect_audio_language_fn=detect_audio_language,
-                            language_hint=ebook_result.get('language')
+                            language_hint=ebook_result.get('language'),
+                            series_name=ebook_result.get('series')
                         )
                         if lang_code:
                             profile['detected_language'] = lang_code
@@ -861,7 +870,8 @@ def process_layer_1_audio(
                         title,
                         audio_config,
                         detect_audio_language_fn=detect_audio_language,
-                        language_hint=result.get('detected_language') or result.get('language')
+                        language_hint=result.get('detected_language') or result.get('language'),
+                        series_name=series
                     )
                     if lang_code:
                         profile['detected_language'] = lang_code

--- a/library_manager/pipeline/layer_audio_id.py
+++ b/library_manager/pipeline/layer_audio_id.py
@@ -22,6 +22,7 @@ from typing import Callable, Dict, Optional, Tuple
 
 from library_manager.config import use_skaldleita_for_audio
 from library_manager.database import insert_history_entry, get_series_language_override
+from library_manager.utils.path_safety import ISO_639_2_TO_1
 from library_manager.utils.validation import (
     is_garbage_author_match, is_placeholder_author,
     is_valid_author_for_recommendation, is_valid_title_for_recommendation
@@ -42,7 +43,12 @@ def _detect_title_language(text):
 
 
 def _normalize_language_code(language_code):
-    """Normalize a language identifier to the region map format used by the app."""
+    """Normalize a language identifier to the region map format used by the app.
+
+    Returns ISO 639-1 two-letter codes. Three-letter ISO 639-2 codes
+    (e.g. 'eng', 'ger' from Skaldleita) are mapped to their 639-1 equivalent
+    so downstream lookups (LANGUAGE_NAMES, region maps, tag formats) work.
+    """
     if not language_code:
         return None
     normalized = str(language_code).lower().strip()
@@ -53,6 +59,9 @@ def _normalize_language_code(language_code):
         normalized = normalized.split('-')[0].strip()
     if normalized in ('', 'none', 'null', 'und'):
         return None
+    # Map ISO 639-2 three-letter codes (eng, ger, ...) to ISO 639-1
+    if len(normalized) == 3 and normalized in ISO_639_2_TO_1:
+        normalized = ISO_639_2_TO_1[normalized]
     return normalized
 
 

--- a/library_manager/utils/path_safety.py
+++ b/library_manager/utils/path_safety.py
@@ -19,6 +19,50 @@ LANGUAGE_NAMES = {
     'vi': 'Vietnamese', 'uk': 'Ukrainian', 'ro': 'Romanian', 'id': 'Indonesian'
 }
 
+# Issue #282: ISO 639-1 code to regional-indicator flag emoji for compact
+# visual language tags (e.g. "Title 🇩🇪"). Languages mapped to their most
+# commonly associated country flag.
+LANGUAGE_FLAGS = {
+    'en': '🇬🇧', 'de': '🇩🇪', 'fr': '🇫🇷', 'es': '🇪🇸',
+    'it': '🇮🇹', 'pt': '🇵🇹', 'nl': '🇳🇱', 'sv': '🇸🇪',
+    'no': '🇳🇴', 'da': '🇩🇰', 'fi': '🇫🇮', 'pl': '🇵🇱',
+    'ru': '🇷🇺', 'ja': '🇯🇵', 'zh': '🇨🇳', 'ko': '🇰🇷',
+    'ar': '🇸🇦', 'he': '🇮🇱', 'hi': '🇮🇳', 'tr': '🇹🇷',
+    'cs': '🇨🇿', 'hu': '🇭🇺', 'el': '🇬🇷', 'th': '🇹🇭',
+    'vi': '🇻🇳', 'uk': '🇺🇦', 'ro': '🇷🇴', 'id': '🇮🇩'
+}
+
+# Issue #279: ISO 639-1 <-> ISO 639-2/B (bibliographic) mapping.
+# Bibliographic codes (ger, fre, ...) are used because Skaldleita and most
+# media tooling emit them. Only covers languages in LANGUAGE_NAMES.
+ISO_639_1_TO_2 = {
+    'en': 'eng', 'de': 'ger', 'fr': 'fre', 'es': 'spa',
+    'it': 'ita', 'pt': 'por', 'nl': 'dut', 'sv': 'swe',
+    'no': 'nor', 'da': 'dan', 'fi': 'fin', 'pl': 'pol',
+    'ru': 'rus', 'ja': 'jpn', 'zh': 'chi', 'ko': 'kor',
+    'ar': 'ara', 'he': 'heb', 'hi': 'hin', 'tr': 'tur',
+    'cs': 'cze', 'hu': 'hun', 'el': 'gre', 'th': 'tha',
+    'vi': 'vie', 'uk': 'ukr', 'ro': 'rum', 'id': 'ind'
+}
+ISO_639_2_TO_1 = {v: k for k, v in ISO_639_1_TO_2.items()}
+
+
+def lang_code_for_display(lang_code: str, code_format: str = 'iso639-1') -> str:
+    """Convert an internal ISO 639-1 code for display/naming output.
+
+    Args:
+        lang_code: Internal ISO 639-1 code (e.g. 'de')
+        code_format: 'iso639-1' (default) or 'iso639-2' (three-letter)
+
+    Returns:
+        Code in the requested format; unknown codes pass through unchanged.
+    """
+    if not lang_code:
+        return lang_code
+    if code_format == 'iso639-2':
+        return ISO_639_1_TO_2.get(lang_code, lang_code)
+    return lang_code
+
 # Patterns to strip from titles when strip_unabridged is enabled (Issue #92)
 UNABRIDGED_PATTERNS = [
     r'\s*\(Unabridged\)',
@@ -181,26 +225,35 @@ def format_author_fl(author: str) -> str:
     return f"{first} {last}"
 
 
-def format_language_tag(lang_code: str, lang_name: str = None, fmt: str = "bracket_full") -> str:
+def format_language_tag(lang_code: str, lang_name: str = None, fmt: str = "bracket_full",
+                        code_format: str = "iso639-1") -> str:
     """Format language tag based on user preference.
 
     Args:
         lang_code: ISO 639-1 language code (e.g., 'pl', 'ru')
         lang_name: Full language name (optional, will lookup from LANGUAGE_NAMES)
-        fmt: Tag format - "code", "full", "bracket_code", "bracket_full"
+        fmt: Tag format - "code", "full", "bracket_code", "bracket_full", "emoji_flag"
+        code_format: "iso639-1" (pl) or "iso639-2" (pol) for code-based formats
 
     Returns:
         Formatted tag string
     """
     name = lang_name or LANGUAGE_NAMES.get(lang_code, lang_code.upper())
+    display_code = lang_code_for_display(lang_code, code_format)
 
     if fmt == "code":
-        return f"_{lang_code}"
+        return f"_{display_code}"
     elif fmt == "full":
         return f" {name}"
     elif fmt == "bracket_code":
-        return f" [{lang_code}]"
+        return f" [{display_code}]"
     elif fmt == "bracket_full":
+        return f" ({name})"
+    elif fmt == "emoji_flag":
+        # Issue #282: compact flag emoji tag; fall back to name if unmapped
+        flag = LANGUAGE_FLAGS.get(lang_code)
+        if flag:
+            return f" {flag}"
         return f" ({name})"
     return ""
 
@@ -529,27 +582,35 @@ def build_new_path(lib_path, author, title, series=None, series_num=None, narrat
                 title_folder = f"{title_folder} ({safe_narrator})"
 
     # Multi-language naming: add language tag to title folder if enabled
-    # (subfolder position handled separately during path construction)
+    # (subfolder/top_folder positions handled separately during path construction)
     lang_subfolder = None  # Will be set if position is "subfolder"
+    lang_top_folder = None  # Will be set if position is "top_folder" (Issue #278)
     if config and language_code:
         preferred_lang = config.get('preferred_language', 'en')
         multilang_mode = config.get('multilang_naming_mode', 'native')
         tag_enabled = config.get('language_tag_enabled', False)
+        tag_format = config.get('language_tag_format', 'bracket_full')
+        tag_position = config.get('language_tag_position', 'after_title')
+        code_format = config.get('language_code_format', 'iso639-1')
 
         # Determine if we should add a tag
-        should_tag = (tag_enabled or multilang_mode == 'tagged') and language_code != preferred_lang
+        tag_requested = tag_enabled or multilang_mode == 'tagged'
+        should_tag = tag_requested and language_code != preferred_lang
 
-        if should_tag:
-            tag_format = config.get('language_tag_format', 'bracket_full')
-            tag_position = config.get('language_tag_position', 'after_title')
-
+        if tag_requested and tag_position == 'top_folder':
+            # Issue #278: Language/Author/Title structure. Applies to ALL books
+            # with a known language (including the preferred one) so the library
+            # is fully partitioned by language at the top level.
+            lang_name = language or LANGUAGE_NAMES.get(language_code, language_code.upper())
+            lang_top_folder = sanitize_path_component(lang_name)
+        elif should_tag:
             if tag_position == 'subfolder':
                 # Will create Author/Language/Title structure
                 lang_name = language or LANGUAGE_NAMES.get(language_code, language_code.upper())
                 lang_subfolder = sanitize_path_component(lang_name)
             else:
                 # Add tag to title folder
-                lang_tag = format_language_tag(language_code, language, tag_format)
+                lang_tag = format_language_tag(language_code, language, tag_format, code_format)
                 title_folder = apply_language_tag(title_folder, lang_tag, tag_position)
 
     if naming_format == 'custom':
@@ -617,8 +678,11 @@ def build_new_path(lib_path, author, title, series=None, series_num=None, narrat
         path_str = path_str.replace('{variant}', safe_variant)
         # Multi-language template tags
         safe_language = LANGUAGE_NAMES.get(language_code, language_code.upper()) if language_code else ''
+        tpl_code_format = config.get('language_code_format', 'iso639-1') if config else 'iso639-1'
         path_str = path_str.replace('{language}', safe_language)
-        path_str = path_str.replace('{lang_code}', language_code or '')
+        path_str = path_str.replace('{lang_code}', lang_code_for_display(language_code, tpl_code_format) if language_code else '')
+        # Issue #282: {lang_flag} - flag emoji for the book's language
+        path_str = path_str.replace('{lang_flag}', LANGUAGE_FLAGS.get(language_code, '') if language_code else '')
 
         # Clean up empty brackets/parens from missing optional data
         path_str = re.sub(r'\(\s*\)', '', path_str)  # Empty ()
@@ -685,6 +749,11 @@ def build_new_path(lib_path, author, title, series=None, series_num=None, narrat
         # Default: Author/Title (two-level)
         result_path = lib_path / safe_author / title_folder
 
+    # Issue #278: Language as top-level folder - wrap whatever structure the
+    # naming format produced inside a language folder (Language/Author/...)
+    if lang_top_folder:
+        result_path = Path(lib_path) / lang_top_folder / result_path.relative_to(lib_path)
+
     # CRITICAL SAFETY: Verify path is within library and has minimum depth
     try:
         # Resolve to absolute path
@@ -713,11 +782,15 @@ __all__ = [
     'find_existing_author_folder',
     'format_language_tag',
     'apply_language_tag',
+    'lang_code_for_display',
     'strip_unabridged_markers',
     'parse_author_name',
     'format_author_lf',
     'format_author_fl',
     'LANGUAGE_NAMES',
+    'LANGUAGE_FLAGS',
+    'ISO_639_1_TO_2',
+    'ISO_639_2_TO_1',
     'NAME_PREFIXES',
     'NAME_SUFFIXES',
 ]

--- a/library_manager/utils/path_safety.py
+++ b/library_manager/utils/path_safety.py
@@ -258,6 +258,46 @@ def format_language_tag(lang_code: str, lang_name: str = None, fmt: str = "brack
     return ""
 
 
+def format_languages_tag(lang_codes, fmt: str = "bracket_full",
+                         code_format: str = "iso639-1") -> str:
+    """Format a language tag for one or more languages (Issue #280).
+
+    Args:
+        lang_codes: Ordered list of ISO 639-1 codes, primary first
+        fmt: Tag format - "code", "full", "bracket_code", "bracket_full", "emoji_flag"
+        code_format: "iso639-1" (pl) or "iso639-2" (pol) for code-based formats
+
+    Returns:
+        Formatted tag string. Multiple languages are joined: names with ", "
+        (e.g. " (German, English)"), codes with "," (e.g. " [de,en]"), emoji
+        flags with a space (e.g. " 🇩🇪 🇬🇧"). A single language is
+        byte-identical to format_language_tag().
+
+        NOTE: "/" is deliberately NOT used as a separator - it is a path
+        separator on POSIX and would nest folders when the tag lands in a
+        directory name.
+    """
+    codes = [str(c).lower().strip() for c in (lang_codes or []) if c]
+    if len(codes) <= 1:
+        return format_language_tag(codes[0], fmt=fmt, code_format=code_format) if codes else ""
+
+    if fmt == "emoji_flag":
+        flags = [LANGUAGE_FLAGS.get(c) for c in codes]
+        if all(flags):
+            return " " + " ".join(flags)
+        # Fall back to joined names when any language has no flag
+        return f" ({', '.join(LANGUAGE_NAMES.get(c, c.upper()) for c in codes)})"
+    if fmt == "code":
+        return "_" + ",".join(lang_code_for_display(c, code_format) for c in codes)
+    if fmt == "full":
+        return " " + ", ".join(LANGUAGE_NAMES.get(c, c.upper()) for c in codes)
+    if fmt == "bracket_code":
+        return " [" + ",".join(lang_code_for_display(c, code_format) for c in codes) + "]"
+    if fmt == "bracket_full":
+        return " (" + ", ".join(LANGUAGE_NAMES.get(c, c.upper()) for c in codes) + ")"
+    return ""
+
+
 def apply_language_tag(title: str, tag: str, position: str) -> str:
     """Apply language tag to title in specified position.
 
@@ -482,7 +522,7 @@ def find_existing_author_folder(lib_path, target_author) -> Optional[str]:
 
 
 def build_new_path(lib_path, author, title, series=None, series_num=None, narrator=None, year=None,
-                   edition=None, variant=None, language=None, language_code=None, config=None):
+                   edition=None, variant=None, language=None, language_code=None, languages=None, config=None):
     """Build a new path based on the naming format configuration.
 
     Audiobookshelf-compatible format (when series_grouping enabled):
@@ -505,6 +545,9 @@ def build_new_path(lib_path, author, title, series=None, series_num=None, narrat
         variant: Variant info like "Graphic Audio" (optional)
         language: Full language name like "Russian" (optional)
         language_code: ISO 639-1 code like "ru" (optional)
+        languages: Ordered list of ISO 639-1 codes, primary first (optional,
+            Issue #280). When multiple languages are present and tagging
+            applies, the tag shows all of them (e.g. "(German/English)").
         config: Configuration dict
 
     SAFETY: Returns None if path would be invalid/dangerous.
@@ -610,7 +653,16 @@ def build_new_path(lib_path, author, title, series=None, series_num=None, narrat
                 lang_subfolder = sanitize_path_component(lang_name)
             else:
                 # Add tag to title folder
-                lang_tag = format_language_tag(language_code, language, tag_format, code_format)
+                # Issue #280: show all languages when the book is multi-language
+                lang_codes = []
+                for code in ([language_code] + list(languages or [])):
+                    normalized = str(code).lower().strip() if code else ''
+                    if normalized and normalized not in lang_codes:
+                        lang_codes.append(normalized)
+                if len(lang_codes) > 1:
+                    lang_tag = format_languages_tag(lang_codes, tag_format, code_format)
+                else:
+                    lang_tag = format_language_tag(language_code, language, tag_format, code_format)
                 title_folder = apply_language_tag(title_folder, lang_tag, tag_position)
 
     if naming_format == 'custom':
@@ -781,6 +833,7 @@ __all__ = [
     'build_new_path',
     'find_existing_author_folder',
     'format_language_tag',
+    'format_languages_tag',
     'apply_language_tag',
     'lang_code_for_display',
     'strip_unabridged_markers',

--- a/library_manager/utils/path_safety.py
+++ b/library_manager/utils/path_safety.py
@@ -547,13 +547,24 @@ def build_new_path(lib_path, author, title, series=None, series_num=None, narrat
         language_code: ISO 639-1 code like "ru" (optional)
         languages: Ordered list of ISO 639-1 codes, primary first (optional,
             Issue #280). When multiple languages are present and tagging
-            applies, the tag shows all of them (e.g. "(German/English)").
+            applies, the tag shows all of them (e.g. "(German, English)").
         config: Configuration dict
 
     SAFETY: Returns None if path would be invalid/dangerous.
     """
     naming_format = config.get('naming_format', 'author/title') if config else 'author/title'
     series_grouping = config.get('series_grouping', False) if config else False
+
+    # Defensive: callers may pass ISO 639-2 three-letter codes straight from
+    # metadata sources (Skaldleita emits 'eng', 'ger'). Normalize to 639-1 so
+    # name/flag/tag lookups work regardless of the caller.
+    if language_code and len(str(language_code).strip()) == 3:
+        language_code = ISO_639_2_TO_1.get(str(language_code).strip().lower(), language_code)
+    if languages:
+        languages = [
+            ISO_639_2_TO_1.get(str(c).strip().lower(), c) if c and len(str(c).strip()) == 3 else c
+            for c in languages
+        ]
 
     # Issue #125: Strip encoding/format junk before path building
     author = strip_encoding_junk(author)

--- a/templates/library.html
+++ b/templates/library.html
@@ -266,6 +266,13 @@
                     </div>
                     <small class="text-muted">Edit series info if it's missing or incorrect. Leave blank if not part of a series.</small>
                 </div>
+
+                <!-- Languages (Issue #280) -->
+                <div class="mb-2">
+                    <label class="form-label small text-muted"><i class="bi bi-translate"></i> Languages</label>
+                    <select class="form-select form-select-sm bg-dark text-light" id="edit-languages" multiple size="4"></select>
+                    <small class="text-muted">Ctrl/Cmd-click for multiple (bilingual books). First stored entry is the primary language; select none to fall back to auto-detection.</small>
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
@@ -1087,6 +1094,51 @@ setInterval(() => {
 let editBookModal = null;
 let selectedBookDBResult = null;
 
+// Issue #280: mirror of LANGUAGE_NAMES from library_manager/utils/path_safety.py
+const EDIT_LANGUAGES = {
+    en: 'English', de: 'German', fr: 'French', es: 'Spanish',
+    it: 'Italian', pt: 'Portuguese', nl: 'Dutch', sv: 'Swedish',
+    no: 'Norwegian', da: 'Danish', fi: 'Finnish', pl: 'Polish',
+    ru: 'Russian', ja: 'Japanese', zh: 'Chinese', ko: 'Korean',
+    ar: 'Arabic', he: 'Hebrew', hi: 'Hindi', tr: 'Turkish',
+    cs: 'Czech', hu: 'Hungarian', el: 'Greek', th: 'Thai',
+    vi: 'Vietnamese', uk: 'Ukrainian', ro: 'Romanian', id: 'Indonesian'
+};
+let editBookPrimaryLanguage = null;
+
+function loadEditLanguages(bookId) {
+    const sel = document.getElementById('edit-languages');
+    sel.innerHTML = Object.entries(EDIT_LANGUAGES)
+        .map(([code, name]) => `<option value="${code}">${name} (${code})</option>`)
+        .join('');
+    editBookPrimaryLanguage = null;
+    fetch(`/api/books/${bookId}/languages`)
+        .then(r => r.json())
+        .then(data => {
+            const langs = data.languages || [];
+            editBookPrimaryLanguage = langs[0] || null;
+            for (const opt of sel.options) {
+                opt.selected = langs.includes(opt.value);
+            }
+        })
+        .catch(() => {});
+}
+
+function saveBookLanguages(bookId) {
+    const sel = document.getElementById('edit-languages');
+    let selected = [...sel.selectedOptions].map(o => o.value);
+    // Keep the existing primary first when it is still selected (the API
+    // treats the first entry as primary); otherwise the first option wins.
+    if (editBookPrimaryLanguage && selected.includes(editBookPrimaryLanguage)) {
+        selected = [editBookPrimaryLanguage, ...selected.filter(c => c !== editBookPrimaryLanguage)];
+    }
+    return fetch(`/api/books/${bookId}/languages`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({languages: selected})
+    });
+}
+
 function editBook(bookId, author, title) {
     // Warn if processing is active (item may change before save)
     if (isProcessing && !suppressProcessingWarning) {
@@ -1105,6 +1157,7 @@ function editBook(bookId, author, title) {
     document.getElementById('edit-series-name').value = '';
     document.getElementById('edit-series-num').value = '';
     selectedBookDBResult = null;
+    loadEditLanguages(bookId);
 
     if (!editBookModal) {
         editBookModal = new bootstrap.Modal(document.getElementById('editBookModal'));
@@ -1242,9 +1295,11 @@ function saveBookEdit() {
     .then(r => r.json())
     .then(data => {
         if (data.success) {
-            editBookModal.hide();
-            addActivity('Book saved and locked!', 'success');
-            loadLibrary();
+            saveBookLanguages(bookId).finally(() => {
+                editBookModal.hide();
+                addActivity('Book saved and locked!', 'success');
+                loadLibrary();
+            });
         } else {
             alert('Error: ' + (data.error || 'Unknown error'));
         }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -146,7 +146,8 @@
                                         <button type="button" class="btn btn-sm btn-outline-success naming-tag" onclick="insertTag('{narrator}')">{narrator}</button>
                                         <button type="button" class="btn btn-sm btn-outline-secondary naming-tag" onclick="insertTag('{year}')">{year}</button>
                                         <button type="button" class="btn btn-sm btn-outline-primary naming-tag" onclick="insertTag('{language}')" title="Full language name: English, Russian, Polish">{language}</button>
-                                        <button type="button" class="btn btn-sm btn-outline-primary naming-tag" onclick="insertTag('{lang_code}')" title="ISO code: en, ru, pl">{lang_code}</button>
+                                        <button type="button" class="btn btn-sm btn-outline-primary naming-tag" onclick="insertTag('{lang_code}')" title="ISO code: en, ru, pl (or eng, rus, pol with ISO 639-2 code format)">{lang_code}</button>
+                                        <button type="button" class="btn btn-sm btn-outline-primary naming-tag" onclick="insertTag('{lang_flag}')" title="Flag emoji: 🇬🇧, 🇷🇺, 🇵🇱">{lang_flag}</button>
                                     </div>
                                     <small class="text-muted d-block mt-1"><i class="bi bi-info-circle"></i> Use <code>.pad(N)</code> for zero-padding: <code>{series_num.pad(2)}</code> → 01, 02... 10</small>
                                     <small class="text-muted d-block"><i class="bi bi-info-circle"></i> Author formats: <code>{author_lf}</code> → "Sanderson, Brandon", <code>{author_last}</code> → "Sanderson", <code>{author_first}</code> → "Brandon"</small>
@@ -230,6 +231,7 @@
                                                 <option value="bracket_code" {% if config.language_tag_format == 'bracket_code' %}selected{% endif %}>[pl]</option>
                                                 <option value="full" {% if config.language_tag_format == 'full' %}selected{% endif %}>Polish</option>
                                                 <option value="code" {% if config.language_tag_format == 'code' %}selected{% endif %}>_pl</option>
+                                                <option value="emoji_flag" {% if config.language_tag_format == 'emoji_flag' %}selected{% endif %}>🇵🇱</option>
                                             </select>
                                         </div>
                                         <div class="col-6">
@@ -238,6 +240,16 @@
                                                 <option value="after_title" {% if config.language_tag_position == 'after_title' or not config.language_tag_position %}selected{% endif %}>After Title</option>
                                                 <option value="before_title" {% if config.language_tag_position == 'before_title' %}selected{% endif %}>Before Title</option>
                                                 <option value="subfolder" {% if config.language_tag_position == 'subfolder' %}selected{% endif %}>Subfolder</option>
+                                                <option value="top_folder" {% if config.language_tag_position == 'top_folder' %}selected{% endif %}>Top-Level Folder</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="row g-2 mt-1">
+                                        <div class="col-6">
+                                            <label class="form-label small mb-1">Code Format</label>
+                                            <select class="form-select form-select-sm bg-dark text-light" name="language_code_format" id="language_code_format" onchange="updateLanguageTagPreview()">
+                                                <option value="iso639-1" {% if config.language_code_format == 'iso639-1' or not config.language_code_format %}selected{% endif %}>ISO 639-1 (pl)</option>
+                                                <option value="iso639-2" {% if config.language_code_format == 'iso639-2' %}selected{% endif %}>ISO 639-2 (pol)</option>
                                             </select>
                                         </div>
                                     </div>
@@ -1849,16 +1861,20 @@ function toggleLanguageTagOptions() {
 function updateLanguageTagPreview() {
     const format = document.getElementById('language_tag_format').value;
     const position = document.getElementById('language_tag_position').value;
+    const codeFormatEl = document.getElementById('language_code_format');
+    const codeFormat = codeFormatEl ? codeFormatEl.value : 'iso639-1';
     const previewEl = document.getElementById('language-tag-preview');
     if (!previewEl) return;
 
     // Build tag based on format
+    const code = codeFormat === 'iso639-2' ? 'rus' : 'ru';
     let tag = '';
     switch (format) {
         case 'bracket_full': tag = ' (Russian)'; break;
-        case 'bracket_code': tag = ' [ru]'; break;
+        case 'bracket_code': tag = ' [' + code + ']'; break;
         case 'full': tag = ' Russian'; break;
-        case 'code': tag = '_ru'; break;
+        case 'code': tag = '_' + code; break;
+        case 'emoji_flag': tag = ' 🇷🇺'; break;
     }
 
     // Build preview based on position
@@ -1867,6 +1883,7 @@ function updateLanguageTagPreview() {
         case 'after_title': preview = 'Author/Title' + tag + '/'; break;
         case 'before_title': preview = 'Author/' + tag.trim() + ' Title/'; break;
         case 'subfolder': preview = 'Author/Russian/Title/'; break;
+        case 'top_folder': preview = 'Russian/Author/Title/'; break;
     }
     previewEl.textContent = preview;
 }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -258,6 +258,41 @@
                                     </div>
                                 </div>
                             </div>
+
+                            <hr class="my-3">
+
+                            <!-- Series Language Overrides (Issue #281) -->
+                            <div class="mb-3">
+                                <label class="form-label">
+                                    <i class="bi bi-lock text-primary"></i>
+                                    <strong>Series Language Overrides</strong>
+                                    <span class="hint-icon" aria-label="Help">?<span class="hint-text">{{ hints.series_language_override }}</span></span>
+                                </label>
+                                <small class="text-muted d-block mb-2">
+                                    Lock a series to a fixed language (e.g. "Mistborn" &rarr; German). The locked language
+                                    overrides audio/title detection for every book in that series. Matching is case-insensitive.
+                                </small>
+                                <div id="series-language-overrides-list" class="mb-2">
+                                    <small class="text-muted">Loading...</small>
+                                </div>
+                                <div class="row g-2 align-items-center">
+                                    <div class="col-5">
+                                        <input type="text" class="form-control form-control-sm bg-dark text-light"
+                                               id="series-override-name" placeholder="Series name">
+                                    </div>
+                                    <div class="col-4">
+                                        <select class="form-select form-select-sm bg-dark text-light" id="series-override-language">
+                                            <option value="auto">Auto (detect)</option>
+                                            {% for code, name in language_names.items() %}
+                                            <option value="{{ code }}">{{ name }} ({{ code }})</option>
+                                            {% endfor %}
+                                        </select>
+                                    </div>
+                                    <div class="col-3">
+                                        <button type="button" class="btn btn-sm btn-outline-primary w-100" onclick="addSeriesLanguageOverride()">Add</button>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -1600,7 +1635,54 @@ document.addEventListener('DOMContentLoaded', function() {
     toggleLayer4Settings();
     updateNamingPreview();
     refreshLogs();
+    loadSeriesLanguageOverrides();
 });
+
+// Series Language Overrides (Issue #281)
+function loadSeriesLanguageOverrides() {
+    const listEl = document.getElementById('series-language-overrides-list');
+    if (!listEl) return;
+    fetch('/api/series-language-overrides').then(r => r.json()).then(data => {
+        const overrides = (data && data.overrides) || [];
+        if (overrides.length === 0) {
+            listEl.innerHTML = '<small class="text-muted">No overrides set - all series use automatic detection.</small>';
+            return;
+        }
+        listEl.innerHTML = overrides.map(o =>
+            `<div class="d-flex justify-content-between align-items-center border border-secondary rounded px-2 py-1 mb-1">` +
+            `<span>${escapeHtml(o.series_name)} <span class="badge bg-secondary">${escapeHtml(o.language_code)}</span></span>` +
+            `<button type="button" class="btn btn-sm btn-outline-danger py-0" onclick="removeSeriesLanguageOverride('${encodeURIComponent(o.series_name)}')">` +
+            `<i class="bi bi-x"></i></button></div>`
+        ).join('');
+    }).catch(e => { listEl.innerHTML = `<small class="text-danger">Error loading overrides: ${escapeHtml(String(e))}</small>`; });
+}
+
+function addSeriesLanguageOverride() {
+    const name = document.getElementById('series-override-name').value.trim();
+    const code = document.getElementById('series-override-language').value;
+    if (!name) return;
+    fetch('/api/series-language-overrides', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({series_name: name, language_code: code})
+    }).then(r => r.json()).then(data => {
+        if (data.success) {
+            document.getElementById('series-override-name').value = '';
+            loadSeriesLanguageOverrides();
+        } else {
+            alert(data.error || 'Failed to save override');
+        }
+    }).catch(e => alert('Failed to save override: ' + e));
+}
+
+function removeSeriesLanguageOverride(encodedName) {
+    fetch('/api/series-language-overrides', {
+        method: 'DELETE',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({series_name: decodeURIComponent(encodedName)})
+    }).then(r => r.json()).then(() => loadSeriesLanguageOverrides())
+        .catch(e => alert('Failed to remove override: ' + e));
+}
 
 function dismissHowItWorks() {
     localStorage.setItem('hideHowItWorks', 'true');

--- a/test-env/e2e-language-features.py
+++ b/test-env/e2e-language-features.py
@@ -1,0 +1,625 @@
+"""End-to-end test for the language naming pack, inside the quarantined container.
+
+Covers:
+- #278 language_tag_position=top_folder (Language/Author/Title)
+- #282 language_tag_format=emoji_flag + preview
+- #279 language_code_format select presence
+- #281 series language overrides (settings UI + API + pipeline hard override)
+- #280 per-book languages list (API + library edit modal)
+
+Flow: verify settings UI, change language tag settings, save via the real UI,
+add a "Dune" -> German series override, process a messy Dune copy end-to-end,
+verify the fix lands under a German/ top folder, exercise the book languages
+API + edit modal, then clean up everything it touched.
+"""
+import json
+import shutil
+import sqlite3
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "http://127.0.0.1:5757"
+APP_DIR = Path("/opt/library-manager")
+LIBRARY_PATH = Path("/opt/test-library")
+SOURCE_BOOK = LIBRARY_PATH / "Frank Herbert" / "Dune (Scott Brick) (ENG)" / "audiobook.mp3"
+TEST_FOLDER = LIBRARY_PATH / "[ messy ] Herbert, Frank - Doon2 (audio)"
+TEST_AUDIO = TEST_FOLDER / "audiobook.mp3"
+NESTED_PARENT = LIBRARY_PATH / "Frank, Herbert" / "Dune Series 01"
+NESTED_FOLDER = NESTED_PARENT / "[ messy ] Herbert, Frank - Doon2 (audio)"
+CANONICAL_FOLDER = LIBRARY_PATH / "Frank Herbert" / "Dune (Scott Brick) (ENG)"
+DB_PATH = APP_DIR / "library.db"
+CONFIG_FILES = [APP_DIR / "config.json", APP_DIR / "data" / "config.json"]
+SCREENSHOT_DIR = APP_DIR / "test-screenshots"
+MAX_WAIT_SECONDS = 300
+
+FAILURES = []
+
+
+def check(ok, msg):
+    """Record a PASS/FAIL line."""
+    if ok:
+        print(f"[PASS] {msg}")
+    else:
+        print(f"[FAIL] {msg}")
+        FAILURES.append(msg)
+
+
+def info(msg):
+    print(f"[INFO] {msg}")
+
+
+def api_request(method, path, payload=None, timeout=30):
+    """Small JSON API helper. Returns (status, parsed_json_or_None)."""
+    data = json.dumps(payload).encode() if payload is not None else (b"" if method in ("POST", "DELETE") else None)
+    req = urllib.request.Request(f"{BASE_URL}{path}", method=method, data=data)
+    if payload is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode()
+            return resp.status, json.loads(body) if body else None
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        try:
+            return e.code, json.loads(body)
+        except (ValueError, json.JSONDecodeError):
+            return e.code, None
+    except Exception as e:
+        info(f"API {method} {path} failed: {e}")
+        return None, None
+
+
+def force_open_library_tab(page):
+    """Force the Settings Library tab pane visible (Bootstrap tabs are flaky headless)."""
+    page.evaluate("""() => {
+        document.querySelectorAll('.tab-pane').forEach(p => { p.classList.remove('show', 'active'); p.style.display = 'none'; });
+        document.querySelectorAll('.nav-link').forEach(l => { l.classList.remove('active'); l.setAttribute('aria-selected', 'false'); });
+        const tab = document.querySelector('button[data-bs-target="#tab-library"]');
+        if (tab) { tab.classList.add('active'); tab.setAttribute('aria-selected', 'true'); }
+        const pane = document.getElementById('tab-library');
+        if (pane) { pane.classList.add('show', 'active'); pane.style.display = 'block'; }
+    }""")
+    time.sleep(0.3)
+
+
+def db_query(sql, params=()):
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(sql, params).fetchall()
+    conn.close()
+    return rows
+
+
+def db_execute(sql, params=()):
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(sql, params)
+    conn.commit()
+    conn.close()
+
+
+def delete_book_records(path_like):
+    """Remove books/history/queue rows referencing a path prefix."""
+    rows = db_query("SELECT id FROM books WHERE path LIKE ?", (path_like,))
+    for row in rows:
+        bid = row['id']
+        db_execute("DELETE FROM history WHERE book_id = ?", (bid,))
+        db_execute("DELETE FROM queue WHERE book_id = ?", (bid,))
+        db_execute("DELETE FROM books WHERE id = ?", (bid,))
+    db_execute("DELETE FROM history WHERE old_path LIKE ? OR new_path LIKE ?", (path_like, path_like))
+    return [r['id'] for r in rows]
+
+
+def wait_for_book_state(test_folder, status_targets, timeout=MAX_WAIT_SECONDS):
+    """Poll the DB until the messy test book reaches one of the target statuses."""
+    started = time.time()
+    while time.time() - started < timeout:
+        rows = db_query(
+            "SELECT id, current_author, current_title, status, verification_layer, profile "
+            "FROM books WHERE path LIKE ?", (str(test_folder) + '%',))
+        if rows and rows[0]['status'] in status_targets:
+            return dict(rows[0])
+        time.sleep(5)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Phase 1-4: browser-based settings UI tests
+# ---------------------------------------------------------------------------
+
+def phase_settings_ui():
+    info("Phase 1: Settings UI - language naming controls")
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(viewport={"width": 1280, "height": 1000})
+        page = context.new_page()
+        page.on("dialog", lambda d: d.accept())
+
+        page.goto(f"{BASE_URL}/settings", wait_until="networkidle", timeout=30000)
+        force_open_library_tab(page)
+        page.screenshot(path=str(SCREENSHOT_DIR / "e2e-lang-01-settings-library-tab.png"), full_page=True)
+
+        # New options/selects exist
+        fmt_options = page.eval_on_selector_all(
+            "#language_tag_format option", "els => els.map(e => e.value)")
+        check('emoji_flag' in fmt_options, f"#language_tag_format has emoji_flag option (got {fmt_options})")
+        pos_options = page.eval_on_selector_all(
+            "#language_tag_position option", "els => els.map(e => e.value)")
+        check('top_folder' in pos_options, f"#language_tag_position has top_folder option (got {pos_options})")
+        check(page.locator("#language_code_format").count() == 1, "#language_code_format select exists")
+        check(page.locator("#series-language-overrides-list").count() == 1
+              and page.locator("#series-override-name").count() == 1,
+              "Series Language Overrides card present")
+
+        # Phase 2: enable tags, set emoji_flag + top_folder, check preview
+        info("Phase 2: enable Add Language Tags, set emoji_flag + top_folder")
+        page.evaluate("""() => {
+            const cb = document.getElementById('language_tag_enabled');
+            if (!cb.checked) { cb.checked = true; }
+            cb.dispatchEvent(new Event('change', { bubbles: true }));
+        }""")
+        time.sleep(0.3)
+
+        # First verify the flag renders in the preview with after_title position
+        page.evaluate("""() => {
+            const fmt = document.getElementById('language_tag_format');
+            fmt.value = 'emoji_flag';
+            fmt.dispatchEvent(new Event('change', { bubbles: true }));
+        }""")
+        time.sleep(0.3)
+        preview_flag = page.locator("#language-tag-preview").text_content()
+        check('🇷🇺' in preview_flag, f"emoji_flag preview contains flag: {preview_flag!r}")
+
+        # Now switch to top_folder and check the Language/Author/Title preview
+        page.evaluate("""() => {
+            const pos = document.getElementById('language_tag_position');
+            pos.value = 'top_folder';
+            pos.dispatchEvent(new Event('change', { bubbles: true }));
+        }""")
+        time.sleep(0.3)
+        preview_top = page.locator("#language-tag-preview").text_content()
+        check('Russian/Author/Title/' in preview_top,
+              f"top_folder preview is Language/Author/Title: {preview_top!r}")
+        if '🇷🇺' not in preview_top:
+            info("Note: top_folder preview does not render the flag emoji "
+                 "(top folder uses full language name regardless of tag format)")
+        page.screenshot(path=str(SCREENSHOT_DIR / "e2e-lang-02-tag-preview.png"), full_page=True)
+
+        # Phase 3: save via the real UI save button, verify persistence
+        info("Phase 3: save settings via UI")
+        # Keep background processing enabled - saving the form with it unchecked
+        # would disable the pipeline needed for phase 5.
+        page.evaluate("""() => {
+            const en = document.getElementById('enabled');
+            if (en && !en.checked) { en.checked = true; }
+        }""")
+        mtimes_before = {str(f): f.stat().st_mtime for f in CONFIG_FILES if f.exists()}
+
+        with page.expect_navigation(wait_until="networkidle", timeout=30000):
+            page.locator("button:has-text('Save Settings')").click()
+
+        mtimes_after = {str(f): f.stat().st_mtime for f in CONFIG_FILES if f.exists()}
+        changed = [p for p in mtimes_after if mtimes_after[p] != mtimes_before.get(p)]
+        info(f"Config files written by UI save: {changed or 'NONE'}")
+        check(len(changed) > 0, "UI save wrote at least one config file")
+        for f in CONFIG_FILES:
+            info(f"  {f}: mtime {mtimes_before.get(str(f))} -> {mtimes_after.get(str(f))}")
+
+        # Reload and verify the selects kept the new values
+        page.goto(f"{BASE_URL}/settings", wait_until="networkidle", timeout=30000)
+        force_open_library_tab(page)
+        saved_fmt = page.locator("#language_tag_format").input_value()
+        saved_pos = page.locator("#language_tag_position").input_value()
+        saved_enabled = page.locator("#language_tag_enabled").is_checked()
+        check(saved_fmt == 'emoji_flag', f"language_tag_format persisted as emoji_flag (got {saved_fmt})")
+        check(saved_pos == 'top_folder', f"language_tag_position persisted as top_folder (got {saved_pos})")
+        check(saved_enabled, "language_tag_enabled persisted as checked")
+        page.screenshot(path=str(SCREENSHOT_DIR / "e2e-lang-03-settings-saved.png"), full_page=True)
+
+        # Phase 4: add series override "Dune" -> German via the UI
+        info("Phase 4: add series override Dune -> de via UI")
+        page.locator("#series-override-name").fill("Dune")
+        page.locator("#series-override-language").select_option("de")
+        page.locator("button:has-text('Add')").first.click()
+        # Wait for the overrides list to re-render with the new entry
+        try:
+            page.wait_for_function(
+                """() => document.getElementById('series-language-overrides-list')
+                        .textContent.includes('Dune')""",
+                timeout=10000)
+            check(True, "Series override 'Dune' appears in the UI list")
+        except Exception:
+            check(False, "Series override 'Dune' did not appear in the UI list")
+        page.screenshot(path=str(SCREENSHOT_DIR / "e2e-lang-04-series-override.png"), full_page=True)
+
+        browser.close()
+
+    # API verification of the override
+    status, data = api_request("GET", "/api/series-language-overrides")
+    overrides = (data or {}).get('overrides', [])
+    match = [o for o in overrides
+             if o.get('series_name', '').lower() == 'dune' and o.get('language_code') == 'de']
+    check(bool(match), f"API lists Dune -> de override (got {overrides})")
+
+
+# ---------------------------------------------------------------------------
+# Phase 5a: deterministic check that the override mechanism reaches language
+# resolution and path building (uses the app's own code with the live DB
+# override set in phase 4, independent of fixture metadata containing a series)
+# ---------------------------------------------------------------------------
+
+def phase_override_mechanism():
+    info("Phase 5a: verify override mechanism reaches language resolution + path building")
+    from library_manager import database as app_db
+    from library_manager.pipeline.layer_audio_id import _resolve_metadata_language
+    from library_manager.utils.path_safety import build_new_path
+    from library_manager.config import load_config
+
+    # database module keeps its own global db path (normally set by the app at
+    # startup); without this, get_series_language_override() silently misses.
+    app_db.set_db_path(str(DB_PATH))
+
+    config = load_config()
+    check(config.get('language_tag_position') == 'top_folder',
+          f"config language_tag_position is top_folder (got {config.get('language_tag_position')!r})")
+
+    # Hard override: with Dune -> de set, resolution must return 'de' without detection
+    resolved = _resolve_metadata_language(None, 'Dune', config, series_name='Dune')
+    check(resolved == 'de',
+          f"series override wins in _resolve_metadata_language (got {resolved!r}, expected 'de')")
+
+    # The resolved language must produce a German/ top folder
+    path_de = build_new_path(LIBRARY_PATH, 'Frank Herbert', 'Dune',
+                             series='Dune', language_code='de', config=config)
+    top_de = Path(path_de).relative_to(LIBRARY_PATH).parts[0] if path_de else None
+    check(top_de == 'German',
+          f"override language reaches path building: de -> German/ top folder (got {top_de!r})")
+
+    # ISO 639-2 codes (what Skaldleita emits, e.g. 'eng') must normalize to 'en'
+    path_eng = build_new_path(LIBRARY_PATH, 'Frank Herbert', 'Dune',
+                              language_code='eng', config=config)
+    top_eng = Path(path_eng).relative_to(LIBRARY_PATH).parts[0] if path_eng else None
+    check(top_eng == 'English',
+          f"PRODUCT BUG if failed: ISO 639-2 'eng' should map to 'English' top folder (got {top_eng!r})")
+
+
+# ---------------------------------------------------------------------------
+# Phase 5b: processing E2E with top_folder + series override
+# ---------------------------------------------------------------------------
+
+def clean_library_artifacts():
+    """Remove leftovers from previous runs (messy folders + language trees)."""
+    for folder in (TEST_FOLDER, NESTED_FOLDER):
+        if folder.exists():
+            shutil.rmtree(folder)
+        delete_book_records(str(folder) + '%')
+    if NESTED_PARENT.exists():
+        delete_book_records(str(NESTED_PARENT) + '%')
+        shutil.rmtree(NESTED_PARENT)
+    for lang_dir in ("German", "ENG", "English"):
+        lang_root = LIBRARY_PATH / lang_dir
+        if lang_root.exists():
+            delete_book_records(str(lang_root) + '%')
+            shutil.rmtree(lang_root)
+            info(f"Removed leftover {lang_dir}/ tree from a previous run")
+    # Nested parents from previous runs
+    for parent in (NESTED_PARENT, NESTED_PARENT.parent):
+        delete_book_records(str(parent) + '%')
+        if parent.exists() and parent != LIBRARY_PATH:
+            shutil.rmtree(parent)
+
+
+def run_processing_scenario(test_folder, label, expect_detected, expect_top,
+                            override_needs_series=False):
+    """Copy the Dune audio into test_folder, process it, apply the fix, and
+    verify the resolved language and the language top folder.
+
+    override_needs_series: when True, the expect_* checks are tied to a series
+    override firing; if the identification metadata carries no series (fixture
+    limitation), those checks are skipped with an INFO instead of failing.
+
+    Returns (book_row_dict, final_path) or (book_row_dict, None).
+    """
+    info(f"Processing scenario [{label}]: {test_folder}")
+    test_audio = test_folder / "audiobook.mp3"
+
+    # Prepare messy copy with stripped tags
+    if test_folder.exists():
+        shutil.rmtree(test_folder)
+    delete_book_records(str(test_folder) + '%')
+    test_folder.mkdir(parents=True)
+    shutil.copy2(SOURCE_BOOK, test_audio)
+    from mutagen.mp3 import MP3
+    audio = MP3(str(test_audio))
+    if audio.tags:
+        audio.tags.clear()
+        audio.save()
+    info(f"Copied and stripped test audio to {test_audio}")
+
+    # Trigger scan + background processing
+    info("Triggering library scan...")
+    api_request("POST", "/api/scan")
+    info("Starting background processing...")
+    api_request("POST", "/api/process_background")
+
+    info("Waiting for book to reach pending_fix or verified...")
+    book = wait_for_book_state(test_folder, {"pending_fix", "verified"})
+    if not book:
+        check(False, f"[{label}] messy book did not reach pending_fix or verified within timeout")
+        return None, None
+
+    info(f"Book state: {book['status']} (layer {book['verification_layer']}, "
+         f"author={book['current_author']!r}, title={book['current_title']!r})")
+    profile = json.loads(book['profile'] or '{}')
+
+    detected = profile.get('detected_language') or (profile.get('language') or {}).get('value')
+    series_profile = (profile.get('series') or {}).get('value') if isinstance(
+        profile.get('series'), dict) else profile.get('series')
+    info(f"Profile: detected_language={profile.get('detected_language')!r}, "
+         f"language={profile.get('language')!r}, series={series_profile!r}")
+    override_missed = override_needs_series and not series_profile
+    if override_missed:
+        info(f"[{label}] identification metadata carries no series - the "
+             "series override cannot fire (fixture/server data limitation); "
+             "skipping override-dependent checks")
+    if expect_detected and not override_missed:
+        check(detected == expect_detected,
+              f"[{label}] language resolution yields {expect_detected!r} "
+              f"(detected={detected!r}, series={series_profile!r})")
+
+    # Apply the fix
+    hist_rows = db_query(
+        "SELECT id FROM history WHERE book_id = ? AND status = 'pending_fix' "
+        "ORDER BY id DESC LIMIT 1", (book['id'],))
+    if not hist_rows:
+        info("No pending_fix history entry; book may already be verified in place")
+        return book, None
+
+    history_id = hist_rows[0]['id']
+    info(f"Applying fix (history id {history_id})...")
+    status, result = api_request("POST", f"/api/apply_fix/{history_id}", timeout=60)
+    if not (result and result.get('success')):
+        check(False, f"[{label}] apply_fix failed: status={status} result={result}")
+        return book, None
+    info(f"apply_fix result: {result}")
+
+    rows = db_query("SELECT path FROM books WHERE id = ?", (book['id'],))
+    if not rows or not rows[0]['path']:
+        check(False, f"[{label}] book has no path after apply_fix")
+        return book, None
+    final_path = Path(rows[0]['path'])
+    info(f"Final path: {final_path}")
+
+    try:
+        rel = final_path.relative_to(LIBRARY_PATH)
+        top_component = rel.parts[0]
+    except ValueError:
+        top_component = None
+        check(False, f"[{label}] final path {final_path} is outside the library")
+    if top_component:
+        if not override_missed:
+            check(top_component == expect_top,
+                  f"[{label}] final path starts with language folder {expect_top!r} "
+                  f"(got {top_component!r})")
+        check(final_path.exists(), f"[{label}] final path exists on disk: {final_path}")
+        check(any(final_path.glob("*.mp3")) or any(final_path.glob("*.m4b")),
+              f"[{label}] final folder contains an audio file")
+
+    return book, final_path
+
+
+def phase_processing():
+    """Two live processing scenarios with top_folder active.
+
+    A) Flat messy folder (as prescribed): the Skaldleita fixture record for
+       this Dune audio carries series=null, so the Dune=de override has no
+       series to match and cannot fire; language falls back to the Skaldleita
+       hint 'eng' (ISO 639-2). Expectation if the product were correct:
+       override wins (German) - failing that, the folder must at least be the
+       proper language name 'English', not the raw code 'ENG'.
+    B) Messy folder nested under 'Frank, Herbert/Dune Series 01/': path
+       completion (#127) supplies series='Dune Series', the matching override
+       'Dune Series'=de must fire live, and the book must land under German/.
+    """
+    info("Phase 5b: live processing E2E with top_folder")
+
+    # Scenario A: flat messy folder, series-less fixture
+    book_a, path_a = run_processing_scenario(
+        TEST_FOLDER, "flat/series-less", expect_detected='de', expect_top='German',
+        override_needs_series=True)
+    if book_a:
+        profile = json.loads(book_a['profile'] or '{}')
+        detected = profile.get('detected_language')
+        series_profile = profile.get('series')
+        if detected != 'de' and not series_profile:
+            info("Override did not fire in scenario A: identification metadata carries "
+                 "no series for this fixture (Skaldleita identify_audio returns "
+                 "series=null for the Dune record), so the Dune=de override had "
+                 "nothing to match. Override wiring is verified in phase 5a and "
+                 "scenario B; this is a fixture/server data limitation.")
+            if detected and detected not in ('de',):
+                # The folder must still be a proper language NAME for whatever
+                # language was detected (ISO 639-2 codes must be normalized).
+                from library_manager.utils.path_safety import ISO_639_2_TO_1, LANGUAGE_NAMES
+                normalized = ISO_639_2_TO_1.get(detected, detected)
+                expected_name = LANGUAGE_NAMES.get(normalized)
+                if path_a and expected_name:
+                    actual_top = Path(path_a).relative_to(LIBRARY_PATH).parts[0]
+                    check(actual_top == expected_name,
+                          f"[flat/series-less] PRODUCT BUG if failed: detected {detected!r} "
+                          f"should produce top folder {expected_name!r} (got {actual_top!r})")
+
+    # Scenario B: nested folder supplies the series via path completion
+    api_request("POST", "/api/series-language-overrides",
+                {"series_name": "Dune Series", "language_code": "de"})
+    book_b, path_b = run_processing_scenario(
+        NESTED_FOLDER, "nested/series-from-path", expect_detected='de', expect_top='German')
+
+    return (book_b or book_a), (path_b or path_a)
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: per-book languages API + library edit modal
+# ---------------------------------------------------------------------------
+
+def phase_book_languages(book):
+    info("Phase 6: per-book languages API + edit modal")
+    if not book:
+        check(False, "No processed book available for languages test")
+        return
+    book_id = book['id']
+
+    status, data = api_request("POST", f"/api/books/{book_id}/languages",
+                               {"languages": ["de", "en"]})
+    check(status == 200 and data and data.get('success'),
+          f"POST languages ['de','en'] succeeded (status={status}, body={data})")
+
+    status, data = api_request("GET", f"/api/books/{book_id}/languages")
+    langs = (data or {}).get('languages')
+    check(langs == ['de', 'en'], f"GET languages returns ordered ['de','en'] (got {langs})")
+
+    # Library edit modal must show both selected
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(viewport={"width": 1280, "height": 1000})
+        page = context.new_page()
+        page.on("dialog", lambda d: d.accept())
+        page.goto(f"{BASE_URL}/library", wait_until="networkidle", timeout=30000)
+
+        opened = page.evaluate(
+            """(bid) => {
+                if (typeof editBook !== 'function') return 'editBook not defined';
+                editBook(bid, 'Frank Herbert', 'Dune');
+                return null;
+            }""", book_id)
+        if opened:
+            check(False, f"Could not open edit modal: {opened}")
+            browser.close()
+            return
+
+        try:
+            # Wait until the async language fetch marks both options selected
+            page.wait_for_function(
+                """() => {
+                    const sel = document.getElementById('edit-languages');
+                    if (!sel || sel.options.length === 0) return false;
+                    const selVals = Array.from(sel.selectedOptions).map(o => o.value);
+                    return selVals.includes('de') && selVals.includes('en');
+                }""",
+                timeout=10000)
+            check(True, "Edit modal Languages multi-select shows de + en selected")
+        except Exception:
+            selected = page.evaluate(
+                """() => Array.from(document.getElementById('edit-languages').selectedOptions)
+                        .map(o => o.value)""")
+            check(False, f"Edit modal Languages multi-select did not show de+en (selected={selected})")
+
+        # Make sure the modal is visible for the screenshot
+        try:
+            page.wait_for_selector("#editBookModal.show", timeout=5000)
+        except Exception:
+            pass
+        page.screenshot(path=str(SCREENSHOT_DIR / "e2e-lang-05-edit-book-languages.png"), full_page=True)
+        browser.close()
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+def cleanup(config_backups, final_path, book_ids):
+    info("Cleanup: restoring configs, removing overrides and test artifacts")
+
+    # Remove the series overrides via the API
+    for name in ("Dune", "Dune Series"):
+        status, data = api_request("DELETE", "/api/series-language-overrides",
+                                   {"series_name": name})
+        check(status == 200 and data and data.get('success'),
+              f"Series override {name!r} removed (status={status}, body={data})")
+
+    # Restore both config backups
+    for original, backup in config_backups.items():
+        if backup.exists():
+            shutil.copy2(backup, original)
+            backup.unlink()
+            info(f"Restored {original}")
+
+    # Remove the messy test folders and their DB records
+    for folder in (TEST_FOLDER, NESTED_FOLDER):
+        if folder.exists():
+            shutil.rmtree(folder)
+        delete_book_records(str(folder) + '%')
+    # Also remove the nested parents (the scanner registers the series-pattern
+    # dir as a 'series_folder' record, and may do so again mid-run)
+    for parent in (NESTED_PARENT, NESTED_PARENT.parent):
+        delete_book_records(str(parent) + '%')
+        if parent.exists() and parent != LIBRARY_PATH:
+            shutil.rmtree(parent)
+            info(f"Removed nested test parent {parent}")
+
+    # Remove the language-folder destination trees produced by apply_fix
+    for bid in book_ids:
+        db_execute("DELETE FROM history WHERE book_id = ?", (bid,))
+        db_execute("DELETE FROM queue WHERE book_id = ?", (bid,))
+        db_execute("DELETE FROM books WHERE id = ?", (bid,))
+    for lang_dir in ("German", "ENG", "English"):
+        lang_root = LIBRARY_PATH / lang_dir
+        if lang_root.exists():
+            delete_book_records(str(lang_root) + '%')
+            shutil.rmtree(lang_root)
+            info(f"Removed test destination tree {lang_root}")
+
+    # Sanity: canonical known-good folder must still be there
+    check(SOURCE_BOOK.exists(), f"canonical source book intact: {SOURCE_BOOK}")
+    if final_path and str(final_path).startswith(str(CANONICAL_FOLDER)):
+        info("WARN: final path overlapped the canonical folder - manual check advised")
+
+
+def main():
+    SCREENSHOT_DIR.mkdir(exist_ok=True)
+
+    # Back up BOTH config files before touching anything
+    config_backups = {}
+    for f in CONFIG_FILES:
+        if f.exists():
+            backup = f.with_name(f.name + ".e2e-bak")
+            shutil.copy2(f, backup)
+            config_backups[f] = backup
+            info(f"Backed up {f} -> {backup}")
+
+    book = None
+    final_path = None
+    book_ids = []
+    try:
+        clean_library_artifacts()
+        phase_settings_ui()
+        phase_override_mechanism()
+        book, final_path = phase_processing()
+        if book:
+            book_ids.append(book['id'])
+        phase_book_languages(book)
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        check(False, f"Unexpected exception: {e}")
+    finally:
+        try:
+            cleanup(config_backups, final_path, book_ids)
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            check(False, f"Cleanup failed: {e}")
+
+    if FAILURES:
+        print("\nFAILURES:")
+        for f in FAILURES:
+            print(f"  - {f}")
+        sys.exit(1)
+    print("\nLanguage features E2E test passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/test-env/test-language-features.py
+++ b/test-env/test-language-features.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+Tests for language naming features:
+- Issue #278: language as top-level folder (top_folder position)
+- Issue #282: emoji flag language tags (emoji_flag format, {lang_flag} tag)
+- Issue #279: ISO 639-2 three-letter codes (language_code_format)
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import tempfile
+from pathlib import Path
+
+from library_manager.utils.path_safety import (
+    build_new_path,
+    format_language_tag,
+    lang_code_for_display,
+    LANGUAGE_FLAGS,
+    ISO_639_1_TO_2,
+    ISO_639_2_TO_1,
+)
+
+
+def test_result(name, passed, details=""):
+    status = "\033[92mPASS\033[0m" if passed else "\033[91mFAIL\033[0m"
+    print(f"[{status}] {name}")
+    if details and not passed:
+        print(f"       {details}")
+    return passed
+
+
+def main():
+    passed = 0
+    failed = 0
+
+    def check(name, cond, details=""):
+        nonlocal passed, failed
+        if test_result(name, cond, details):
+            passed += 1
+        else:
+            failed += 1
+
+    tmp = Path(tempfile.mkdtemp(prefix="lm-langtest-"))
+    lib = tmp / "library"
+    lib.mkdir()
+
+    print("=" * 60)
+    print("LANGUAGE FEATURE TESTS - Issues #278, #279, #282")
+    print("=" * 60)
+
+    # ==========================================
+    # Issue #278: top-level language folder
+    # ==========================================
+    print("\n--- Issue #278: language_tag_position = top_folder ---")
+
+    cfg_top = {
+        'naming_format': 'author/title',
+        'language_tag_enabled': True,
+        'language_tag_position': 'top_folder',
+        'preferred_language': 'en',
+    }
+
+    p = build_new_path(lib, "Brandon Sanderson", "Die Nebelgeborenen",
+                       language="German", language_code="de", config=cfg_top)
+    check("non-preferred book -> German/Author/Title",
+          p is not None and p.relative_to(lib).parts == ("German", "Brandon Sanderson", "Die Nebelgeborenen"),
+          f"got: {p}")
+
+    p = build_new_path(lib, "Frank Herbert", "Dune",
+                       language="English", language_code="en", config=cfg_top)
+    check("preferred-language book still gets language folder (full partition)",
+          p is not None and p.relative_to(lib).parts == ("English", "Frank Herbert", "Dune"),
+          f"got: {p}")
+
+    cfg_top_series = dict(cfg_top, series_grouping=True)
+    p = build_new_path(lib, "Brandon Sanderson", "The Final Empire",
+                       series="Mistborn", series_num=1,
+                       language="German", language_code="de", config=cfg_top_series)
+    check("series grouping preserved below language folder",
+          p is not None and p.relative_to(lib).parts == (
+              "German", "Brandon Sanderson", "Mistborn", "01 - The Final Empire"),
+          f"got: {p}")
+
+    cfg_top_flat = dict(cfg_top, naming_format='author - title')
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language="German", language_code="de", config=cfg_top_flat)
+    check("flat 'author - title' format wrapped in language folder",
+          p is not None and p.relative_to(lib).parts == ("German", "Frank Herbert - Der Wuestenplanet"),
+          f"got: {p}")
+
+    cfg_top_lf = dict(cfg_top, naming_format='author_lf/title')
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language="German", language_code="de", config=cfg_top_lf)
+    check("author_lf/title format wrapped in language folder",
+          p is not None and p.relative_to(lib).parts == ("German", "Herbert, Frank", "Der Wuestenplanet"),
+          f"got: {p}")
+
+    cfg_top_custom = dict(cfg_top, naming_format='custom',
+                          custom_naming_template='{author}/{title}')
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language="German", language_code="de", config=cfg_top_custom)
+    check("custom template wrapped in language folder",
+          p is not None and p.relative_to(lib).parts == ("German", "Frank Herbert", "Der Wuestenplanet"),
+          f"got: {p}")
+
+    cfg_top_off = dict(cfg_top, language_tag_enabled=False, multilang_naming_mode='native')
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language="German", language_code="de", config=cfg_top_off)
+    check("top_folder ignored when tagging not requested",
+          p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Der Wuestenplanet"),
+          f"got: {p}")
+
+    p = build_new_path(lib, "Frank Herbert", "Dune", config=cfg_top)
+    check("no language known -> plain path, no language folder",
+          p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Dune"),
+          f"got: {p}")
+
+    # Existing subfolder behavior must be unaffected
+    cfg_sub = dict(cfg_top, language_tag_position='subfolder')
+    p = build_new_path(lib, "Brandon Sanderson", "Die Nebelgeborenen",
+                       language="German", language_code="de", config=cfg_sub)
+    check("subfolder position still works (Author/German/Title)",
+          p is not None and p.relative_to(lib).parts == (
+              "Brandon Sanderson", "German", "Die Nebelgeborenen"),
+          f"got: {p}")
+
+    # ==========================================
+    # Issue #282: emoji flag tags
+    # ==========================================
+    print("\n--- Issue #282: emoji_flag format and {lang_flag} template tag ---")
+
+    check("format_language_tag de emoji_flag",
+          format_language_tag('de', fmt='emoji_flag') == ' 🇩🇪',
+          f"got: {format_language_tag('de', fmt='emoji_flag')!r}")
+    check("format_language_tag en emoji_flag",
+          format_language_tag('en', fmt='emoji_flag') == ' 🇬🇧',
+          f"got: {format_language_tag('en', fmt='emoji_flag')!r}")
+    check("unmapped code falls back to bracket_full name",
+          format_language_tag('xx', fmt='emoji_flag') == ' (XX)',
+          f"got: {format_language_tag('xx', fmt='emoji_flag')!r}")
+    check("all LANGUAGE_NAMES codes have flags",
+          all(c in LANGUAGE_FLAGS for c in
+              ['en', 'de', 'fr', 'es', 'it', 'pt', 'nl', 'sv', 'no', 'da', 'fi',
+               'pl', 'ru', 'ja', 'zh', 'ko', 'ar', 'he', 'hi', 'tr', 'cs', 'hu',
+               'el', 'th', 'vi', 'uk', 'ro', 'id']))
+
+    cfg_flag = {
+        'naming_format': 'author/title',
+        'language_tag_enabled': True,
+        'language_tag_format': 'emoji_flag',
+        'language_tag_position': 'after_title',
+        'preferred_language': 'en',
+    }
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language="German", language_code="de", config=cfg_flag)
+    check("emoji flag appended after title",
+          p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Der Wuestenplanet 🇩🇪"),
+          f"got: {p}")
+
+    cfg_flag_custom = dict(cfg_flag, naming_format='custom',
+                           custom_naming_template='{author}/{title} {lang_flag}')
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language="German", language_code="de", config=cfg_flag_custom)
+    check("{lang_flag} in custom template",
+          p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Der Wuestenplanet 🇩🇪"),
+          f"got: {p}")
+
+    cfg_flag_none = dict(cfg_flag_custom)
+    p = build_new_path(lib, "Frank Herbert", "Dune",
+                       config=cfg_flag_none)
+    check("{lang_flag} empty when no language known (no trailing junk)",
+          p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Dune"),
+          f"got: {p}")
+
+    # ==========================================
+    # Issue #279: ISO 639-2 three-letter codes
+    # ==========================================
+    print("\n--- Issue #279: language_code_format = iso639-2 ---")
+
+    check("lang_code_for_display de -> ger",
+          lang_code_for_display('de', 'iso639-2') == 'ger')
+    check("lang_code_for_display default keeps 639-1",
+          lang_code_for_display('de') == 'de')
+    check("lang_code_for_display iso639-1 explicit",
+          lang_code_for_display('de', 'iso639-1') == 'de')
+    check("unknown code passes through",
+          lang_code_for_display('xx', 'iso639-2') == 'xx')
+    check("empty code passes through",
+          lang_code_for_display('', 'iso639-2') == '')
+    check("reverse map ger -> de",
+          ISO_639_2_TO_1.get('ger') == 'de')
+    check("reverse map round-trips all entries",
+          all(ISO_639_2_TO_1[v] == k for k, v in ISO_639_1_TO_2.items()))
+
+    check("bracket_code with iso639-2",
+          format_language_tag('de', fmt='bracket_code', code_format='iso639-2') == ' [ger]',
+          f"got: {format_language_tag('de', fmt='bracket_code', code_format='iso639-2')!r}")
+    check("code format with iso639-2",
+          format_language_tag('fr', fmt='code', code_format='iso639-2') == '_fre',
+          f"got: {format_language_tag('fr', fmt='code', code_format='iso639-2')!r}")
+    check("bracket_code default stays 639-1",
+          format_language_tag('de', fmt='bracket_code') == ' [de]',
+          f"got: {format_language_tag('de', fmt='bracket_code')!r}")
+    check("bracket_full unaffected by code_format",
+          format_language_tag('de', fmt='bracket_full', code_format='iso639-2') == ' (German)',
+          f"got: {format_language_tag('de', fmt='bracket_full', code_format='iso639-2')!r}")
+
+    cfg_6392 = {
+        'naming_format': 'author/title',
+        'language_tag_enabled': True,
+        'language_tag_format': 'bracket_code',
+        'language_tag_position': 'after_title',
+        'language_code_format': 'iso639-2',
+        'preferred_language': 'en',
+    }
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language="German", language_code="de", config=cfg_6392)
+    check("folder tag uses three-letter code",
+          p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Der Wuestenplanet [ger]"),
+          f"got: {p}")
+
+    cfg_6392_custom = dict(cfg_6392, naming_format='custom',
+                           custom_naming_template='{author}/{title} [{lang_code}]')
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language="German", language_code="de", config=cfg_6392_custom)
+    check("{lang_code} respects iso639-2 in custom template",
+          p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Der Wuestenplanet [ger]"),
+          f"got: {p}")
+
+    cfg_6391_custom = dict(cfg_6392_custom, language_code_format='iso639-1')
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language="German", language_code="de", config=cfg_6391_custom)
+    check("{lang_code} stays two-letter by default",
+          p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Der Wuestenplanet [de]"),
+          f"got: {p}")
+
+    print("\n" + "=" * 60)
+    print(f"RESULTS: {passed} passed, {failed} failed")
+    print("=" * 60)
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test-env/test-language-features.py
+++ b/test-env/test-language-features.py
@@ -31,6 +31,14 @@ def test_result(name, passed, details=""):
     return passed
 
 
+def _raises_value_error(fn):
+    try:
+        fn()
+        return False
+    except ValueError:
+        return True
+
+
 def main():
     passed = 0
     failed = 0
@@ -233,6 +241,308 @@ def main():
     p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
                        language="German", language_code="de", config=cfg_6391_custom)
     check("{lang_code} stays two-letter by default",
+          p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Der Wuestenplanet [de]"),
+          f"got: {p}")
+
+    # ==========================================
+    # Issue #281: per-series language override/lock
+    # ==========================================
+    print("\n--- Issue #281: per-series language override ---")
+
+    from library_manager import database as db
+    from library_manager.pipeline.layer_audio_id import _resolve_metadata_language
+
+    test_db = tmp / "series-lang.db"
+    db.init_db(db_path=str(test_db))
+
+    # --- DB CRUD ---
+    db.set_series_language_override('Mistborn', 'de', db_path=str(test_db))
+    check("set + get override",
+          db.get_series_language_override('Mistborn', db_path=str(test_db)) == 'de')
+
+    check("case-insensitive lookup",
+          db.get_series_language_override('mistborn', db_path=str(test_db)) == 'de')
+    check("whitespace/case-insensitive lookup",
+          db.get_series_language_override('  MISTBORN ', db_path=str(test_db)) == 'de')
+
+    db.set_series_language_override('mistborn', 'fr', db_path=str(test_db))
+    all_overrides = db.get_all_series_language_overrides(db_path=str(test_db))
+    check("update in place (no duplicate row)",
+          len(all_overrides) == 1 and all_overrides[0]['language_code'] == 'fr',
+          f"got: {all_overrides}")
+
+    db.set_series_language_override('The Expanse', 'en', db_path=str(test_db))
+    check("second series stored independently",
+          db.get_series_language_override('The Expanse', db_path=str(test_db)) == 'en')
+
+    check("unknown series returns None",
+          db.get_series_language_override('Unknown Series', db_path=str(test_db)) is None)
+
+    check("invalid language code rejected",
+          _raises_value_error(lambda: db.set_series_language_override('X', 'xx', db_path=str(test_db))))
+
+    check("'auto' removes the override",
+          db.set_series_language_override('Mistborn', 'auto', db_path=str(test_db)) is None
+          and db.get_series_language_override('Mistborn', db_path=str(test_db)) is None)
+
+    check("delete returns True when removed",
+          db.delete_series_language_override('the expanse', db_path=str(test_db)) is True)
+    check("delete returns False when absent",
+          db.delete_series_language_override('the expanse', db_path=str(test_db)) is False)
+
+    # --- Resolution behavior ---
+    def _audio_detector_must_not_run(*args, **kwargs):
+        raise AssertionError("audio language detection should have been skipped")
+
+    def _audio_detector_fr(*args, **kwargs):
+        return {'language': 'fr'}
+
+    old_db_path = db._db_path
+    try:
+        db.set_db_path(str(test_db))
+        db.set_series_language_override('Mistborn', 'de')
+
+        cfg_detect = {'detect_language_from_audio': True}
+        lang = _resolve_metadata_language(
+            tmp / "fake.m4b", "The Final Empire", cfg_detect,
+            detect_audio_language_fn=_audio_detector_must_not_run,
+            series_name='mistborn'
+        )
+        check("override is a hard override (audio detection skipped)", lang == 'de',
+              f"got: {lang}")
+
+        lang = _resolve_metadata_language(
+            None, "The Final Empire", {},
+            language_hint='en',
+            series_name='Mistborn'
+        )
+        check("override beats explicit language hint", lang == 'de', f"got: {lang}")
+
+        # auto/unset: normal detection still happens
+        lang = _resolve_metadata_language(
+            tmp / "fake.m4b", "The Final Empire", cfg_detect,
+            detect_audio_language_fn=_audio_detector_fr,
+            series_name='Other Series'
+        )
+        check("no override -> audio detection used", lang == 'fr', f"got: {lang}")
+
+        lang = _resolve_metadata_language(
+            None, "Der Wuestenplanet", {},
+            series_name=None
+        )
+        check("no series -> title detection still runs", lang == 'de', f"got: {lang}")
+    finally:
+        db.set_db_path(old_db_path)
+
+    # ==========================================
+    # Issue #280: bilingual/multi-language tagging
+    # ==========================================
+    print("\n--- Issue #280: bilingual/multi-language tagging ---")
+
+    import json as _json
+    from library_manager.models.book_profile import (
+        BookProfile, save_book_profile, load_book_profile,
+    )
+    from library_manager.models import book_profile as bp_module
+    from library_manager.utils.path_safety import format_languages_tag
+
+    # --- Profile: languages list set/get + primary back-compat ---
+    profile = BookProfile()
+    check("empty profile has no languages", profile.get_languages() == [])
+
+    profile.language.value = 'de'
+    check("get_languages falls back to primary language",
+          profile.get_languages() == ['de'])
+
+    profile.set_languages(['de', 'en'])
+    check("set_languages stores ordered list",
+          profile.languages == ['de', 'en'])
+    check("set_languages syncs primary language",
+          profile.language.value == 'de')
+
+    profile.set_languages(['EN', 'en', ' fr '])
+    check("set_languages normalizes and dedupes",
+          profile.languages == ['en', 'fr'] and profile.language.value == 'en')
+
+    # finalize() populates languages from the detected primary
+    profile2 = BookProfile()
+    profile2.language.add_source('audio', 'fr')
+    profile2.finalize()
+    check("finalize populates languages with primary",
+          profile2.languages == ['fr'] and profile2.get_languages() == ['fr'])
+
+    # to_dict/from_dict round-trip
+    profile.set_languages(['de', 'en'])
+    restored = BookProfile.from_dict(profile.to_dict())
+    check("profile dict round-trip keeps languages",
+          restored.languages == ['de', 'en'] and restored.language.value == 'de')
+    old_profile = BookProfile.from_dict({'language': {'value': 'es', 'confidence': 80, 'sources': ['ai']}})
+    check("old profile JSON without languages still works",
+          old_profile.languages == [] and old_profile.get_languages() == ['es'])
+
+    # --- Persistence: books.languages column + profile JSON ---
+    lang_db = tmp / "book-langs.db"
+    db.init_db(db_path=str(lang_db))
+    conn = db.get_db(db_path=str(lang_db))
+    conn.execute("INSERT INTO books (path, current_author, current_title) VALUES (?, ?, ?)",
+                 (str(tmp / "book1"), "Frank Herbert", "Der Wuestenplanet"))
+    book_id = conn.execute("SELECT id FROM books WHERE path = ?", (str(tmp / "book1"),)).fetchone()[0]
+    conn.commit()
+    conn.close()
+
+    db.set_book_languages(book_id, ['de', 'en'], db_path=str(lang_db))
+    check("set/get book languages round-trip",
+          db.get_book_languages(book_id, db_path=str(lang_db)) == ['de', 'en'])
+
+    check("invalid language code rejected",
+          _raises_value_error(lambda: db.set_book_languages(book_id, ['de', 'xx'], db_path=str(lang_db))))
+    check("rejected update leaves previous list intact",
+          db.get_book_languages(book_id, db_path=str(lang_db)) == ['de', 'en'])
+
+    db.set_book_languages(book_id, [], db_path=str(lang_db))
+    check("empty list clears languages",
+          db.get_book_languages(book_id, db_path=str(lang_db)) == [])
+
+    # Old rows: no languages column value -> fall back to profile JSON language
+    conn = db.get_db(db_path=str(lang_db))
+    conn.execute("UPDATE books SET profile = ? WHERE id = ?",
+                 (_json.dumps({'language': {'value': 'pl', 'confidence': 90, 'sources': ['audio']}}), book_id))
+    conn.commit()
+    conn.close()
+    check("get_book_languages falls back to profile language",
+          db.get_book_languages(book_id, db_path=str(lang_db)) == ['pl'])
+
+    # save/load_book_profile persists the list (column + profile JSON)
+    old_db_path = db._db_path
+    try:
+        db.set_db_path(str(lang_db))
+        bp_module.set_db_getter(db.get_db)
+        profile3 = BookProfile()
+        profile3.language.add_source('audio', 'de')
+        profile3.finalize()
+        profile3.set_languages(['de', 'en'])
+        save_book_profile(book_id, profile3)
+        loaded = load_book_profile(book_id)
+        check("save/load_book_profile round-trips languages",
+              loaded is not None and loaded.languages == ['de', 'en'])
+        check("languages column written by save_book_profile",
+              db.get_book_languages(book_id) == ['de', 'en'])
+    finally:
+        db.set_db_path(old_db_path)
+
+    # --- API: POST /api/books/<id>/languages ---
+    from app import app as flask_app
+    client = flask_app.test_client()
+    old_db_path = db._db_path
+    try:
+        db.set_db_path(str(lang_db))
+
+        resp = client.post(f'/api/books/{book_id}/languages',
+                           json={'languages': ['de', 'en']})
+        check("POST sets languages", resp.status_code == 200 and
+              resp.get_json().get('languages') == ['de', 'en'],
+              f"got: {resp.status_code} {resp.get_json()}")
+
+        resp = client.get(f'/api/books/{book_id}/languages')
+        check("GET returns stored languages",
+              resp.status_code == 200 and resp.get_json().get('languages') == ['de', 'en'],
+              f"got: {resp.status_code} {resp.get_json()}")
+
+        resp = client.post(f'/api/books/{book_id}/languages',
+                           json={'languages': ['de', 'xx']})
+        check("bad code rejected with 400",
+              resp.status_code == 400 and resp.get_json().get('success') is False,
+              f"got: {resp.status_code} {resp.get_json()}")
+        check("rejected API call keeps previous list",
+              db.get_book_languages(book_id, db_path=str(lang_db)) == ['de', 'en'])
+
+        resp = client.post(f'/api/books/{book_id}/languages', json={'languages': []})
+        check("empty list clears secondaries, falls back to primary",
+              resp.status_code == 200 and resp.get_json().get('languages') == ['de'],
+              f"got: {resp.status_code} {resp.get_json()}")
+
+        resp = client.post(f'/api/books/{book_id}/languages', json={'languages': 'de'})
+        check("non-list body rejected with 400", resp.status_code == 400)
+
+        resp = client.post('/api/books/999999/languages', json={'languages': ['de']})
+        check("unknown book returns 404", resp.status_code == 404)
+
+        # Setting a new primary via API syncs the profile JSON language
+        client.post(f'/api/books/{book_id}/languages', json={'languages': ['fr', 'en']})
+        loaded = load_book_profile(book_id)
+        check("API set syncs profile primary language",
+              loaded is not None and loaded.language.value == 'fr'
+              and loaded.languages == ['fr', 'en'],
+              f"got: {loaded.language.value if loaded else None}")
+    finally:
+        db.set_db_path(old_db_path)
+
+    # --- Naming: multi-language tags ---
+    check("bracket_full joins names with ', '",
+          format_languages_tag(['de', 'en'], fmt='bracket_full') == ' (German, English)',
+          f"got: {format_languages_tag(['de', 'en'], fmt='bracket_full')!r}")
+    check("bracket_code joins codes with ','",
+          format_languages_tag(['de', 'en'], fmt='bracket_code') == ' [de,en]')
+    check("bracket_code respects iso639-2",
+          format_languages_tag(['de', 'en'], fmt='bracket_code', code_format='iso639-2') == ' [ger,eng]')
+    check("emoji_flag joins flags with space",
+          format_languages_tag(['de', 'en'], fmt='emoji_flag') == ' 🇩🇪 🇬🇧')
+    check("single language identical to format_language_tag",
+          format_languages_tag(['de'], fmt='bracket_full') == format_language_tag('de', fmt='bracket_full'))
+    check("empty list gives empty tag", format_languages_tag([], fmt='bracket_full') == '')
+
+    cfg_multi = {
+        'naming_format': 'author/title',
+        'language_tag_enabled': True,
+        'language_tag_format': 'bracket_full',
+        'language_tag_position': 'after_title',
+        'preferred_language': 'en',
+    }
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language="German", language_code="de",
+                       languages=['de', 'en'], config=cfg_multi)
+    check("multi-language folder tag (German, English)",
+          p is not None and str(p.relative_to(lib)) == "Frank Herbert/Der Wuestenplanet (German, English)",
+          f"got: {p}")
+
+    cfg_multi_code = dict(cfg_multi, language_tag_format='bracket_code')
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language_code="de", languages=['de', 'en'], config=cfg_multi_code)
+    check("multi-language folder tag [de,en]",
+          p is not None and str(p.relative_to(lib)) == "Frank Herbert/Der Wuestenplanet [de,en]",
+          f"got: {p}")
+
+    cfg_multi_6392 = dict(cfg_multi_code, language_code_format='iso639-2')
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language_code="de", languages=['de', 'en'], config=cfg_multi_6392)
+    check("multi-language folder tag [ger,eng]",
+          p is not None and str(p.relative_to(lib)) == "Frank Herbert/Der Wuestenplanet [ger,eng]",
+          f"got: {p}")
+
+    cfg_multi_flag = dict(cfg_multi, language_tag_format='emoji_flag')
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language_code="de", languages=['de', 'en'], config=cfg_multi_flag)
+    check("multi-language folder tag 🇩🇪 🇬🇧",
+          p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Der Wuestenplanet 🇩🇪 🇬🇧"),
+          f"got: {p}")
+
+    # Single-language regression: byte-identical to pre-#280 behavior
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language="German", language_code="de",
+                       languages=['de'], config=cfg_multi)
+    check("single-entry languages list unchanged",
+          p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Der Wuestenplanet (German)"),
+          f"got: {p}")
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language="German", language_code="de", config=cfg_multi)
+    check("no languages param unchanged",
+          p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Der Wuestenplanet (German)"),
+          f"got: {p}")
+
+    # languages=None default does not affect other formats
+    p = build_new_path(lib, "Frank Herbert", "Der Wuestenplanet",
+                       language_code="de", languages=None, config=cfg_multi_code)
+    check("languages=None identical to today",
           p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Der Wuestenplanet [de]"),
           f"got: {p}")
 

--- a/test-env/test-language-features.py
+++ b/test-env/test-language-features.py
@@ -546,6 +546,54 @@ def main():
           p is not None and p.relative_to(lib).parts == ("Frank Herbert", "Der Wuestenplanet [de]"),
           f"got: {p}")
 
+    # ==========================================
+    # E2E-found bug: ISO 639-2 codes from Skaldleita (eng, ger) must be
+    # normalized to 639-1 everywhere, or naming produces "ENG/" folders
+    # ==========================================
+    print("\n--- Regression: ISO 639-2 normalization in language extraction ---")
+
+    from library_manager.pipeline.layer_audio_id import _normalize_language_code
+    from library_manager.pipeline.layer_api import _extract_detected_language as extract_api
+    from library_manager.pipeline.layer_ai_queue import _extract_detected_language as extract_aiq
+    from app import _extract_detected_language as extract_app
+
+    check("_normalize_language_code maps eng -> en",
+          _normalize_language_code('eng') == 'en')
+    check("_normalize_language_code maps ger -> de",
+          _normalize_language_code('ger') == 'de')
+    check("_normalize_language_code upper-case ENG -> en",
+          _normalize_language_code('ENG') == 'en')
+    check("_normalize_language_code strips region pt-BR -> pt",
+          _normalize_language_code('pt-BR') == 'pt')
+    check("_normalize_language_code und -> None",
+          _normalize_language_code('und') is None)
+    check("_normalize_language_code unknown 3-letter passes through",
+          _normalize_language_code('xyz') == 'xyz')
+    check("_normalize_language_code 2-letter unchanged",
+          _normalize_language_code('fr') == 'fr')
+
+    profile_eng = {'detected_language': {'value': 'eng', 'confidence': 95}}
+    check("extract (app) maps eng -> en from FieldValue dict",
+          extract_app(profile_eng) == 'en')
+    check("extract (layer_api) maps eng -> en",
+          extract_api(profile_eng) == 'en')
+    check("extract (layer_ai_queue) maps eng -> en",
+          extract_aiq(profile_eng) == 'en')
+    check("extract maps plain ger -> de",
+          extract_app({'language': 'ger'}) == 'de')
+    check("extract keeps 2-letter codes",
+          extract_app({'detected_language': 'fr'}) == 'fr')
+
+    # End-to-end: a 639-2 code reaching build_new_path via extraction must
+    # produce an English/ top folder, not ENG/
+    cfg_top2 = dict(cfg_multi, language_tag_position='top_folder')
+    extracted = extract_app(profile_eng)
+    p = build_new_path(lib, "Frank Herbert", "Dune",
+                       language=None, language_code=extracted, config=cfg_top2)
+    check("Skaldleita 'eng' -> English/ top folder (not ENG/)",
+          p is not None and p.relative_to(lib).parts == ("English", "Frank Herbert", "Dune"),
+          f"got: {p}")
+
     print("\n" + "=" * 60)
     print(f"RESULTS: {passed} passed, {failed} failed")
     print("=" * 60)


### PR DESCRIPTION
This came out of the multi-language pipeline discussion in #273/#274/#275 - a user running a fully automated German/English audiobook setup needed more control over how languages end up in folder names, so I packed the related requests into one branch.

## What's in here

**#278 - language as a top-level folder.** New `top_folder` option for `language_tag_position`. Instead of `Author/German/Title` you get `German/Author/Title`, with series grouping preserved underneath. It applies to every book with a known language, including preferred-language ones, so the whole library ends up partitioned instead of half-sorted. Works with custom templates too (the template output gets wrapped in the language folder).

**#282 - emoji flag tags.** New `emoji_flag` tag format (`Title 🇩🇪`) plus a `{lang_flag}` custom template tag. There's a full ISO 639-1 to flag map for the 28 languages LM already knows. If a code has no flag mapped it falls back to the bracketed name instead of emitting nothing.

**#279 - ISO 639-2 output.** New `language_code_format` setting (`iso639-1` default, `iso639-2` optional). Affects the code-based tag formats and `{lang_code}` - so `[de]` can become `[ger]`. I used the bibliographic codes (ger, fre, dut...) since that's what Skaldleita emits.

**#281 - per-series language lock.** New `series_language_overrides` table, API (`/api/series-language-overrides`), and a small card in Library settings. Locking a series to a language makes `_resolve_metadata_language` return it immediately - no audio detection, no title guessing for every book in the series. Set it back to auto and detection runs as before.

**#280 - multi-language books.** `BookProfile` gains a `languages` list (primary first, old profiles unaffected). There's a `languages` column on books with a migration, GET/POST on `/api/books/<id>/languages`, and a multi-select in the library edit modal. Folder tags show all languages: `(German, English)`, `[de,en]`, `🇩🇪 🇬🇧`. I deliberately avoided `/` as the join character since it's a path separator - that would have nested folders on disk.

## Bug found by E2E

The container E2E caught a real one: Skaldleita returns three-letter codes (`eng`, `ger`) and they were flowing into naming unmapped, producing `ENG/Frank Herbert/...` folders and causing preferred-language books to get tagged as foreign. All language extraction points now map 639-2 to 639-1.

One caveat worth knowing: the series lock only fires when the pipeline actually knows the series. The Skaldleita test record for Dune returns `series: null` from audio identification even though `/match` knows it, so in that case the lock can't apply. That's server-side data, not wiring - the wiring is covered by tests both ways.

## Testing

- 93 new checks in `test-env/test-language-features.py`, all green
- `test-naming-issues.py` still 290/290, `test-issue-273-274-275.py` green
- ruff: no new warnings (baseline unchanged)
- Full E2E in the quarantined LXD container against live Skaldleita: browser-tested the settings UI (selects, preview, save persistence, override card, edit-modal multi-select), plus two live scan/process/apply cycles verifying actual folder placement on disk

Issues stay open until everything's confirmed working in production.
