### PR TITLE
feat: naming template variables + performance fixes (beta.160)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ test-library/
 
 # Runtime / local state
 .TODO.md
+.PLUGIN-SYSTEM.md
+.SESSIONS.md
 CLAUDE.md
 .nodeterm/
 .playwright-mcp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.160] - 2026-08-20
+
+### Added
+- **#294: `{asin}` custom naming template variable** — The book's Audible ASIN can now be used in custom naming templates (e.g. `{author}/{series}/{series_num.pad(2)} - {title} [{asin}]`). The value comes from the persisted book profile and is only emitted when it passes ASIN validation (`looks_like_asin`), so ISBNs and internal IDs never land in folder names. Empty when no valid ASIN is known; existing cleanup removes leftover empty brackets. Added to the clickable variable list and live preview in Settings.
+- **#200: Separate template for standalone books** — New optional `custom_naming_template_standalone` setting. When set, books without a series use it instead of the main custom template; empty keeps the previous behavior. Settings UI shows a second input with its own no-series live preview, and the tag buttons insert into whichever template field was focused last.
+- **#295: Preserve ripper/release tags** — New `ripper_tags` setting (comma-separated list). A matching trailing `-Tag` on the original folder is detected case-insensitively, kept out of search/matching titles (`clean_search_title` strips it), persisted on the book profile (`BookProfile.ripper`, survives rescans and renames), and exposed as the `{ripper}` custom template variable. Unlisted trailing words are never treated as ripper tags, so legitimate hyphenated titles are untouched.
+
+### Performance
+- **#289: Database indexes** — Added indexes for hot query paths: `history(status)`, `history(book_id)`, `queue(book_id)`, `books(verification_layer)`, `books(status)`. Eliminates full-table scans on dashboard counts, queue lookups, and layer pipeline fetches.
+- **#290: Orphan files cache** — `/api/library` no longer walks every author directory on disk per request. Orphan scan results are cached for 5 minutes; viewing the orphan tab or running organize forces a fresh scan, and organizing invalidates the cache. Especially noticeable on network drives.
+
 ## [0.9.0-beta.159] - 2026-08-17
 
 ### Fixed

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama, OpenAI-compatible APIs)
 """
 
-APP_VERSION = "0.9.0-beta.159"
+APP_VERSION = "0.9.0-beta.160"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:
@@ -68,6 +68,7 @@ from library_manager.utils import (
     # naming
     calculate_title_similarity, extract_series_from_title, clean_search_title,
     standardize_initials, clean_author_name, extract_author_title,
+    extract_ripper_tag,
     # validation
     is_unsearchable_query, is_garbage_author_match, is_garbage_match, is_summary_match, is_placeholder_author, is_drastic_author_change, looks_like_asin,
     # audio
@@ -999,6 +1000,40 @@ def _extract_book_id(result):
             value = str(value).strip()
             if value:
                 return value
+    return None
+
+
+def _parse_ripper_tags(config):
+    """Issue #295: parse the configured ripper/release tag list.
+
+    Stored as a comma- or newline-separated string in config.json.
+    """
+    raw = (config or {}).get('ripper_tags', '') or ''
+    return [t.strip() for t in re.split(r'[,\n]+', raw) if t.strip()]
+
+
+def _resolve_ripper_tag(old_path, profile, config):
+    """Issue #295: ripper tag from the persisted profile, falling back to
+    extracting it from the original folder name using the configured tag list.
+
+    Args:
+        old_path: Original book folder path (basename is inspected).
+        profile: Persisted profile (JSON string or dict), may be None.
+        config: App configuration dict.
+
+    Returns:
+        The ripper tag string, or None.
+    """
+    if profile:
+        try:
+            parsed = json.loads(profile) if isinstance(profile, str) else profile
+        except (json.JSONDecodeError, TypeError):
+            parsed = None
+        if isinstance(parsed, dict) and parsed.get('ripper'):
+            return parsed['ripper']
+    if old_path:
+        _, ripper = extract_ripper_tag(Path(str(old_path)).name, _parse_ripper_tags(config))
+        return ripper
     return None
 
 
@@ -2985,6 +3020,39 @@ def find_orphan_audio_files(lib_path, config=None):
                 })
 
     return orphans
+
+
+# Issue #290: Orphan scan cache. find_orphan_audio_files() walks every author
+# dir on disk, which is painful on network drives when /api/library is polled.
+# Cache the result for 5 minutes; force a rescan when the user is actually
+# viewing the orphan tab or after an organize operation changes the disk state.
+_ORPHAN_CACHE = {'items': [], 'timestamp': 0.0}
+_ORPHAN_CACHE_TTL = 300  # seconds
+
+
+def get_cached_orphans(config, force_refresh=False):
+    """Return orphan audio files, scanning disk at most once per TTL.
+
+    Args:
+        config: App configuration dict.
+        force_refresh: Bypass the cache (e.g. viewing the orphan tab).
+    """
+    now = time.time()
+    if not force_refresh and (now - _ORPHAN_CACHE['timestamp']) < _ORPHAN_CACHE_TTL:
+        return list(_ORPHAN_CACHE['items'])
+
+    orphan_list = []
+    for lib_path in config.get('library_paths', []):
+        orphan_list.extend(find_orphan_audio_files(lib_path, config=config))
+
+    _ORPHAN_CACHE['items'] = orphan_list
+    _ORPHAN_CACHE['timestamp'] = now
+    return list(orphan_list)
+
+
+def invalidate_orphan_cache():
+    """Force the next get_cached_orphans() call to rescan (e.g. after organizing)."""
+    _ORPHAN_CACHE['timestamp'] = 0.0
 
 
 def organize_orphan_files(author_path, book_title, files, config=None):
@@ -6371,6 +6439,20 @@ def apply_fix(history_id):
 
         # Build new path from fix metadata
         # Detect language for multi-language naming
+        # Issue #295: preserve ripper/release tag from profile or original folder
+        ripper_tag = _resolve_ripper_tag(str(old_path), book_row['profile'] if book_row else None, config)
+        if ripper_tag:
+            # Persist so the tag survives rescans and future renames
+            try:
+                _profile = json.loads(book_row['profile']) if book_row and book_row['profile'] else {}
+                if isinstance(_profile, dict) and _profile.get('ripper') != ripper_tag:
+                    _profile['ripper'] = ripper_tag
+                    c.execute('UPDATE books SET profile = ? WHERE id = ?',
+                              (json.dumps(_profile), book_id))
+                    conn.commit()
+            except (json.JSONDecodeError, TypeError) as e:
+                logger.debug(f"[APPLY FIX] Could not persist ripper tag: {e}")
+
         new_path = build_new_path(
             Path(library_paths[0]),
             fix['new_author'] or fix['old_author'],
@@ -6383,6 +6465,8 @@ def apply_fix(history_id):
             variant=fix['new_variant'] if fix['new_variant'] else None,
             language_code=fix_lang,
             languages=fix_languages or None,
+            asin=metadata_book_id,
+            ripper=ripper_tag,
             config=config
         )
         if not new_path:
@@ -7566,6 +7650,10 @@ def settings_page():
         config['update_channel'] = request.form.get('update_channel', 'stable')
         config['naming_format'] = request.form.get('naming_format', 'author/title')
         config['custom_naming_template'] = request.form.get('custom_naming_template', '{author}/{title}').strip()
+        # Issue #200: optional separate template for standalone (non-series) books
+        config['custom_naming_template_standalone'] = request.form.get('custom_naming_template_standalone', '').strip()
+        # Issue #295: comma-separated ripper/release tags to preserve
+        config['ripper_tags'] = request.form.get('ripper_tags', '').strip()
         # Watch folder settings
         config['watch_mode'] = 'watch_mode' in request.form
         config['watch_folder'] = request.form.get('watch_folder', '').strip()
@@ -9955,11 +10043,8 @@ def api_recent_activity():
 def api_orphans():
     """Find orphan audio files (files sitting directly in author folders)."""
     config = load_config()
-    orphans = []
-
-    for lib_path in config.get('library_paths', []):
-        lib_orphans = find_orphan_audio_files(lib_path, config)
-        orphans.extend(lib_orphans)
+    # Explicit orphan view: bypass the cache for fresh disk state (Issue #290)
+    orphans = get_cached_orphans(config, force_refresh=True)
 
     return jsonify({
         'count': len(orphans),
@@ -9980,6 +10065,8 @@ def api_organize_orphan():
 
     config = load_config()
     success, message = organize_orphan_files(author_path, book_title, files, config)
+    if success:
+        invalidate_orphan_cache()  # Issue #290: disk state changed
 
     return jsonify({
         'success': success,
@@ -9993,9 +10080,10 @@ def api_organize_all_orphans():
     config = load_config()
     results = {'organized': 0, 'errors': 0, 'details': []}
 
-    for lib_path in config.get('library_paths', []):
-        orphans = find_orphan_audio_files(lib_path, config)
-
+    # Fresh scan of current disk state, then invalidate since organizing
+    # changes what's on disk (Issue #290)
+    orphans = get_cached_orphans(config, force_refresh=True)
+    try:
         for orphan in orphans:
             if orphan['detected_title'] == 'Unknown Album':
                 results['errors'] += 1
@@ -10015,6 +10103,8 @@ def api_organize_all_orphans():
             else:
                 results['errors'] += 1
                 results['details'].append(f"Error: {orphan['author']}: {message}")
+    finally:
+        invalidate_orphan_cache()
 
     # Issue #57: Auto-scan after organizing to pick up newly created book folders
     # This ensures the database reflects the new folder structure
@@ -10152,10 +10242,9 @@ def api_library():
     c.execute("SELECT COUNT(*) FROM books WHERE validation_status = 'invalid'")
     counts['validation_failed'] = c.fetchone()[0]
 
-    # Count orphans (detected on-the-fly)
-    orphan_list = []
-    for lib_path in config.get('library_paths', []):
-        orphan_list.extend(find_orphan_audio_files(lib_path))
+    # Count orphans (Issue #290: cached disk scan - rescan when viewing the
+    # orphan tab or when the cache is stale)
+    orphan_list = get_cached_orphans(config, force_refresh=(status_filter == 'orphan'))
     counts['orphan'] = len(orphan_list)
 
     # Update 'all' count to include orphans
@@ -12584,11 +12673,22 @@ def api_manual_match():
         # Detect language from title for multi-language naming
         lang_code = detect_title_language(new_title) if new_title else None
 
+        # Issue #294: ASIN for the {asin} template variable - prefer the
+        # selected BookDB result, fall back to the persisted profile
+        c.execute('SELECT profile FROM books WHERE id = ?', (book_id,))
+        _profile_row = c.fetchone()
+        _profile_json = _profile_row['profile'] if _profile_row else None
+        asin_for_path = _extract_book_id(bookdb_result) or _extract_book_id(_profile_json)
+
+        # Issue #295: preserve ripper/release tag from profile or original folder
+        ripper_tag = _resolve_ripper_tag(str(old_path), _profile_json, config)
+
         # Build the new path
         new_path = build_new_path(lib_path, new_author, new_title,
                                   series=new_series, series_num=new_series_num,
                                   narrator=new_narrator, year=new_year,
-                                  language_code=lang_code, config=config)
+                                  language_code=lang_code, asin=asin_for_path,
+                                  ripper=ripper_tag, config=config)
 
         if new_path is None:
             conn.close()
@@ -12758,11 +12858,22 @@ def api_edit_book():
         # Detect language from title for multi-language naming
         lang_code = detect_title_language(new_title) if new_title else None
 
+        # Issue #294: ASIN for the {asin} template variable - prefer the
+        # selected BookDB result, fall back to the persisted profile
+        c.execute('SELECT profile FROM books WHERE id = ?', (book_id,))
+        _profile_row = c.fetchone()
+        _profile_json = _profile_row['profile'] if _profile_row else None
+        asin_for_path = _extract_book_id(bookdb_result) or _extract_book_id(_profile_json)
+
+        # Issue #295: preserve ripper/release tag from profile or original folder
+        ripper_tag = _resolve_ripper_tag(str(old_path), _profile_json, config)
+
         # Build the new path
         new_path = build_new_path(lib_path, new_author, new_title,
                                   series=new_series, series_num=new_series_num,
                                   narrator=new_narrator, year=new_year,
-                                  language_code=lang_code, config=config)
+                                  language_code=lang_code, asin=asin_for_path,
+                                  ripper=ripper_tag, config=config)
 
         if new_path is None:
             conn.close()

--- a/config.example.json
+++ b/config.example.json
@@ -16,6 +16,8 @@
   "update_channel": "stable",
   "naming_format": "author/title",
   "custom_naming_template": "{author}/{title}",
+  "custom_naming_template_standalone": "",
+  "ripper_tags": "",
   "series_grouping": true,
   "ebook_management": false,
   "ebook_library_mode": "merge",

--- a/library_manager/config.py
+++ b/library_manager/config.py
@@ -82,6 +82,8 @@ DEFAULT_CONFIG = {
     "update_channel": "beta",  # "stable", "beta", or "nightly"
     "naming_format": "author/title",  # "author/title", "author - title", "custom"
     "custom_naming_template": "{author}/{title}",  # Custom template with {author}, {title}, {series}, etc.
+    "custom_naming_template_standalone": "",  # Issue #200: optional separate template for non-series books; empty = use main template
+    "ripper_tags": "",  # Issue #295: comma-separated ripper/release tags to preserve (e.g. "H2OKing, SomeGroup"); empty = detection off
     "standardize_author_initials": True,  # Normalize initials: "James S A Corey" -> "James S. A. Corey" (Issue #54)
     # Metadata embedding settings
     "metadata_embedding_enabled": False,  # Embed tags into audio files when fixes are applied

--- a/library_manager/database.py
+++ b/library_manager/database.py
@@ -205,6 +205,14 @@ def init_db(db_path=None):
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )''')
 
+    # Issue #289: indexes for hot query paths (dashboard counts, queue lookups,
+    # layer pipeline fetches). books.path is already indexed via UNIQUE.
+    c.execute('CREATE INDEX IF NOT EXISTS idx_history_status ON history(status)')
+    c.execute('CREATE INDEX IF NOT EXISTS idx_history_book_id ON history(book_id)')
+    c.execute('CREATE INDEX IF NOT EXISTS idx_queue_book_id ON queue(book_id)')
+    c.execute('CREATE INDEX IF NOT EXISTS idx_books_verification_layer ON books(verification_layer)')
+    c.execute('CREATE INDEX IF NOT EXISTS idx_books_status ON books(status)')
+
     conn.commit()
     conn.close()
 

--- a/library_manager/models/book_profile.py
+++ b/library_manager/models/book_profile.py
@@ -253,6 +253,7 @@ class BookProfile:
     book_id: Optional[str] = None                # Book ID (ISBN, ASIN, internal)
     version_id: Optional[str] = None             # Unique recording version ID
     voice_cluster_id: Optional[str] = None       # Voice cluster for unknown narrators
+    ripper: Optional[str] = None                 # Issue #295: preserved ripper/release tag from original folder
 
     def add_author(self, source: str, author: str, weight: int = None):
         """Add author source with validation to prevent garbage recommendations.
