### PR TITLE
feat: detect multi-language libraries and prompt for naming preference (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.157] - 2026-08-13
+
+### Added
+- **#284: Multi-language library onboarding prompt** — After scanning, LM now detects multi-language libraries from the language distribution of processed books (ISO 639-2 normalized) and shows a dashboard banner with one-click naming preferences: keep native naming, tag non-preferred titles, or sort into top-level language folders. New `/api/language-summary` and `/api/language-onboarding` endpoints; the prompt can be dismissed via the new `multilang_onboarding_dismissed` config flag.
+
 ## [0.9.0-beta.156] - 2026-08-13
 
 ### Added

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama)
 """
 
-APP_VERSION = "0.9.0-beta.156"
+APP_VERSION = "0.9.0-beta.157"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:
@@ -56,7 +56,8 @@ from library_manager.database import (
     watch_folder_is_processed, watch_folder_mark_processed,
     set_series_language_override, get_all_series_language_overrides,
     delete_series_language_override,
-    set_book_languages, get_book_languages
+    set_book_languages, get_book_languages,
+    get_language_distribution
 )
 from library_manager.models.book_profile import (
     SOURCE_WEIGHTS, FIELD_WEIGHTS, FieldValue, BookProfile,
@@ -7680,6 +7681,65 @@ def api_book_languages_set(book_id):
     cleaned = get_book_languages(book_id)
     log_action('book_languages', detail=f"book {book_id} -> {','.join(cleaned) or '(cleared)'}", result='success')
     return jsonify({'success': True, 'languages': cleaned})
+
+
+# ============== MULTI-LANGUAGE ONBOARDING (Issue #284) ==============
+
+@app.route('/api/language-summary', methods=['GET'])
+def api_language_summary():
+    """Language distribution across processed books + onboarding prompt state."""
+    config = load_config()
+    languages = get_language_distribution()
+    preferred = config.get('preferred_language', 'en')
+    # Multi-language library: 2+ distinct languages, or a detected language
+    # that differs from the preferred one. Only books with a detected
+    # language are counted.
+    multi = len(languages) >= 2 or any(code != preferred for code in languages)
+    return jsonify({
+        'success': True,
+        'languages': languages,
+        'total_books': sum(languages.values()),
+        'preferred_language': preferred,
+        'multi': multi,
+        'dismissed': bool(config.get('multilang_onboarding_dismissed', False)),
+        'language_names': LANGUAGE_NAMES,
+    })
+
+
+@app.route('/api/language-onboarding', methods=['POST'])
+def api_language_onboarding():
+    """Apply a naming preference from the onboarding prompt, or dismiss it.
+
+    POST body: {"action": "apply", "choice": "native"|"tagged"|"top_folder"}
+            or {"action": "dismiss"}
+    """
+    data = request.get_json() or {}
+    action = (data.get('action') or '').strip().lower()
+    if action not in ('apply', 'dismiss'):
+        return jsonify({'success': False, 'error': "action must be 'apply' or 'dismiss'"}), 400
+
+    config = load_config()
+    if action == 'apply':
+        choice = (data.get('choice') or '').strip().lower()
+        if choice == 'native':
+            config['multilang_naming_mode'] = 'native'
+            config['language_tag_enabled'] = False
+        elif choice == 'tagged':
+            config['multilang_naming_mode'] = 'tagged'
+            config['language_tag_enabled'] = True  # keeps existing position/format
+        elif choice == 'top_folder':
+            config['language_tag_enabled'] = True
+            config['language_tag_position'] = 'top_folder'
+        else:
+            return jsonify({'success': False, 'error': "choice must be 'native', 'tagged', or 'top_folder'"}), 400
+
+    # Applying a choice counts as handling the prompt too
+    config['multilang_onboarding_dismissed'] = True
+    save_config(config)
+
+    detail = f"choice={data.get('choice')}" if action == 'apply' else 'dismissed'
+    log_action('language_onboarding', detail=detail, result='success')
+    return jsonify({'success': True, 'action': action})
 
 
 # ============== PATH DIAGNOSTIC ==============

--- a/library_manager/config.py
+++ b/library_manager/config.py
@@ -100,6 +100,7 @@ DEFAULT_CONFIG = {
     "language_tag_format": "bracket_full",  # "code" (_pl), "full" (Polish), "bracket_code" ([pl]), "bracket_full" ((Polish)), "emoji_flag" (🇵🇱)
     "language_tag_position": "after_title", # "after_title", "before_title", "subfolder", "top_folder"
     "language_code_format": "iso639-1",     # "iso639-1" (pl) or "iso639-2" (pol) for code-based tags and {lang_code}
+    "multilang_onboarding_dismissed": False,  # Hide the multi-language onboarding prompt on the dashboard (Issue #284)
     # Trust the Process mode - fully automatic verification chain
     "trust_the_process": False,  # Auto-verify drastic changes, use audio analysis as tie-breaker, only flag truly unidentifiable
     # Book Profile System settings - progressive verification with confidence scoring

--- a/library_manager/database.py
+++ b/library_manager/database.py
@@ -735,9 +735,54 @@ def get_book_languages(book_id, db_path=None):
         conn.close()
 
 
+def get_language_distribution(db_path=None):
+    """Return a {language_code: count} map of detected book languages (Issue #284).
+
+    Reads the profile JSON of every book, extracts the primary language
+    (plain string or FieldValue dict), normalizes ISO 639-2 codes to 639-1,
+    and skips empty/undetermined values.
+    """
+    path = db_path or _db_path
+    if not path:
+        return {}
+    import json as _json
+    from library_manager.utils.path_safety import ISO_639_2_TO_1
+
+    conn = sqlite3.connect(path, timeout=30)
+    try:
+        rows = conn.execute(
+            'SELECT profile FROM books WHERE profile IS NOT NULL'
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return {}  # Table may not exist yet on older databases
+    finally:
+        conn.close()
+
+    distribution = {}
+    for (profile_json,) in rows:
+        try:
+            profile = _json.loads(profile_json)
+        except ValueError:
+            continue
+        if not isinstance(profile, dict):
+            continue
+        lang = profile.get('language')
+        if isinstance(lang, dict):
+            lang = lang.get('value')
+        if not lang:
+            continue
+        code = str(lang).lower().strip()
+        code = ISO_639_2_TO_1.get(code, code)
+        if not code or code == 'und':
+            continue
+        distribution[code] = distribution.get(code, 0) + 1
+    return distribution
+
+
 __all__ = ['init_db', 'get_db', 'set_db_path', 'cleanup_garbage_entries',
            'cleanup_duplicate_history_entries', 'insert_history_entry',
            'should_requeue_book',
            'set_series_language_override', 'get_series_language_override',
            'get_all_series_language_overrides', 'delete_series_language_override',
-           'set_book_languages', 'get_book_languages']
+           'set_book_languages', 'get_book_languages',
+           'get_language_distribution']

--- a/library_manager/database.py
+++ b/library_manager/database.py
@@ -738,9 +738,9 @@ def get_book_languages(book_id, db_path=None):
 def get_language_distribution(db_path=None):
     """Return a {language_code: count} map of detected book languages (Issue #284).
 
-    Reads the profile JSON of every book, extracts the primary language
-    (plain string or FieldValue dict), normalizes ISO 639-2 codes to 639-1,
-    and skips empty/undetermined values.
+    Reads the profile JSON of every book, extracts the primary language from
+    'detected_language' or 'language' (plain string or FieldValue dict),
+    normalizes ISO 639-2 codes to 639-1, and skips empty/undetermined values.
     """
     path = db_path or _db_path
     if not path:
@@ -766,7 +766,10 @@ def get_language_distribution(db_path=None):
             continue
         if not isinstance(profile, dict):
             continue
-        lang = profile.get('language')
+        # The pipeline persists either 'detected_language' (plain string or
+        # FieldValue dict) or 'language' (FieldValue) - accept both, matching
+        # _extract_detected_language semantics.
+        lang = profile.get('detected_language') or profile.get('language')
         if isinstance(lang, dict):
             lang = lang.get('value')
         if not lang:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -87,6 +87,30 @@
 </div>
 {% endif %}
 
+<!-- Multi-language onboarding prompt (Issue #284) - shown by JS when a
+     multi-language library is detected and the prompt is not dismissed -->
+<div class="row mb-3 d-none" id="multilang-banner-row">
+    <div class="col-12">
+        <div class="alert alert-info py-2 mb-0" role="alert">
+            <div class="d-flex align-items-center">
+                <i class="bi bi-translate me-2"></i>
+                <small>
+                    <strong>{{ _('We found books in multiple languages:') }}</strong>
+                    <span id="multilang-banner-langs"></span>.
+                    {{ _('Choose how Library Manager should name them:') }}
+                </small>
+                <button type="button" class="btn-close ms-auto" id="multilang-dismiss" aria-label="{{ _('Dismiss') }}"></button>
+            </div>
+            <div class="mt-2">
+                <button type="button" class="btn btn-sm btn-outline-primary me-1" data-multilang-choice="native">{{ _('Keep native naming') }}</button>
+                <button type="button" class="btn btn-sm btn-outline-primary me-1" data-multilang-choice="tagged">{{ _('Tag non-preferred titles') }}</button>
+                <button type="button" class="btn btn-sm btn-outline-primary me-1" data-multilang-choice="top_folder">{{ _('Sort into language folders') }}</button>
+                <a href="/settings" class="btn btn-sm btn-link">{{ _('Language settings') }}</a>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Toast container for action feedback -->
 <div class="toast-container position-fixed top-0 end-0 p-3" style="z-index: 1080;">
     <div id="action-toast" class="toast align-items-center border-0" role="alert" aria-live="assertive" aria-atomic="true">
@@ -282,6 +306,51 @@
 
 {% block scripts %}
 <script>
+// Issue #284: multi-language onboarding prompt
+function initMultilangOnboarding() {
+    fetch('/api/language-summary')
+        .then(r => r.json())
+        .then(data => {
+            if (!data.success || !data.multi || data.dismissed) return;
+            const names = data.language_names || {};
+            const langs = Object.entries(data.languages)
+                .sort((a, b) => b[1] - a[1])
+                .map(([code, count]) => `${names[code] || code.toUpperCase()} (${count})`)
+                .join(', ');
+            // textContent, not innerHTML: language codes come from book profiles
+            document.getElementById('multilang-banner-langs').textContent = langs;
+            document.getElementById('multilang-banner-row').classList.remove('d-none');
+
+            document.querySelectorAll('[data-multilang-choice]').forEach(btn => {
+                btn.addEventListener('click', () => multilangOnboarding('apply', btn.dataset.multilangChoice));
+            });
+            document.getElementById('multilang-dismiss').addEventListener('click', () => multilangOnboarding('dismiss'));
+        })
+        .catch(() => {});
+}
+
+function multilangOnboarding(action, choice) {
+    const body = {action: action};
+    if (choice) body.choice = choice;
+    fetch('/api/language-onboarding', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(body)
+    })
+        .then(r => r.json())
+        .then(data => {
+            if (!data.success) return;
+            if (action === 'apply') {
+                location.reload();
+            } else {
+                document.getElementById('multilang-banner-row').classList.add('d-none');
+            }
+        })
+        .catch(() => {});
+}
+
+document.addEventListener('DOMContentLoaded', initMultilangOnboarding);
+
 function triggerScan() {
     const btn = document.getElementById('scan-btn');
     btn.disabled = true;

--- a/test-env/e2e-onboarding-banner.py
+++ b/test-env/e2e-onboarding-banner.py
@@ -1,0 +1,67 @@
+"""Browser E2E for issue #284 onboarding banner (runs inside lm-e2e-ct).
+
+Precondition: the DB has a book whose detected language differs from the
+preferred language (set up by the caller). Verifies the banner renders,
+then clicks "Sort into language folders" and verifies config was applied.
+"""
+import json
+import time
+import urllib.request
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "http://127.0.0.1:5757"
+SHOTS = Path("/opt/library-manager/test-screenshots")
+SHOTS.mkdir(exist_ok=True)
+failures = []
+
+
+def check(ok, name):
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}")
+    if not ok:
+        failures.append(name)
+
+
+def get_config_key(key):
+    with open("/opt/library-manager/config.json") as f:
+        return json.load(f).get(key)
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_context(viewport={"width": 1280, "height": 900}).new_page()
+
+    page.goto(f"{BASE_URL}/", wait_until="networkidle", timeout=30000)
+    time.sleep(1.5)  # let the summary fetch + banner render
+
+    banner = page.locator("#multilang-banner-row")
+    check(banner.count() == 1, "banner element exists in DOM")
+    visible = banner.is_visible()
+    check(visible, "banner visible when multi && !dismissed")
+    if visible:
+        text = banner.inner_text()
+        print(f"[INFO] banner text: {text!r}")
+        check("German" in text, "banner names the detected language")
+        page.screenshot(path=str(SHOTS / "e2e-onboarding-banner.png"), full_page=True)
+
+        btn = page.locator("button[data-multilang-choice='top_folder']")
+        check(btn.count() == 1, "'Sort into language folders' button present")
+        if btn.count():
+            btn.click()
+            page.wait_for_load_state("networkidle")
+            time.sleep(1)
+            check(get_config_key("language_tag_position") == "top_folder",
+                  "config language_tag_position=top_folder after apply")
+            check(get_config_key("language_tag_enabled") is True,
+                  "config language_tag_enabled=true after apply")
+            check(get_config_key("multilang_onboarding_dismissed") is True,
+                  "onboarding marked dismissed after apply")
+            time.sleep(1.5)
+            check(not banner.is_visible(), "banner gone after apply + reload")
+            page.screenshot(path=str(SHOTS / "e2e-onboarding-applied.png"), full_page=True)
+
+    browser.close()
+
+print("\nOnboarding E2E", "FAILED" if failures else "passed")
+raise SystemExit(1 if failures else 0)

--- a/test-env/test-language-features.py
+++ b/test-env/test-language-features.py
@@ -619,6 +619,7 @@ def main():
     _insert_onb_book("b-de-fieldvalue", {'language': {'value': 'GER', 'confidence': 92}})
     _insert_onb_book("b-en-6392", {'language': {'value': 'eng', 'confidence': 95}})
     _insert_onb_book("b-en-plain", {'language': 'en'})
+    _insert_onb_book("b-fr-detected", {'detected_language': 'fr'})
     _insert_onb_book("b-und", {'language': 'und'})
     _insert_onb_book("b-empty", {'language': ''})
     _insert_onb_book("b-missing", {'title': 'No language here'})
@@ -630,8 +631,10 @@ def main():
     check("distribution normalizes 639-2 'eng'/'GER' -> 639-1",
           dist.get('en') == 2 and 'eng' not in dist and 'ger' not in dist,
           f"got: {dist}")
+    check("distribution reads detected_language key (what the pipeline persists)",
+          dist.get('fr') == 1, f"got: {dist}")
     check("distribution skips und/empty/missing/no-profile",
-          len(dist) == 2, f"got: {dist}")
+          len(dist) == 3, f"got: {dist}")
 
     # --- API: GET /api/language-summary + POST /api/language-onboarding ---
     import app as app_module
@@ -663,14 +666,14 @@ def main():
               resp.status_code == 200 and body.get('multi') is True,
               f"got: {resp.status_code} {body}")
         check("summary: counts only books with a detected language",
-              body.get('total_books') == 4 and body.get('languages') == {'de': 2, 'en': 2},
+              body.get('total_books') == 5 and body.get('languages') == {'de': 2, 'en': 2, 'fr': 1},
               f"got: {body}")
         check("summary: exposes preferred language and dismissed flag",
               body.get('preferred_language') == 'en' and body.get('dismissed') is False)
 
         # Single language == preferred -> not multi
         conn = db.get_db(db_path=str(onb_db))
-        conn.execute("DELETE FROM books WHERE path LIKE '%b-de%'")
+        conn.execute("DELETE FROM books WHERE path LIKE '%b-de%' OR path LIKE '%b-fr%'")
         conn.commit()
         conn.close()
         resp = client.get('/api/language-summary')

--- a/test-env/test-language-features.py
+++ b/test-env/test-language-features.py
@@ -4,6 +4,7 @@ Tests for language naming features:
 - Issue #278: language as top-level folder (top_folder position)
 - Issue #282: emoji flag language tags (emoji_flag format, {lang_flag} tag)
 - Issue #279: ISO 639-2 three-letter codes (language_code_format)
+- Issue #284: multi-language library detection + onboarding prompt
 """
 
 import sys
@@ -593,6 +594,151 @@ def main():
     check("Skaldleita 'eng' -> English/ top folder (not ENG/)",
           p is not None and p.relative_to(lib).parts == ("English", "Frank Herbert", "Dune"),
           f"got: {p}")
+
+    # ==========================================
+    # Issue #284: multi-language detection + onboarding prompt
+    # ==========================================
+    print("\n--- Issue #284: multi-language library onboarding ---")
+
+    from library_manager.config import DEFAULT_CONFIG as _DEFAULT_CONFIG
+
+    check("DEFAULT_CONFIG has multilang_onboarding_dismissed",
+          _DEFAULT_CONFIG.get('multilang_onboarding_dismissed') is False)
+
+    onb_db = tmp / "onboarding.db"
+    db.init_db(db_path=str(onb_db))
+
+    def _insert_onb_book(path, profile):
+        conn = db.get_db(db_path=str(onb_db))
+        conn.execute("INSERT INTO books (path, profile) VALUES (?, ?)",
+                     (str(tmp / path), _json.dumps(profile) if profile is not None else None))
+        conn.commit()
+        conn.close()
+
+    _insert_onb_book("b-de-plain", {'language': 'de'})
+    _insert_onb_book("b-de-fieldvalue", {'language': {'value': 'GER', 'confidence': 92}})
+    _insert_onb_book("b-en-6392", {'language': {'value': 'eng', 'confidence': 95}})
+    _insert_onb_book("b-en-plain", {'language': 'en'})
+    _insert_onb_book("b-und", {'language': 'und'})
+    _insert_onb_book("b-empty", {'language': ''})
+    _insert_onb_book("b-missing", {'title': 'No language here'})
+    _insert_onb_book("b-noprofile", None)
+
+    dist = db.get_language_distribution(db_path=str(onb_db))
+    check("distribution counts plain + FieldValue languages",
+          dist.get('de') == 2, f"got: {dist}")
+    check("distribution normalizes 639-2 'eng'/'GER' -> 639-1",
+          dist.get('en') == 2 and 'eng' not in dist and 'ger' not in dist,
+          f"got: {dist}")
+    check("distribution skips und/empty/missing/no-profile",
+          len(dist) == 2, f"got: {dist}")
+
+    # --- API: GET /api/language-summary + POST /api/language-onboarding ---
+    import app as app_module
+    real_load_config = app_module.load_config
+    real_save_config = app_module.save_config
+    onb_cfg = {
+        'preferred_language': 'en',
+        'multilang_naming_mode': 'native',
+        'language_tag_enabled': False,
+        'language_tag_position': 'after_title',
+        'language_tag_format': 'bracket_full',
+        'multilang_onboarding_dismissed': False,
+    }
+    saved_configs = []
+
+    def _fake_save(cfg):
+        saved_configs.append(dict(cfg))
+        onb_cfg.update(cfg)
+
+    old_db_path = db._db_path
+    try:
+        app_module.load_config = lambda: dict(onb_cfg)
+        app_module.save_config = _fake_save
+        db.set_db_path(str(onb_db))
+
+        resp = client.get('/api/language-summary')
+        body = resp.get_json()
+        check("summary: multi true for mixed library",
+              resp.status_code == 200 and body.get('multi') is True,
+              f"got: {resp.status_code} {body}")
+        check("summary: counts only books with a detected language",
+              body.get('total_books') == 4 and body.get('languages') == {'de': 2, 'en': 2},
+              f"got: {body}")
+        check("summary: exposes preferred language and dismissed flag",
+              body.get('preferred_language') == 'en' and body.get('dismissed') is False)
+
+        # Single language == preferred -> not multi
+        conn = db.get_db(db_path=str(onb_db))
+        conn.execute("DELETE FROM books WHERE path LIKE '%b-de%'")
+        conn.commit()
+        conn.close()
+        resp = client.get('/api/language-summary')
+        check("summary: single preferred-language library is not multi",
+              resp.get_json().get('multi') is False, f"got: {resp.get_json()}")
+
+        # Single language != preferred -> multi
+        onb_cfg['preferred_language'] = 'fr'
+        resp = client.get('/api/language-summary')
+        check("summary: language differing from preferred is multi",
+              resp.get_json().get('multi') is True, f"got: {resp.get_json()}")
+        onb_cfg['preferred_language'] = 'en'
+
+        # --- POST /api/language-onboarding: apply choices ---
+        resp = client.post('/api/language-onboarding', json={'action': 'apply', 'choice': 'tagged'})
+        check("apply 'tagged' succeeds",
+              resp.status_code == 200 and resp.get_json().get('success') is True,
+              f"got: {resp.status_code} {resp.get_json()}")
+        check("apply 'tagged' sets tagged mode + enables tags, keeps position/format",
+              onb_cfg.get('multilang_naming_mode') == 'tagged'
+              and onb_cfg.get('language_tag_enabled') is True
+              and onb_cfg.get('language_tag_position') == 'after_title'
+              and onb_cfg.get('language_tag_format') == 'bracket_full',
+              f"got: {onb_cfg}")
+        check("apply marks onboarding dismissed",
+              onb_cfg.get('multilang_onboarding_dismissed') is True)
+        check("apply persists config via save_config",
+              len(saved_configs) == 1 and saved_configs[0].get('multilang_onboarding_dismissed') is True)
+
+        resp = client.post('/api/language-onboarding', json={'action': 'apply', 'choice': 'native'})
+        check("apply 'native' sets native mode + disables tags",
+              resp.status_code == 200
+              and onb_cfg.get('multilang_naming_mode') == 'native'
+              and onb_cfg.get('language_tag_enabled') is False,
+              f"got: {resp.status_code} {onb_cfg}")
+
+        resp = client.post('/api/language-onboarding', json={'action': 'apply', 'choice': 'top_folder'})
+        check("apply 'top_folder' enables tags with top_folder position",
+              resp.status_code == 200
+              and onb_cfg.get('language_tag_enabled') is True
+              and onb_cfg.get('language_tag_position') == 'top_folder',
+              f"got: {resp.status_code} {onb_cfg}")
+
+        resp = client.post('/api/language-onboarding', json={'action': 'apply', 'choice': 'bogus'})
+        check("invalid choice rejected with 400",
+              resp.status_code == 400 and resp.get_json().get('success') is False,
+              f"got: {resp.status_code} {resp.get_json()}")
+        check("invalid choice does not persist config",
+              len(saved_configs) == 3, f"got: {len(saved_configs)}")
+
+        resp = client.post('/api/language-onboarding', json={'action': 'bogus'})
+        check("invalid action rejected with 400", resp.status_code == 400)
+
+        # Reset the flag, then dismiss via the banner's X button
+        onb_cfg['multilang_onboarding_dismissed'] = False
+        resp = client.post('/api/language-onboarding', json={'action': 'dismiss'})
+        check("dismiss succeeds and sets dismissed flag",
+              resp.status_code == 200
+              and onb_cfg.get('multilang_onboarding_dismissed') is True,
+              f"got: {resp.status_code} {onb_cfg}")
+
+        resp = client.get('/api/language-summary')
+        check("summary reflects dismissed flag",
+              resp.get_json().get('dismissed') is True, f"got: {resp.get_json()}")
+    finally:
+        app_module.load_config = real_load_config
+        app_module.save_config = real_save_config
+        db.set_db_path(old_db_path)
 
     print("\n" + "=" * 60)
     print(f"RESULTS: {passed} passed, {failed} failed")


### PR DESCRIPTION
Follow-up to the language naming pack (#283). Those features are all opt-in, but nothing told the user they exist - a mixed German/English library would just keep processing with native naming unless the owner went digging in Settings.

Now, when a scan has given us language info, the dashboard notices. If your library has books in more than one language (or books that don't match your preferred language), a dismissible banner shows up: "We found books in multiple languages: English (134), German (12)" with three one-click choices - keep native naming, tag non-preferred titles, or sort into language folders. Picking one writes the config right there; dismiss sticks.

What it deliberately does not do: move your existing books. The choice applies to future processing. Reorganizing what's already on disk stays an explicit reprocess through the queue, because that's real file moves and should never happen from a banner click.

Implementation notes:

- `get_language_distribution()` counts languages from book profiles - reads both `detected_language` and `language` keys (the pipeline persists the former; my first pass missed that and counted zero books, caught in container testing)
- `GET /api/language-summary` reports the distribution + whether the prompt should show; `POST /api/language-onboarding` applies a choice or dismisses, persisting `multilang_onboarding_dismissed` either way
- Banner is client-side on the dashboard, uses textContent for the language list since codes come from book profiles

Testing: 21 new checks in test-language-features.py (114 total, plus 290 naming tests green). Browser E2E in the quarantined container: banner rendered with the right language name, "Sort into language folders" click wrote `language_tag_position=top_folder` to config, banner stayed gone after reload. Screenshot verified visually.

Closes nothing yet - #284 stays open until it's confirmed in production.
