### PR TITLE
docs: multi-language naming guide, WWWAUDIOFILE, beta.155 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ All notable changes to Library Manager will be documented in this file.
 ### Fixed
 - **ISO 639-2 normalization** — Three-letter codes from Skaldleita (`eng`, `ger`) are now mapped to ISO 639-1 in `_normalize_language_code`, all three `_extract_detected_language` copies, and defensively in `build_new_path`. Previously they produced `ENG/` top folders and wrongly tagged preferred-language books.
 
+## [0.9.0-beta.155] - 2026-08-12
+
+### Fixed
+- **#273: ASIN persistence** — The ASIN from an Audnexus/Skaldleita match is now persisted to `book_id` on the book profile instead of being dropped after identification.
+- **#275: "Detect language from audio" setting** — The setting now actually drives language detection during processing; detected languages are persisted as `detected_language` on the profile.
+- **#274: Per-book Audible region hint** — `WWWAUDIOFILE` (Audible region URL built from the audio-detected language) is embedded into MP3/MP4 tags when fixes are applied, so downstream tools like beets-audible can pick the right marketplace per book.
+
 ## [0.9.0-beta.154] - 2026-07-14
 
 ### Fixed

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -49,6 +49,37 @@ Author/Series Name/2 - Book Title/
 
 Standalone books stay as `Author/Title/`.
 
+## Multi-Language Naming
+
+For libraries with books in more than one language. All of this is opt-in - by default LM uses "native" naming (a German book gets its German title, no tags, no extra folders).
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Naming mode | `native` | `native` = book's own language, `preferred` = always your library language, `tagged` = preferred + language tag |
+| Add Language Tags | `false` | Master switch for language tags/folders |
+| Tag Format | `bracket_full` | `(Polish)`, `[pl]`, `Polish`, `_pl`, or `🇵🇱` (emoji flag) |
+| Tag Position | `after_title` | `after_title`, `before_title`, `subfolder` (`Author/Language/Title`), or `top_folder` (`Language/Author/Title`) |
+| Code Format | `iso639-1` | Two-letter (`pl`) or three-letter ISO 639-2 bibliographic codes (`pol`, `ger`) for code-based tags and `{lang_code}` |
+
+Notes:
+
+- `top_folder` partitions the **whole** library by language, including books in your preferred language: `German/Brandon Sanderson/Mistborn/01 - The Final Empire`. It wraps every naming format, including custom templates.
+- Tags are only added to books whose language differs from your preferred language (except `top_folder`, which always applies).
+- Custom templates also support `{language}` (full name), `{lang_code}`, and `{lang_flag}` (flag emoji).
+- Three-letter codes from Skaldleita (`eng`, `ger`) are normalized to two-letter internally; the Code Format setting only controls output.
+
+### Series Language Overrides
+
+Settings > Library > **Series Language Overrides**: lock a series to a language (e.g. the German edition of Mistborn → `de`). Books in a locked series skip audio/title language detection entirely. Set to `auto` (or remove the override) to detect per book again. Only applies when the book's series is known. API: `GET/POST/DELETE /api/series-language-overrides`.
+
+### Multi-Language Books
+
+For books containing multiple languages (language courses, dual narration): edit the book in the Library page and pick multiple languages (first = primary). Folder tags show all of them: `Title (German, English)`, `[de,en]`, `🇩🇪 🇬🇧`. The primary language drives the Audible region hint; the full list is kept on the profile for downstream tools. API: `GET/POST /api/books/<id>/languages`.
+
+### Multi-Language Onboarding Prompt
+
+When a scan finds books in multiple languages (or in a language other than your preferred one), a dismissible dashboard banner offers one-click setup: keep native naming, tag non-preferred titles, or sort into language folders. The choice applies to future processing only - existing books are not moved until you reprocess them through the queue.
+
 ## Metadata Embedding (Beta)
 
 When enabled, the app will write verified metadata directly into audio file tags when fixes are applied.
@@ -76,8 +107,11 @@ When enabled, the app will write verified metadata directly into audio file tags
 | Series | - | SERIES |
 | Series # | - | SERIESNUMBER |
 | Narrator | - | NARRATOR |
+| Audible Region URL | - | WWWAUDIOFILE |
 | Edition | - | EDITION |
 | Variant | - | VARIANT |
+
+`WWWAUDIOFILE` holds the per-book Audible product URL (e.g. `https://www.audible.com/pd/B001180MB2`), built from the audio-detected language so downstream tools (beets-audible, etc.) pick the correct marketplace per book instead of relying on one global region setting.
 
 ### Backup Files
 


### PR DESCRIPTION
Fills the doc gaps from the language naming pack and the region-hint fixes.

- Configuration.md gets a Multi-Language Naming section: naming modes, tag formats (incl. emoji flags), positions (incl. top-level folders), ISO 639-2 output, series language overrides, multi-language books, and the onboarding banner - plus the caveat that the banner never moves existing books
- The metadata embedding tag table now lists WWWAUDIOFILE and explains it's the per-book Audible region URL
- CHANGELOG gets the missing 0.9.0-beta.155 entry for the #273/#274/#275 fixes (the version shipped without one)

Docs + changelog only, no code changes.