@@ -476,6 +477,7 @@ class BookProfile:
         result['book_id'] = self.book_id
         result['version_id'] = self.version_id
         result['voice_cluster_id'] = self.voice_cluster_id
+        result['ripper'] = self.ripper
         return result
 
     @classmethod
@@ -504,6 +506,7 @@ class BookProfile:
         profile.book_id = data.get('book_id')
         profile.version_id = data.get('version_id')
         profile.voice_cluster_id = data.get('voice_cluster_id')
+        profile.ripper = data.get('ripper')
         return profile
 
 

--- a/library_manager/utils/__init__.py
+++ b/library_manager/utils/__init__.py
@@ -3,6 +3,7 @@
 from library_manager.utils.naming import (
     calculate_title_similarity,
     extract_series_from_title,
+    extract_ripper_tag,
     clean_search_title,
     standardize_initials,
     clean_author_name,

--- a/library_manager/utils/naming.py
+++ b/library_manager/utils/naming.py
@@ -88,8 +88,39 @@ def extract_series_from_title(title):
     return None, None, title
 
 
-def clean_search_title(messy_name):
-    """Clean up a messy filename to extract searchable title."""
+def extract_ripper_tag(name, tags):
+    """Strip a configured trailing ripper/release tag from a folder/file name.
+
+    Issue #295: Only tags from the user-configured list are stripped, so
+    legitimate hyphenated titles stay untouched. Matches "-Tag" or "- Tag"
+    at the end of the name, case-insensitively.
+
+    Args:
+        name: Folder or file name (e.g. "The Final Empire -H2OKing")
+        tags: Iterable of configured ripper/release tags (e.g. ["H2OKing"])
+
+    Returns:
+        (cleaned_name, ripper_tag or None)
+    """
+    if not name or not tags:
+        return name, None
+    for tag in tags:
+        tag = str(tag).strip().lstrip('-').strip()
+        if not tag:
+            continue
+        match = re.search(r'\s*-\s*' + re.escape(tag) + r'\s*$', name, re.IGNORECASE)
+        if match:
+            cleaned = name[:match.start()].rstrip(' -')
+            return cleaned, tag
+    return name, None
+
+
+def clean_search_title(messy_name, ripper_tags=None):
+    """Clean up a messy filename to extract searchable title.
+
+    Issue #295: when ripper_tags (configured release tags) are given, a
+    trailing ripper tag is stripped too so it can't pollute search queries.
+    """
     # Remove common junk patterns
     clean = messy_name
 
@@ -128,6 +159,9 @@ def clean_search_title(messy_name):
     # Also handles "02 Night" (number + space, no separator) which is common in downloads
     # These are common in audiobook folders but mess up search
     clean = re.sub(r'^(?:track\s*)?\d+\s*[-–—:.]?\s+', '', clean, flags=re.IGNORECASE)
+
+    # Issue #295: Strip configured ripper/release tags (e.g. "-H2OKing")
+    clean, _ = extract_ripper_tag(clean, ripper_tags)
 
     # Remove extra whitespace
     clean = re.sub(r'\s+', ' ', clean)
@@ -331,6 +365,7 @@ def extract_author_title(messy_name, clean_author=True):
 __all__ = [
     'calculate_title_similarity',
     'extract_series_from_title',
+    'extract_ripper_tag',
     'clean_search_title',
     'strip_encoding_junk',
     'standardize_initials',

--- a/library_manager/utils/path_safety.py
+++ b/library_manager/utils/path_safety.py
@@ -5,6 +5,7 @@ from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Optional, Tuple
 from library_manager.utils.naming import strip_encoding_junk, standardize_initials
+from library_manager.utils.validation import looks_like_asin
 
 logger = logging.getLogger(__name__)
 
@@ -522,7 +523,8 @@ def find_existing_author_folder(lib_path, target_author) -> Optional[str]:
 
 
 def build_new_path(lib_path, author, title, series=None, series_num=None, narrator=None, year=None,
-                   edition=None, variant=None, language=None, language_code=None, languages=None, config=None):
+                   edition=None, variant=None, language=None, language_code=None, languages=None,
+                   asin=None, ripper=None, config=None):
     """Build a new path based on the naming format configuration.
 
     Audiobookshelf-compatible format (when series_grouping enabled):
@@ -548,6 +550,11 @@ def build_new_path(lib_path, author, title, series=None, series_num=None, narrat
         languages: Ordered list of ISO 639-1 codes, primary first (optional,
             Issue #280). When multiple languages are present and tagging
             applies, the tag shows all of them (e.g. "(German, English)").
+        asin: Audible ASIN (optional, Issue #294). Only used in custom
+            templates via {asin}, and only when it passes ASIN validation -
+            ISBNs or internal IDs resolve to empty.
+        ripper: Preserved ripper/release tag (optional, Issue #295). Only
+            used in custom templates via {ripper}; empty when none detected.
         config: Configuration dict
 
     SAFETY: Returns None if path would be invalid/dangerous.
@@ -679,6 +686,11 @@ def build_new_path(lib_path, author, title, series=None, series_num=None, narrat
     if naming_format == 'custom':
         # Custom template: parse and replace tags
         custom_template = config.get('custom_naming_template', '{author}/{title}') if config else '{author}/{title}'
+        # Issue #200: separate template for standalone (non-series) books.
+        # Empty/unset falls back to the main template.
+        standalone_template = (config.get('custom_naming_template_standalone', '') or '').strip() if config else ''
+        if standalone_template and not safe_series:
+            custom_template = standalone_template
 
         # Prepare all available data for replacement
         safe_narrator = sanitize_path_component(narrator) if narrator else ''
@@ -746,6 +758,13 @@ def build_new_path(lib_path, author, title, series=None, series_num=None, narrat
         path_str = path_str.replace('{lang_code}', lang_code_for_display(language_code, tpl_code_format) if language_code else '')
         # Issue #282: {lang_flag} - flag emoji for the book's language
         path_str = path_str.replace('{lang_flag}', LANGUAGE_FLAGS.get(language_code, '') if language_code else '')
+        # Issue #294: {asin} - validated ASIN only; anything else (ISBN,
+        # internal IDs) resolves to empty and cleanup removes empty brackets
+        safe_asin = str(asin).strip().upper() if asin and looks_like_asin(asin) else ''
+        path_str = path_str.replace('{asin}', safe_asin)
+        # Issue #295: {ripper} - preserved ripper/release tag, empty when none
+        safe_ripper = sanitize_path_component(ripper) if ripper else ''
+        path_str = path_str.replace('{ripper}', safe_ripper or '')
 
         # Clean up empty brackets/parens from missing optional data
         path_str = re.sub(r'\(\s*\)', '', path_str)  # Empty ()
@@ -756,6 +775,7 @@ def build_new_path(lib_path, author, title, series=None, series_num=None, narrat
         path_str = re.sub(r'^-\s+', '', path_str)  # Leading "- " at start
         path_str = re.sub(r'^\s*-\s+', '', path_str)  # Leading " - " at start (with space)
         path_str = re.sub(r'\s+-$', '', path_str)  # Trailing " -" at end
+        path_str = re.sub(r'(?<=\S)-$', '', path_str)  # Trailing "-" at end (Issue #295: "{title}-{ripper}" with no ripper)
         path_str = re.sub(r'/+', '/', path_str)  # Multiple slashes
         path_str = re.sub(r'\s{2,}', ' ', path_str)  # Multiple spaces
         path_str = path_str.strip(' /')

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -126,7 +126,8 @@
                                            name="custom_naming_template" id="custom_naming_template"
                                            value="{{ config.custom_naming_template or '{author}/{title}' }}"
                                            placeholder="{author}/{title}"
-                                           oninput="updateNamingPreview()">
+                                           oninput="updateNamingPreview()"
+                                           onfocus="activeTemplateInputId = this.id">
                                     <button type="button" class="btn btn-outline-secondary" onclick="clearNamingTemplate()">
                                         <i class="bi bi-x-lg"></i>
                                     </button>
@@ -145,6 +146,8 @@
                                         <button type="button" class="btn btn-sm btn-outline-warning naming-tag" onclick="insertTag('{series_num.pad(2)}')" title="Zero-pad to 2 digits: 1→01, 10→10">{series_num.pad(2)}</button>
                                         <button type="button" class="btn btn-sm btn-outline-success naming-tag" onclick="insertTag('{narrator}')">{narrator}</button>
                                         <button type="button" class="btn btn-sm btn-outline-secondary naming-tag" onclick="insertTag('{year}')">{year}</button>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary naming-tag" onclick="insertTag('{asin}')" title="Audible ASIN (empty if none): B002V0QCYU">{asin}</button>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary naming-tag" onclick="insertTag('{ripper}')" title="Preserved ripper/release tag (empty if none): -H2OKing">{ripper}</button>
                                         <button type="button" class="btn btn-sm btn-outline-primary naming-tag" onclick="insertTag('{language}')" title="Full language name: English, Russian, Polish">{language}</button>
                                         <button type="button" class="btn btn-sm btn-outline-primary naming-tag" onclick="insertTag('{lang_code}')" title="ISO code: en, ru, pl (or eng, rus, pol with ISO 639-2 code format)">{lang_code}</button>
                                         <button type="button" class="btn btn-sm btn-outline-primary naming-tag" onclick="insertTag('{lang_flag}')" title="Flag emoji: 🇬🇧, 🇷🇺, 🇵🇱">{lang_flag}</button>
@@ -155,6 +158,36 @@
 
                                 <div class="alert alert-dark small py-2 mb-0">
                                     <strong>Preview:</strong> <code id="preview-output">Brandon Sanderson/The Final Empire</code>
+                                </div>
+
+                                <!-- Issue #200: Separate template for standalone (non-series) books -->
+                                <div class="mt-3">
+                                    <label class="form-label">Standalone Book Template <small class="text-muted">(optional)</small></label>
+                                    <div class="input-group mb-2">
+                                        <input type="text" class="form-control bg-dark text-light font-monospace"
+                                               name="custom_naming_template_standalone" id="custom_naming_template_standalone"
+                                               value="{{ config.custom_naming_template_standalone or '' }}"
+                                               placeholder="Leave empty to use the main template for all books"
+                                               oninput="updateNamingPreview()"
+                                               onfocus="activeTemplateInputId = this.id">
+                                        <button type="button" class="btn btn-outline-secondary" onclick="clearNamingTemplate()">
+                                            <i class="bi bi-x-lg"></i>
+                                        </button>
+                                    </div>
+                                    <small class="text-muted d-block mb-1"><i class="bi bi-info-circle"></i> Used for books <strong>without</strong> a series. If empty, the main template applies to all books.</small>
+                                    <div class="alert alert-dark small py-2 mb-0">
+                                        <strong>Preview (no series):</strong> <code id="preview-output-standalone">Brandon Sanderson/The Final Empire</code>
+                                    </div>
+                                </div>
+
+                                <!-- Issue #295: Ripper/release tag preservation -->
+                                <div class="mt-3">
+                                    <label class="form-label">Ripper/Release Tags <small class="text-muted">(optional)</small></label>
+                                    <input type="text" class="form-control bg-dark text-light font-monospace"
+                                           name="ripper_tags" id="ripper_tags"
+                                           value="{{ config.ripper_tags or '' }}"
+                                           placeholder="H2OKing, SomeOtherGroup">
+                                    <small class="text-muted d-block mt-1"><i class="bi bi-info-circle"></i> Comma-separated list. A matching trailing <code>-Tag</code> on the original folder is preserved and available as <code>{ripper}</code> instead of being lost during renaming.</small>
                                 </div>
                             </div>
 
@@ -2169,7 +2202,9 @@ const sampleData = {
     series: 'Mistborn',
     series_num: '1',
     narrator: 'Michael Kramer',
-    year: '2006'
+    year: '2006',
+    asin: 'B002V0QCYU',
+    ripper: 'H2OKing'
 };
 
 function toggleCustomNaming() {
@@ -2180,8 +2215,12 @@ function toggleCustomNaming() {
     }
 }
 
+// Issue #200: tag buttons insert into whichever template input was focused last
+let activeTemplateInputId = 'custom_naming_template';
+const sampleDataStandalone = Object.assign({}, sampleData, {series: '', series_num: ''});
+
 function insertTag(tag) {
-    const input = document.getElementById('custom_naming_template');
+    const input = document.getElementById(activeTemplateInputId) || document.getElementById('custom_naming_template');
     const start = input.selectionStart;
     input.value = input.value.substring(0, start) + tag + input.value.substring(input.selectionEnd);
     input.focus();
@@ -2190,20 +2229,32 @@ function insertTag(tag) {
 }
 
 function clearNamingTemplate() {
-    document.getElementById('custom_naming_template').value = '';
+    const input = document.getElementById(activeTemplateInputId) || document.getElementById('custom_naming_template');
+    input.value = '';
     updateNamingPreview();
 }
 
-function updateNamingPreview() {
-    let preview = document.getElementById('custom_naming_template').value || '{author}/{title}';
+function renderTemplatePreview(inputId, outputId, data, fallback) {
+    const input = document.getElementById(inputId);
+    const output = document.getElementById(outputId);
+    if (!input || !output) return;
+    let preview = input.value || fallback;
     // Issue #80: Handle .pad(N) modifier for series_num
     preview = preview.replace(/\{series_num\.pad\((\d+)\)\}/g, (match, width) => {
-        const num = parseInt(sampleData.series_num || '0');
+        if (!data.series_num) return '';
+        const num = parseInt(data.series_num);
         return String(num).padStart(parseInt(width), '0');
     });
-    Object.keys(sampleData).forEach(key => { preview = preview.replace(new RegExp(`\\{${key}\\}`, 'g'), sampleData[key] || ''); });
-    preview = preview.replace(/\(\s*\)/g, '').replace(/\/+/g, '/').replace(/\s{2,}/g, ' ').trim();
-    document.getElementById('preview-output').textContent = preview || '(empty)';
+    Object.keys(data).forEach(key => { preview = preview.replace(new RegExp(`\\{${key}\\}`, 'g'), data[key] || ''); });
+    preview = preview.replace(/\(\s*\)/g, '').replace(/\[\s*\]/g, '').replace(/\/+/g, '/').replace(/\s{2,}/g, ' ').trim();
+    output.textContent = preview || '(empty)';
+}
+
+function updateNamingPreview() {
+    renderTemplatePreview('custom_naming_template', 'preview-output', sampleData, '{author}/{title}');
+    // Standalone preview: empty standalone template falls back to the main template
+    const mainTemplate = document.getElementById('custom_naming_template').value || '{author}/{title}';
+    renderTemplatePreview('custom_naming_template_standalone', 'preview-output-standalone', sampleDataStandalone, mainTemplate);
 }
 
 // Logs

--- a/test-env/test-naming-issues.py
+++ b/test-env/test-naming-issues.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from app import (
     clean_search_title,
     extract_series_from_title,
+    extract_ripper_tag,
     build_new_path,
     is_garbage_match,
     is_summary_match,
@@ -137,6 +138,226 @@ def main():
         path_str = str(result)
         if test_result("With series = proper format",
                        "Mistborn" in path_str and "1 - " in path_str,
+                       f"Got path: {path_str}"):
+            passed += 1
+        else:
+            failed += 1
+    else:
+        failed += 1
+        print(f"[FAIL] build_new_path returned None")
+
+    # ==========================================
+    # Issue #294: {asin} template variable
+    # ==========================================
+    print("\n--- Issue #294: {asin} template variable ---")
+
+    asin_config = {
+        'naming_format': 'custom',
+        'custom_naming_template': '{author}/{series}/{series_num.pad(2)} - {title} [{asin}]',
+        'series_grouping': True
+    }
+
+    # Valid ASIN - included in path
+    result = build_new_path(lib_path, "Brandon Sanderson", "The Final Empire",
+                           series="Mistborn", series_num="1",
+                           asin="B002V0QCYU", config=asin_config)
+    if result:
+        path_str = str(result)
+        if test_result("Valid ASIN included",
+                       "01 - The Final Empire [B002V0QCYU]" in path_str,
+                       f"Got path: {path_str}"):
+            passed += 1
+        else:
+            failed += 1
+    else:
+        failed += 1
+        print(f"[FAIL] build_new_path returned None")
+
+    # No ASIN - brackets cleaned up, no empty []
+    result = build_new_path(lib_path, "Brandon Sanderson", "The Final Empire",
+                           series="Mistborn", series_num="1",
+                           asin=None, config=asin_config)
+    if result:
+        path_str = str(result)
+        if test_result("Missing ASIN = no empty brackets",
+                       "[]" not in path_str and "The Final Empire" in path_str,
+                       f"Got path: {path_str}"):
+            passed += 1
+        else:
+            failed += 1
+    else:
+        failed += 1
+        print(f"[FAIL] build_new_path returned None")
+
+    # ISBN or internal ID - rejected, resolves to empty
+    result = build_new_path(lib_path, "Brandon Sanderson", "The Final Empire",
+                           series="Mistborn", series_num="1",
+                           asin="9780765350381",  # 13-digit ISBN, not an ASIN
+                           config=asin_config)
+    if result:
+        path_str = str(result)
+        if test_result("ISBN rejected from {asin}",
+                       "9780765350381" not in path_str and "[]" not in path_str,
+                       f"Got path: {path_str}"):
+            passed += 1
+        else:
+            failed += 1
+    else:
+        failed += 1
+        print(f"[FAIL] build_new_path returned None")
+
+    # ==========================================
+    # Issue #200: Separate standalone (no-series) template
+    # ==========================================
+    print("\n--- Issue #200: Standalone vs series templates ---")
+
+    dual_config = {
+        'naming_format': 'custom',
+        'custom_naming_template': '{author}/{series}/{series_num.pad(2)} - {title}',
+        'custom_naming_template_standalone': '{author}/{title} ({year})',
+        'series_grouping': True
+    }
+
+    # Book with series uses the main template
+    result = build_new_path(lib_path, "Brandon Sanderson", "The Final Empire",
+                           series="Mistborn", series_num="1", year="2006",
+                           config=dual_config)
+    if result:
+        path_str = str(result)
+        if test_result("Series book uses main template",
+                       "Mistborn/01 - The Final Empire" in path_str and "(2006)" not in path_str,
+                       f"Got path: {path_str}"):
+            passed += 1
+        else:
+            failed += 1
+    else:
+        failed += 1
+        print(f"[FAIL] build_new_path returned None")
+
+    # Standalone book uses the standalone template
+    result = build_new_path(lib_path, "Andy Weir", "Project Hail Mary",
+                           series=None, series_num=None, year="2021",
+                           config=dual_config)
+    if result:
+        path_str = str(result)
+        if test_result("Standalone book uses standalone template",
+                       "Andy Weir/Project Hail Mary (2021)" in path_str,
+                       f"Got path: {path_str}"):
+            passed += 1
+        else:
+            failed += 1
+    else:
+        failed += 1
+        print(f"[FAIL] build_new_path returned None")
+
+    # Empty standalone template falls back to the main template
+    fallback_config = dict(dual_config)
+    fallback_config['custom_naming_template_standalone'] = ''
+    result = build_new_path(lib_path, "Andy Weir", "Project Hail Mary",
+                           series=None, series_num=None, config=fallback_config)
+    if result:
+        path_str = str(result)
+        if test_result("Empty standalone template falls back to main",
+                       "Andy Weir/Project Hail Mary" in path_str,
+                       f"Got path: {path_str}"):
+            passed += 1
+        else:
+            failed += 1
+    else:
+        failed += 1
+        print(f"[FAIL] build_new_path returned None")
+
+    # ==========================================
+    # Issue #295: Preserve ripper/release tags
+    # ==========================================
+    print("\n--- Issue #295: Ripper/release tag preservation ---")
+
+    ripper_tags = ['H2OKing', 'SomeGroup']
+
+    # Detection: configured trailing tags are stripped and returned
+    detection_cases = [
+        ("The Final Empire -H2OKing", "The Final Empire", "H2OKing"),
+        ("Columbus Day-H2OKing", "Columbus Day", "H2OKing"),
+        ("Dungeon Crawler Carl - H2OKing", "Dungeon Crawler Carl", "H2OKing"),
+        ("The Final Empire -h2oking", "The Final Empire", "H2OKing"),  # case-insensitive match, canonical config casing
+        ("The Final Empire", "The Final Empire", None),  # no tag
+        ("The Final Empire -UnknownGroup", "The Final Empire -UnknownGroup", None),  # unconfigured tag untouched
+        ("Book - Title With Hyphen", "Book - Title With Hyphen", None),  # legit hyphen untouched
+    ]
+    for folder, expected_clean, expected_tag in detection_cases:
+        cleaned, tag = extract_ripper_tag(folder, ripper_tags)
+        if test_result(f"extract_ripper_tag('{folder}')",
+                       cleaned == expected_clean and tag == (expected_tag or None),
+                       f"Got cleaned='{cleaned}' tag={tag}"):
+            passed += 1
+        else:
+            failed += 1
+
+    # No configured tags = detection off
+    cleaned, tag = extract_ripper_tag("The Final Empire -H2OKing", [])
+    if test_result("Empty tag list = detection off",
+                   cleaned == "The Final Empire -H2OKing" and tag is None,
+                   f"Got cleaned='{cleaned}' tag={tag}"):
+        passed += 1
+    else:
+        failed += 1
+
+    # clean_search_title strips configured ripper tags
+    result = clean_search_title("The Final Empire -H2OKing", ripper_tags=ripper_tags)
+    if test_result("clean_search_title strips ripper tag",
+                   "h2oking" not in result.lower() and "final empire" in result.lower(),
+                   f"Got '{result}'"):
+        passed += 1
+    else:
+        failed += 1
+
+    # {ripper} template variable
+    ripper_config = {
+        'naming_format': 'custom',
+        'custom_naming_template': '{author}/{title} -{ripper}',
+        'ripper_tags': 'H2OKing, SomeGroup'
+    }
+    result = build_new_path(lib_path, "Brandon Sanderson", "The Final Empire",
+                           ripper="H2OKing", config=ripper_config)
+    if result:
+        path_str = str(result)
+        if test_result("{ripper} included when present",
+                       "The Final Empire -H2OKing" in path_str,
+                       f"Got path: {path_str}"):
+            passed += 1
+        else:
+            failed += 1
+    else:
+        failed += 1
+        print(f"[FAIL] build_new_path returned None")
+
+    result = build_new_path(lib_path, "Brandon Sanderson", "The Final Empire",
+                           ripper=None, config=ripper_config)
+    if result:
+        path_str = str(result)
+        if test_result("{ripper} empty = no dangling dash",
+                       path_str.endswith("The Final Empire"),
+                       f"Got path: {path_str}"):
+            passed += 1
+        else:
+            failed += 1
+    else:
+        failed += 1
+        print(f"[FAIL] build_new_path returned None")
+
+    # Combined with {asin} (Issue #294 example from #295)
+    combo_config = {
+        'naming_format': 'custom',
+        'custom_naming_template': '{author}/{series}/{series_num.pad(2)} - {title} [{asin}] -{ripper}',
+        'series_grouping': True
+    }
+    result = build_new_path(lib_path, "Brandon Sanderson", "The Final Empire",
+                           series="Mistborn", series_num="1",
+                           asin="B002V0QCYU", ripper="H2OKing", config=combo_config)
+    if result:
+        path_str = str(result)
+        if test_result("{asin} + {ripper} combined",
+                       "01 - The Final Empire [B002V0QCYU] -H2OKing" in path_str,
                        f"Got path: {path_str}"):
             passed += 1
         else:


### PR DESCRIPTION
## Summary

Batch of five community issues — three naming features and two performance fixes.

- **#294** — `{asin}` custom naming template variable. Value comes from the persisted book profile and is only emitted when it passes `looks_like_asin()` validation, so ISBNs/internal IDs resolve to empty. Wired through `apply_fix` and both manual-match endpoints; added to the Settings clickable variable list and live preview.
- **#200** — Optional `custom_naming_template_standalone` setting: books without a series use it when set; empty = main template for everything (backwards compatible). Settings UI gets a second input with its own no-series live preview; tag buttons insert into whichever template field was focused last.
- **#295** — Ripper/release tag preservation. New `ripper_tags` config (comma-separated). `extract_ripper_tag()` matches only configured trailing `-Tag` suffixes (case-insensitive, canonical config casing), `clean_search_title()` strips them from search queries, the tag is persisted as `BookProfile.ripper`, and `{ripper}` is available in custom templates with dangling-dash cleanup. Unlisted suffixes are never touched, so legitimate hyphenated titles are safe.
- **#289** — DB indexes on `history(status)`, `history(book_id)`, `queue(book_id)`, `books(verification_layer)`, `books(status)`.
- **#290** — Orphan file scan cache (5-min TTL) for `/api/library`; force-refresh when viewing the orphan tab or `/api/orphans`, invalidated after organize operations. Fixes the network-drive pain.

## Testing

- `test-env/test-naming-issues.py`: 318/318 pass (13 new tests for #294/#200/#295)
- `test-env/test-language-features.py`: 114/114 pass
- `test-env/test-issue-273-274-275.py`: pass (ASIN regression)
- `ruff check`: no new findings (pre-existing F541/W293 legacy noise unchanged)
- **Isolated-instance E2E** (fresh `DATA_DIR`, scratch library, port 5858):
  - Boot on clean DB, all main pages 200
  - Rename flow A: `Columbus Day (Unabridged) -H2OKing` → `Columbus Day -H2OKing` (standalone template, ripper preserved + persisted to profile)
  - Rename flow B: `Expeditionary Force 1 - Columbus Day -H2OKing` → `Expeditionary Force/01 - Columbus Day [B01N48VJFJ]` (main template, `pad(2)`, `{asin}`)
  - Orphan cache: first call 0.079s, cached call 0.0025s; orphan tab forces refresh; organize invalidates immediately (count 0 on next poll)
  - Settings page renders new fields; save roundtrip persists all new config keys
- ⚠️ Docker container integration suite (`run-integration-tests.sh --local`) could **not** be run — no working container runtime in the dev environment (dockerd down, rootless podman broken). Recommend a CI run or maintainer run before merge.

## Notes

- Issues stay open per repo lifecycle until confirmed in production: Refs #289, Refs #290, Refs #294, Refs #200, Refs #295
- Pre-existing issue spotted during E2E (not caused by this batch): `apply_fix` moves files before the `books.path` UPDATE; a UNIQUE constraint failure leaves the move done but the DB row stale. Worth a follow-up issue.