### PR TITLE
fix: contain ffmpeg memory use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.163] - 2026-08-25
+
+### Fixed
+- **#303: Bounded ffmpeg audio probes** — Intro and shared sample extraction now run with a 2 GiB per-process address-space ceiling on POSIX hosts, cap individual ffmpeg allocations, disable non-audio streams, and explicitly select the first audio stream. Pathological media now fails the probe instead of exhausting host memory.
+
+### Operations
+- **Systemd memory containment** — The documented service and checked-in drop-in apply `MemoryHigh=2G`, `MemoryMax=4G`, `MemorySwapMax=1G`, and `OOMPolicy=continue`, containing oversized audio children while keeping the web process available. Operators using deliberately large local models can raise the values explicitly.
+
 ## [0.9.0-beta.162] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Library Manager will be documented in this file.
 ## [0.9.0-beta.163] - 2026-08-25
 
 ### Fixed
-- **#303: Bounded ffmpeg audio probes** — Intro and shared sample extraction now run with a 2 GiB per-process address-space ceiling on POSIX hosts, cap individual ffmpeg allocations, disable non-audio streams, and explicitly select the first audio stream. Pathological media now fails the probe instead of exhausting host memory.
+- **#303: Bounded ffmpeg audio probes** — Audio validation, intro extraction, fingerprinting, and voice-embedding ffmpeg commands now run with a 2 GiB per-process address-space ceiling on POSIX hosts, cap individual ffmpeg allocations, disable non-audio streams, and explicitly select the first audio stream. Pathological media now fails the probe instead of exhausting host memory.
 
 ### Operations
 - **Systemd memory containment** — The documented service and checked-in drop-in apply `MemoryHigh=2G`, `MemoryMax=4G`, `MemorySwapMax=1G`, and `OOMPolicy=continue`, containing oversized audio children while keeping the web process available. Operators using deliberately large local models can raise the values explicitly.

--- a/app.py
+++ b/app.py
@@ -3878,12 +3878,13 @@ def transcribe_audio_clip(file_path, duration_seconds=30):
                 tmp_path = tmp.name
 
             # Extract 30 seconds starting at 60 seconds in (skip intro)
-            subprocess.run([
-                'ffmpeg', '-y', '-i', str(file_path),
+            subprocess.run(build_limited_ffmpeg_command([
+                '-y', '-i', str(file_path),
                 '-ss', '60', '-t', str(duration_seconds),
+                '-map', '0:a:0', '-vn', '-sn', '-dn',
                 '-acodec', 'libmp3lame', '-ar', '16000',
                 tmp_path
-            ], capture_output=True, timeout=30)
+            ]), capture_output=True, timeout=30)
 
             # Send to Whisper API
             with open(tmp_path, 'rb') as audio_file:

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama, OpenAI-compatible APIs)
 """
 
-APP_VERSION = "0.9.0-beta.162"
+APP_VERSION = "0.9.0-beta.163"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:
@@ -74,7 +74,7 @@ from library_manager.utils import (
     # audio
     AUDIO_EXTENSIONS, EBOOK_EXTENSIONS,
     get_first_audio_file, extract_audio_sample, extract_audio_sample_from_middle,
-    find_audio_files, find_ebook_files,
+    find_audio_files, find_ebook_files, build_limited_ffmpeg_command,
     # path_safety
     sanitize_path_component, build_new_path,
 )
@@ -6047,14 +6047,15 @@ def transcribe_audio_intro(file_path, duration_seconds=45):
 
             # Use -ss BEFORE -i for fast input seeking
             # Keep 22050Hz stereo for better quality than 16kHz mono
-            result = subprocess.run([
-                'ffmpeg', '-y',
+            result = subprocess.run(build_limited_ffmpeg_command([
+                '-y',
                 '-ss', '0',  # Fast seek to start
                 '-i', str(file_path),
                 '-t', str(duration_seconds),  # Extract only this duration
+                '-map', '0:a:0', '-vn', '-sn', '-dn',
                 '-acodec', 'libmp3lame', '-ar', '22050', '-ab', '128k',
                 tmp_path
-            ], capture_output=True, timeout=120)  # 120s for large m4b files with moov at end
+            ]), capture_output=True, timeout=120)  # 120s for large m4b files with moov at end
 
             if result.returncode == 0:
                 # Build initial prompt from folder hints to help with proper noun spelling
@@ -6118,14 +6119,15 @@ def transcribe_audio_intro(file_path, duration_seconds=45):
                 tmp_path = tmp.name
 
             # Use -ss BEFORE -i for fast input seeking
-            subprocess.run([
-                'ffmpeg', '-y',
+            subprocess.run(build_limited_ffmpeg_command([
+                '-y',
                 '-ss', '0',
                 '-i', str(file_path),
                 '-t', str(duration_seconds),
+                '-map', '0:a:0', '-vn', '-sn', '-dn',
                 '-acodec', 'libmp3lame', '-ar', '16000', '-ac', '1',
                 tmp_path
-            ], capture_output=True, timeout=120)  # 120s for large m4b files
+            ]), capture_output=True, timeout=120)  # 120s for large m4b files
 
             with open(tmp_path, 'rb') as audio_file:
                 response = requests.post(
@@ -6154,14 +6156,15 @@ def transcribe_audio_intro(file_path, duration_seconds=45):
                 tmp_path = tmp.name
 
             # Use -ss BEFORE -i for fast input seeking
-            result = subprocess.run([
-                'ffmpeg', '-y',
+            result = subprocess.run(build_limited_ffmpeg_command([
+                '-y',
                 '-ss', '0',
                 '-i', str(file_path),
                 '-t', str(duration_seconds),
+                '-map', '0:a:0', '-vn', '-sn', '-dn',
                 '-acodec', 'libmp3lame', '-ar', '16000', '-ac', '1',
                 tmp_path
-            ], capture_output=True, timeout=120)  # 120s for large m4b files
+            ]), capture_output=True, timeout=120)  # 120s for large m4b files
 
             if result.returncode == 0 and os.path.exists(tmp_path):
                 # Read audio file and encode as base64

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -64,12 +64,25 @@ ExecStart=/usr/bin/python3 app.py
 Restart=always
 RestartSec=10
 
+# Bound the app and all ffmpeg children. Raise these values if an explicitly
+# configured local model needs more memory.
+MemoryHigh=2G
+MemoryMax=4G
+MemorySwapMax=1G
+OOMPolicy=continue
+
 [Install]
 WantedBy=multi-user.target
 EOF
 
 sudo systemctl enable --now library-manager
 ```
+
+The same memory settings are available as the checked-in
+`systemd/library-manager-memory.conf` drop-in. Audio probes also default to a
+2 GiB per-process address-space ceiling. Set
+`LIBRARY_MANAGER_FFMPEG_MEMORY_MB` in the service environment only when a
+verified workload requires a different value.
 
 ### Check Status
 

--- a/library_manager/file_validation.py
+++ b/library_manager/file_validation.py
@@ -12,6 +12,8 @@ import logging
 from pathlib import Path
 from typing import Tuple, Optional, Dict, Any, List, Callable
 
+from library_manager.utils.audio import build_limited_ffmpeg_command
+
 logger = logging.getLogger(__name__)
 
 # Minimum requirements for a valid audiobook
@@ -162,12 +164,13 @@ def can_seek_to_end(path: str) -> bool:
     """Check if we can read the last 10 seconds of the file."""
     try:
         result = subprocess.run(
-            [
-                'ffmpeg', '-v', 'error',
+            build_limited_ffmpeg_command([
+                '-v', 'error',
                 '-sseof', '-10',  # Seek to 10 seconds before end
                 '-i', path,
+                '-map', '0:a:0', '-vn', '-sn', '-dn',
                 '-f', 'null', '-'
-            ],
+            ]),
             capture_output=True,
             timeout=FFPROBE_TIMEOUT
         )

--- a/library_manager/providers/bookdb.py
+++ b/library_manager/providers/bookdb.py
@@ -34,6 +34,7 @@ from library_manager.utils.voice_embedding import (
     is_voice_embedding_available,
     extract_voice_embedding_from_clip,
 )
+from library_manager.utils.audio import build_limited_ffmpeg_command
 
 logger = logging.getLogger(__name__)
 
@@ -394,16 +395,16 @@ def identify_audio_with_bookdb(audio_file, extract_seconds=90, bookdb_url=None, 
         try:
             # Use ffmpeg to extract the intro - use fast seek for large files
             logger.debug(f"[SKALDLEITA] Extracting {extract_seconds}s from {audio_path.name}")
-            cmd = [
-                'ffmpeg', '-y',
+            cmd = build_limited_ffmpeg_command([
+                '-y',
                 '-ss', '0',  # Fast input seek
                 '-i', str(audio_path),
                 '-t', str(extract_seconds),
-                '-vn',  # No video (faster)
+                '-map', '0:a:0', '-vn', '-sn', '-dn',
                 '-acodec', 'libmp3lame', '-q:a', '5',
                 '-loglevel', 'error',
                 tmp_path
-            ]
+            ])
             result = subprocess.run(cmd, capture_output=True, timeout=60)
 
             if result.returncode != 0:

--- a/library_manager/providers/fingerprint.py
+++ b/library_manager/providers/fingerprint.py
@@ -20,6 +20,7 @@ import requests
 
 from library_manager.providers.bookdb import _sanitize_api_response
 from library_manager.providers.rate_limiter import handle_rate_limit_response
+from library_manager.utils.audio import build_limited_ffmpeg_command
 
 logger = logging.getLogger(__name__)
 
@@ -451,9 +452,6 @@ def extract_voice_embedding(
     Returns:
         numpy array of 256-dim embedding, or None on failure
     """
-    import subprocess
-    import tempfile
-
     _, inference = _get_voice_model()
     if inference is None:
         return None
@@ -463,14 +461,15 @@ def extract_voice_embedding(
         with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as tmp:
             wav_path = tmp.name
 
-        cmd = [
-            'ffmpeg', '-y', '-i', audio_path,
+        cmd = build_limited_ffmpeg_command([
+            '-y', '-i', audio_path,
             '-ss', str(start_sec),
             '-t', str(duration_sec),
+            '-map', '0:a:0', '-vn', '-sn', '-dn',
             '-ar', '16000', '-ac', '1',
             '-loglevel', 'error',
             wav_path
-        ]
+        ])
         result = subprocess.run(cmd, capture_output=True, timeout=60)
 
         if result.returncode != 0:

--- a/library_manager/resource_limited_exec.py
+++ b/library_manager/resource_limited_exec.py
@@ -1,0 +1,41 @@
+"""Execute a child command with a bounded address space on POSIX hosts."""
+
+import argparse
+import os
+from typing import Optional, Sequence
+
+
+def _apply_memory_limit(memory_mb: int) -> None:
+    if os.name != "posix":
+        return
+
+    import resource
+
+    limit_bytes = memory_mb * 1024 * 1024
+    _soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_AS)
+    if hard_limit != resource.RLIM_INFINITY:
+        limit_bytes = min(limit_bytes, hard_limit)
+    resource.setrlimit(resource.RLIMIT_AS, (limit_bytes, limit_bytes))
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--memory-mb", type=int, required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    command = list(args.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    if args.memory_mb < 256:
+        parser.error("--memory-mb must be at least 256")
+    if not command:
+        parser.error("a command is required after --")
+
+    _apply_memory_limit(args.memory_mb)
+    os.execvp(command[0], command)
+    return 127  # pragma: no cover - os.execvp replaces this process
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/library_manager/utils/__init__.py
+++ b/library_manager/utils/__init__.py
@@ -24,6 +24,7 @@ from library_manager.utils.audio import (
     get_first_audio_file,
     extract_audio_sample,
     extract_audio_sample_from_middle,
+    build_limited_ffmpeg_command,
     find_audio_files,
     find_ebook_files,
 )
@@ -54,6 +55,7 @@ __all__ = [
     'get_first_audio_file',
     'extract_audio_sample',
     'extract_audio_sample_from_middle',
+    'build_limited_ffmpeg_command',
     'find_audio_files',
     'find_ebook_files',
     # path_safety

--- a/library_manager/utils/audio.py
+++ b/library_manager/utils/audio.py
@@ -3,6 +3,7 @@ import os
 import re
 import glob
 import subprocess
+import sys
 import tempfile
 import logging
 
@@ -11,6 +12,39 @@ logger = logging.getLogger(__name__)
 # File extension constants
 AUDIO_EXTENSIONS = {'.m4b', '.mp3', '.m4a', '.flac', '.ogg', '.opus', '.wma', '.aac'}
 EBOOK_EXTENSIONS = {'.epub', '.pdf', '.mobi', '.azw3'}
+
+try:
+    FFMPEG_MEMORY_LIMIT_MB = max(
+        256,
+        int(os.environ.get('LIBRARY_MANAGER_FFMPEG_MEMORY_MB', '2048')),
+    )
+except ValueError:
+    logger.warning(
+        "Invalid LIBRARY_MANAGER_FFMPEG_MEMORY_MB; using the 2048 MiB default"
+    )
+    FFMPEG_MEMORY_LIMIT_MB = 2048
+FFMPEG_MAX_SINGLE_ALLOCATION_BYTES = 256 * 1024 * 1024
+
+
+def build_limited_ffmpeg_command(args, memory_limit_mb=None):
+    """Build an ffmpeg command with a process memory ceiling.
+
+    The small Python launcher applies RLIMIT_AS and then replaces itself with
+    ffmpeg, so threaded callers avoid the unsafe ``preexec_fn`` path. Windows
+    keeps the stream-safety flags but relies on its container/service limits.
+    """
+    limit_mb = memory_limit_mb or FFMPEG_MEMORY_LIMIT_MB
+    ffmpeg_command = [
+        'ffmpeg', '-nostdin', '-hide_banner',
+        '-max_alloc', str(FFMPEG_MAX_SINGLE_ALLOCATION_BYTES),
+        *args,
+    ]
+    if os.name != 'posix':
+        return ffmpeg_command
+    return [
+        sys.executable, '-m', 'library_manager.resource_limited_exec',
+        '--memory-mb', str(limit_mb), '--', *ffmpeg_command,
+    ]
 
 
 def get_first_audio_file(folder_path):
@@ -50,17 +84,19 @@ def extract_audio_sample(audio_file, duration_seconds=90, output_format='mp3'):
         temp_file.close()
 
         # Use ffmpeg to extract sample
-        cmd = [
-            'ffmpeg', '-y',
+        cmd = build_limited_ffmpeg_command([
+            '-y',
             '-i', audio_file,
             '-t', str(duration_seconds),  # Duration
             '-vn',  # No video
+            '-sn', '-dn',
+            '-map', '0:a:0',
             '-acodec', 'libmp3lame' if output_format == 'mp3' else 'aac',
             '-b:a', '64k',  # Low bitrate for smaller file
             '-ar', '16000',  # 16kHz sample rate (good for speech)
             '-ac', '1',  # Mono
             temp_path
-        ]
+        ])
 
         result = subprocess.run(cmd, capture_output=True, timeout=60)
 
@@ -114,18 +150,20 @@ def extract_audio_sample_from_middle(audio_file, duration_seconds=60, output_for
         temp_file.close()
 
         # Extract sample from middle
-        cmd = [
-            'ffmpeg', '-y',
+        cmd = build_limited_ffmpeg_command([
+            '-y',
             '-ss', str(start_time),  # Start position
             '-i', audio_file,
             '-t', str(duration_seconds),  # Duration
             '-vn',  # No video
+            '-sn', '-dn',
+            '-map', '0:a:0',
             '-acodec', 'libmp3lame' if output_format == 'mp3' else 'aac',
             '-b:a', '64k',  # Low bitrate for smaller file
             '-ar', '16000',  # 16kHz sample rate
             '-ac', '1',  # Mono
             temp_path
-        ]
+        ])
 
         result = subprocess.run(cmd, capture_output=True, timeout=60)
 
@@ -173,6 +211,7 @@ __all__ = [
     'get_first_audio_file',
     'extract_audio_sample',
     'extract_audio_sample_from_middle',
+    'build_limited_ffmpeg_command',
     'find_audio_files',
     'find_ebook_files',
 ]

--- a/library_manager/utils/audio.py
+++ b/library_manager/utils/audio.py
@@ -31,12 +31,13 @@ def build_limited_ffmpeg_command(args, memory_limit_mb=None):
 
     The small Python launcher applies RLIMIT_AS and then replaces itself with
     ffmpeg, so threaded callers avoid the unsafe ``preexec_fn`` path. Windows
-    keeps the stream-safety flags but relies on its container/service limits.
+    keeps the per-allocation cap but relies on its container/service limits.
     """
     limit_mb = memory_limit_mb or FFMPEG_MEMORY_LIMIT_MB
     ffmpeg_command = [
         'ffmpeg', '-nostdin', '-hide_banner',
         '-max_alloc', str(FFMPEG_MAX_SINGLE_ALLOCATION_BYTES),
+        '-threads', '2', '-filter_threads', '2', '-filter_complex_threads', '2',
         *args,
     ]
     if os.name != 'posix':

--- a/library_manager/utils/voice_embedding.py
+++ b/library_manager/utils/voice_embedding.py
@@ -18,6 +18,8 @@ import tempfile
 import threading
 from pathlib import Path
 
+from library_manager.utils.audio import build_limited_ffmpeg_command
+
 logger = logging.getLogger(__name__)
 
 # Model configuration
@@ -122,15 +124,16 @@ def _compute_fbank(audio_path: str, num_mel_bins: int = 80, sample_rate: int = 1
         tmp_raw = tmp.name
 
     try:
-        cmd = [
-            'ffmpeg', '-y', '-i', audio_path,
+        cmd = build_limited_ffmpeg_command([
+            '-y', '-i', audio_path,
+            '-map', '0:a:0', '-vn', '-sn', '-dn',
             '-ar', str(sample_rate),
             '-ac', '1',
             '-f', 's16le',
             '-acodec', 'pcm_s16le',
             '-loglevel', 'error',
             tmp_raw
-        ]
+        ])
         result = subprocess.run(cmd, capture_output=True, timeout=30)
         if result.returncode != 0:
             return None
@@ -228,16 +231,17 @@ def extract_voice_embedding(audio_path: str, start_sec: int = 0, duration_sec: i
             tmp_wav = tmp.name
 
         try:
-            cmd = [
-                'ffmpeg', '-y', '-i', audio_path,
+            cmd = build_limited_ffmpeg_command([
+                '-y', '-i', audio_path,
                 '-ss', str(start_sec),
                 '-t', str(duration_sec),
+                '-map', '0:a:0', '-vn', '-sn', '-dn',
                 '-ar', '16000',
                 '-ac', '1',
                 '-f', 'wav',
                 '-loglevel', 'error',
                 tmp_wav
-            ]
+            ])
 
             result = subprocess.run(cmd, capture_output=True, timeout=30)
             if result.returncode != 0:

--- a/systemd/library-manager-memory.conf
+++ b/systemd/library-manager-memory.conf
@@ -1,0 +1,9 @@
+[Service]
+# Keep audio-analysis children from exhausting the host. Install this file as:
+# /etc/systemd/system/library-manager.service.d/20-memory.conf
+MemoryHigh=2G
+MemoryMax=4G
+MemorySwapMax=1G
+
+# A cgroup OOM should kill the oversized child without stopping the web app.
+OOMPolicy=continue

--- a/test-env/test-ffmpeg-memory-containment.py
+++ b/test-env/test-ffmpeg-memory-containment.py
@@ -2,6 +2,7 @@
 """Regression coverage for Issue #303 ffmpeg memory containment."""
 
 import os
+import re
 import subprocess
 import sys
 import unittest
@@ -15,6 +16,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from library_manager import resource_limited_exec  # noqa: E402
+from library_manager.file_validation import can_seek_to_end  # noqa: E402
 from library_manager.utils.audio import (  # noqa: E402
     FFMPEG_MAX_SINGLE_ALLOCATION_BYTES,
     build_limited_ffmpeg_command,
@@ -33,6 +35,9 @@ class TestFfmpegMemoryContainment(unittest.TestCase):
             "ffmpeg", "-nostdin", "-hide_banner", "-max_alloc",
             str(FFMPEG_MAX_SINGLE_ALLOCATION_BYTES),
         ])
+        self.assertEqual(command[11:17], [
+            "-threads", "2", "-filter_threads", "2", "-filter_complex_threads", "2",
+        ])
         self.assertEqual(command[-1], "-version")
 
     def test_sample_extraction_selects_audio_only(self):
@@ -49,6 +54,37 @@ class TestFfmpegMemoryContainment(unittest.TestCase):
         self.assertIn("-map", ffmpeg_command)
         self.assertEqual(ffmpeg_command[ffmpeg_command.index("-map") + 1], "0:a:0")
         self.assertEqual(run.call_args.kwargs["timeout"], 60)
+
+    def test_end_seek_validation_is_limited_and_audio_only(self):
+        succeeded = SimpleNamespace(returncode=0)
+        with mock.patch(
+            "library_manager.file_validation.subprocess.run",
+            return_value=succeeded,
+        ) as run:
+            self.assertTrue(can_seek_to_end("pathological.m4b"))
+
+        command = run.call_args.args[0]
+        ffmpeg_index = command.index("ffmpeg")
+        ffmpeg_command = command[ffmpeg_index:]
+        self.assertIn("-max_alloc", ffmpeg_command)
+        self.assertIn("-sseof", ffmpeg_command)
+        self.assertIn("-map", ffmpeg_command)
+        self.assertEqual(ffmpeg_command[ffmpeg_command.index("-map") + 1], "0:a:0")
+        self.assertIn("-vn", ffmpeg_command)
+        self.assertIn("-sn", ffmpeg_command)
+        self.assertIn("-dn", ffmpeg_command)
+
+    def test_no_production_code_bypasses_ffmpeg_limiter(self):
+        direct_ffmpeg = re.compile(r"[\"']ffmpeg[\"']\s*,")
+        bypasses = []
+        for source_path in [REPO_ROOT / "app.py", *(REPO_ROOT / "library_manager").rglob("*.py")]:
+            if source_path.name == "audio.py":
+                continue
+            for line_number, line in enumerate(source_path.read_text().splitlines(), 1):
+                if direct_ffmpeg.search(line):
+                    bypasses.append(f"{source_path.relative_to(REPO_ROOT)}:{line_number}")
+
+        self.assertEqual(bypasses, [], f"direct ffmpeg commands bypass limiter: {bypasses}")
 
     def test_launcher_applies_limit_before_exec(self):
         with (

--- a/test-env/test-ffmpeg-memory-containment.py
+++ b/test-env/test-ffmpeg-memory-containment.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Regression coverage for Issue #303 ffmpeg memory containment."""
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from library_manager import resource_limited_exec  # noqa: E402
+from library_manager.utils.audio import (  # noqa: E402
+    FFMPEG_MAX_SINGLE_ALLOCATION_BYTES,
+    build_limited_ffmpeg_command,
+    extract_audio_sample,
+)
+
+
+class TestFfmpegMemoryContainment(unittest.TestCase):
+    def test_builder_wraps_ffmpeg_with_posix_memory_limit(self):
+        with mock.patch("library_manager.utils.audio.os.name", "posix"):
+            command = build_limited_ffmpeg_command(["-version"], memory_limit_mb=768)
+
+        self.assertEqual(command[:3], [sys.executable, "-m", "library_manager.resource_limited_exec"])
+        self.assertEqual(command[3:6], ["--memory-mb", "768", "--"])
+        self.assertEqual(command[6:11], [
+            "ffmpeg", "-nostdin", "-hide_banner", "-max_alloc",
+            str(FFMPEG_MAX_SINGLE_ALLOCATION_BYTES),
+        ])
+        self.assertEqual(command[-1], "-version")
+
+    def test_sample_extraction_selects_audio_only(self):
+        failed = SimpleNamespace(returncode=1, stderr=b"expected failure")
+        with mock.patch("library_manager.utils.audio.subprocess.run", return_value=failed) as run:
+            self.assertIsNone(extract_audio_sample("pathological.m4b", duration_seconds=45))
+
+        command = run.call_args.args[0]
+        ffmpeg_index = command.index("ffmpeg")
+        ffmpeg_command = command[ffmpeg_index:]
+        self.assertIn("-vn", ffmpeg_command)
+        self.assertIn("-sn", ffmpeg_command)
+        self.assertIn("-dn", ffmpeg_command)
+        self.assertIn("-map", ffmpeg_command)
+        self.assertEqual(ffmpeg_command[ffmpeg_command.index("-map") + 1], "0:a:0")
+        self.assertEqual(run.call_args.kwargs["timeout"], 60)
+
+    def test_launcher_applies_limit_before_exec(self):
+        with (
+            mock.patch.object(resource_limited_exec, "_apply_memory_limit") as apply_limit,
+            mock.patch.object(resource_limited_exec.os, "execvp") as execvp,
+        ):
+            result = resource_limited_exec.main([
+                "--memory-mb", "1024", "--", "ffmpeg", "-version",
+            ])
+
+        self.assertEqual(result, 127)
+        apply_limit.assert_called_once_with(1024)
+        execvp.assert_called_once_with("ffmpeg", ["ffmpeg", "-version"])
+
+    @unittest.skipUnless(os.name == "posix", "RLIMIT_AS is POSIX-only")
+    def test_real_ffmpeg_starts_under_limit(self):
+        command = build_limited_ffmpeg_command(["-version"], memory_limit_mb=2048)
+        result = subprocess.run(command, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr.decode(errors="replace"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Contains pathological ffmpeg audio probes before they can exhaust the host and trigger earlyoom restart loops in Skaldleita.

## Changes

- run every production ffmpeg path behind a 2 GiB POSIX address-space ceiling
- cap individual allocations and bound decoder/filter thread counts
- explicitly select the first audio stream and disable video, subtitle, and data streams
- add a checked-in systemd drop-in with 2G high, 4G max, and 1G swap limits
- document the operational limits and bump APP_VERSION to 0.9.0-beta.163

## Testing

- [x] Focused regression tests pass: 6 tests in test-ffmpeg-memory-containment.py
- [x] Complete existing CI test-script set passes locally
- [x] Python compilation and undefined-name checks pass for changed Python modules
- [x] Naming checks pass: 318 tests
- [x] Production incident M4B end-seek succeeds 20 consecutive times under the wrapper with about 119 MiB peak RSS
- [x] Static regression check prevents any production ffmpeg command from bypassing the limiter
- [x] No UI workflow changed; browser and screenshots are not applicable
- [x] Rollback is documented below
- [ ] Full ruff is clean: 126 existing repository findings remain; this change adds no undefined-name findings
- [ ] Local container integration completed: Podman cannot re-exec into its existing user namespace on this host, so the test container never starts and all downstream checks are unavailable

## Documentation Verification

- [x] Installation documentation and changelog match the branch
- [x] GitHub wiki audited in an isolated clone; its systemd guidance needs the approved limits added after merge
- [x] Ports, defaults, and memory values verified against the runtime unit
- [x] Fresh UI screenshots are not applicable

## Related Issues

Addresses #303. The issue remains open until production deployment and the requested six-hour observation complete.

## Screenshots

Not applicable; no UI changes.

## Release Notes

- [x] CHANGELOG.md updated
- [x] APP_VERSION updated

## Rollback

Revert the two commits, remove the installed library-manager memory drop-in, run daemon-reload, and restart the service. The emergency drop-in stays installed until this PR is approved and deployed.