### PR TITLE
feat: independently verify video moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [0.9.0-beta.167] - 2026-08-25
+
+### Added
+- **#306: Independent video move verification** — The loopback organization service
+  accepts a separately signed, non-mutating verification request bound to the exact
+  operation, approval, catalogue/provider identity, configured roots, and destination
+  library. It proves the binding against the digest-only committed receipt, then freshly
+  re-reads the exact Radarr destination and Jellyfin provider identity so an external
+  policy gate does not need to trust the mutation response.
+
+### Safety
+- Verification cannot create a receipt, move files, accept a different plan for an
+  existing operation, or expose configured paths, titles, credentials, and adapter
+  errors. Missing, mismatched, non-committed, drifted, or unavailable evidence fails
+  closed with a bounded code.
+
+### Fixed
+- **#307: Truthful offline integration probes** — The Docker harness now queries SQLite
+  through the Python runtime present in the production image, rejects execution and
+  non-numeric failures instead of treating them as zero, waits on persisted scan output
+  in offline mode, and does not demand online identity outcomes from deliberately
+  disabled provider layers.
+
 ## [0.9.0-beta.166] - 2026-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ Movies and TV can be enabled independently. The read-only Video dashboard compar
 existing Plex SQLite catalogue with disk and reports stranded files (on disk but not
 indexed) and phantom files (indexed but absent). Browser results use section-relative
 paths; this dashboard has no move capability and never receives the separate organization
-service's signing secret.
+service's signing secret. The loopback organization service exposes only canonical signed
+apply and read-only verification requests. Verification binds the exact digest-only
+committed receipt, then freshly re-reads the Radarr destination and Jellyfin provider
+identity; it cannot move files or inspect a different plan under an existing operation.
 
 Synthetic fixture shown at desktop and mobile widths:
 

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama, OpenAI-compatible APIs)
 """
 
-APP_VERSION = "0.9.0-beta.166"
+APP_VERSION = "0.9.0-beta.167"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/library_manager/video/organize.py
+++ b/library_manager/video/organize.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import secrets
 import sqlite3
 import uuid
 from dataclasses import dataclass
@@ -220,7 +221,68 @@ async def execute_move(plan: VideoMovePlan, *, conn: sqlite3.Connection,
                 "error_code": error_code}
 
 
+async def verify_committed_move(operation_id: str, plan: VideoMovePlan, *,
+                                conn: sqlite3.Connection,
+                                catalogue: CatalogueAdapter,
+                                visibility: VisibilityAdapter) -> dict:
+    """Re-observe one exact committed move without acquiring a mutation verb.
+
+    The apply response is evidence from the executor, not a physical gate.  A
+    later caller therefore binds the same approved plan to its opaque operation
+    id, proves that binding against the digest-only receipt, and asks the
+    injected read adapters for current Radarr and Jellyfin truth again.
+    """
+    _validate(plan)
+    row = conn.execute(
+        "SELECT * FROM video_move_receipts WHERE operation_id = ?",
+        (operation_id,),
+    ).fetchone()
+    if row is None:
+        raise OrganizationRefused("move_receipt_absent")
+    values = dict(row)
+    expected = {
+        "approval_digest": _digest({"approval_ref": plan.approval_ref}),
+        "subject_digest": _digest({"subject_id": plan.subject_id}),
+        "identity_digest": _digest({
+            "provider": plan.provider, "provider_id": plan.provider_id}),
+        "source_root_digest": _digest({"root_ref": plan.source_root_ref}),
+        "destination_root_digest": _digest({
+            "root_ref": plan.destination_root_ref}),
+        "destination_library_digest": _digest({
+            "library_ref": plan.destination_library_ref}),
+    }
+    if (any(not secrets.compare_digest(str(values.get(key) or ""), digest)
+            for key, digest in expected.items())
+            or values.get("media_kind") != plan.media_kind
+            or int(values.get("move_files") or 0) != 1
+            or int(values.get("idle_observed") or 0) != 1
+            or int(values.get("destination_verified") or 0) != 1
+            or int(values.get("library_verified") or 0) != 1
+            or int(values.get("rollback_verified") or 0) != 0):
+        raise OrganizationRefused("move_receipt_mismatch")
+    if values.get("status") != "committed":
+        raise OrganizationRefused("move_not_committed")
+
+    destination_verified = bool(await catalogue.root_is(
+        plan.subject_id, plan.destination_root_ref))
+    library_verified = bool(await visibility.visible_in(
+        plan.provider, plan.provider_id, plan.destination_library_ref))
+    error_code = (None if destination_verified and library_verified else
+                  "destination_not_verified" if not destination_verified else
+                  "library_identity_not_verified")
+    result = {
+        "operation_id": operation_id,
+        "status": "verified" if error_code is None else "unverified",
+        "destination_verified": destination_verified,
+        "library_verified": library_verified,
+    }
+    if error_code is not None:
+        result["error_code"] = error_code
+    return result
+
+
 __all__ = [
     "CatalogueAdapter", "OrganizationRefused", "PlaybackObservation",
     "VideoMovePlan", "VisibilityAdapter", "ensure_schema", "execute_move",
+    "verify_committed_move",
 ]

--- a/test-env/run-integration-tests.sh
+++ b/test-env/run-integration-tests.sh
@@ -166,10 +166,18 @@ EOF
     # Wait for scan to actually complete (queue should have items)
     log_info "Waiting for scan to complete..."
     for i in {1..60}; do
-        queue_count=$(curl -s "http://localhost:$TEST_PORT/api/queue" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['count'])" 2>/dev/null || echo "0")
-        if [[ "$queue_count" -gt 3 ]]; then
-            log_info "Scan populated queue with $queue_count items"
-            break
+        if [[ "$OFFLINE_MODE" -eq 1 ]]; then
+            book_count=$(curl -s "http://localhost:$TEST_PORT/api/stats" | python3 -c "import json,sys; print(json.load(sys.stdin).get('total_books', 0))" 2>/dev/null || echo "0")
+            if [[ "$book_count" -gt 3 ]]; then
+                log_info "Offline scan indexed $book_count books"
+                break
+            fi
+        else
+            queue_count=$(curl -s "http://localhost:$TEST_PORT/api/queue" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['count'])" 2>/dev/null || echo "0")
+            if [[ "$queue_count" -gt 3 ]]; then
+                log_info "Scan populated queue with $queue_count items"
+                break
+            fi
         fi
         sleep 1
     done
@@ -227,6 +235,15 @@ test_queue_endpoint() {
 
 test_scan_detected_issues() {
     log_info "Test: Scanner detected expected issues"
+    if [[ "$OFFLINE_MODE" -eq 1 ]]; then
+        total=$(curl -s "http://localhost:$TEST_PORT/api/stats" | python3 -c "import json,sys; print(json.load(sys.stdin).get('total_books', 0))" 2>/dev/null || echo "0")
+        if [[ "$total" -gt 0 ]]; then
+            log_pass "Offline scan indexed $total books; network-driven issue routing is out of scope"
+        else
+            log_fail "Offline scan produced no durable inventory"
+        fi
+        return
+    fi
     response=$(curl -s "http://localhost:$TEST_PORT/api/queue")
 
     # NOTE: Reversed structure detection was removed in beta.69 (Issue #52 - false positives)
@@ -335,15 +352,18 @@ test_queue_items_not_stuck() {
     log_info "Test: Queue items are not stuck at invalid verification layers"
     # Items should not be stuck at layer 4 in the queue (that's the bug this test catches)
 
-    # This requires DB access - skip if we can't access it
-    if ! command -v sqlite3 &> /dev/null; then
-        log_info "sqlite3 not available, skipping DB check"
+    # The production image intentionally contains Python rather than the
+    # sqlite3 shell. Use the runtime already required by the application, and
+    # never turn an exec/import/query failure into the truthful number zero.
+    if ! stuck=$(container_exec exec "$CONTAINER_NAME" python3 -c \
+        "import sqlite3; c=sqlite3.connect('/data/library.db'); print(c.execute(\"SELECT COUNT(*) FROM queue q JOIN books b ON q.book_id = b.id WHERE b.verification_layer = 4\").fetchone()[0])" 2>/dev/null); then
+        log_fail "Could not query the container database for invalid queue layers"
         return
     fi
-
-    # Check for stuck items (in queue but at layer 4 with no handler)
-    stuck=$(container_exec exec "$CONTAINER_NAME" sqlite3 /data/library.db \
-        "SELECT COUNT(*) FROM queue q JOIN books b ON q.book_id = b.id WHERE b.verification_layer = 4" 2>/dev/null || echo "0")
+    if [[ ! "$stuck" =~ ^[0-9]+$ ]]; then
+        log_fail "Container database query returned a non-numeric result"
+        return
+    fi
 
     if [[ "$stuck" -eq 0 ]]; then
         log_pass "No items stuck at layer 4"
@@ -365,7 +385,22 @@ test_book_verification() {
         return
     fi
 
-    # Run the verification test against the test database
+    if [[ "$OFFLINE_MODE" -eq 1 ]]; then
+        # Offline mode deliberately disables the lookup and AI layers that
+        # produce the fixture's expected identities. Its honest contract is a
+        # readable, non-empty persisted scan, not online verification labels.
+        if result=$(python3 -c \
+            "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); ok=c.execute('PRAGMA quick_check').fetchone()[0]; count=c.execute('SELECT COUNT(*) FROM books').fetchone()[0]; print(f'{ok}:{count}')" \
+            "$TEST_DIR/fresh-deploy/data/library.db" 2>/dev/null) \
+                && [[ "$result" =~ ^ok:[1-9][0-9]*$ ]]; then
+            log_pass "Offline database is valid with ${result#ok:} indexed books; online identity labels are out of scope"
+        else
+            log_fail "Offline scan database is absent, corrupt, or empty"
+        fi
+        return
+    fi
+
+    # Run the online verification test against the test database
     if python3 "$TEST_DIR/test-book-verification.py" "$TEST_DIR/fresh-deploy/data/library.db" >/dev/null 2>&1; then
         log_pass "Book identification verification passed"
     else

--- a/test-env/test-video-organization-service.py
+++ b/test-env/test-video-organization-service.py
@@ -17,12 +17,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from library_manager.video.organize import PlaybackObservation  # noqa: E402
 from video_organization_service import (  # noqa: E402
     REQUEST_SCHEMA,
+    VERIFY_REQUEST_SCHEMA,
     ServiceConfig,
     ThreadingHTTPServer,
     VideoOrganizationService,
     capability_signature,
     make_handler,
     plan_from_payload,
+    verification_from_payload,
 )
 
 
@@ -41,6 +43,11 @@ PAYLOAD = {
 }
 
 
+def verification_payload(operation_id: str) -> dict:
+    return {**PAYLOAD, "schema": VERIFY_REQUEST_SCHEMA,
+            "operation_id": operation_id}
+
+
 class Catalogue:
     def __init__(self):
         self.root = "/media/Movies"
@@ -56,8 +63,12 @@ class Catalogue:
 
 
 class Visibility:
+    def __init__(self):
+        self.visible = True
+
     async def visible_in(self, provider, provider_id, library_ref):
-        return (provider, provider_id, library_ref) == ("tmdb", "123", "jf-docs")
+        return (self.visible and (provider, provider_id, library_ref)
+                == ("tmdb", "123", "jf-docs"))
 
 
 async def idle():
@@ -86,15 +97,23 @@ def test_plan_and_capability_boundary():
         assert plan.approved and plan.movie_length
 
         catalogue = Catalogue()
+        visibility = Visibility()
         service = VideoOrganizationService(
-            cfg, catalogue=catalogue, visibility=Visibility(), idle_probe=idle)
+            cfg, catalogue=catalogue, visibility=visibility, idle_probe=idle)
         status, result = asyncio.run(service.apply(PAYLOAD, "sha256=wrong"))
         assert status == 401 and result["error_code"] == "capability_invalid"
+        assert catalogue.calls == [] and not cfg.database.exists()
+
+        absent = verification_payload("vm_" + "0" * 32)
+        status, result = asyncio.run(service.verify(
+            absent, capability_signature(absent, SECRET)))
+        assert status == 409 and result["error_code"] == "move_receipt_absent"
         assert catalogue.calls == [] and not cfg.database.exists()
 
         signature = capability_signature(PAYLOAD, SECRET)
         status, result = asyncio.run(service.apply(PAYLOAD, signature))
         assert status == 200 and result["status"] == "committed"
+        operation_id = result["operation_id"]
         assert catalogue.calls == [("7", "/media/Documentaries", True)]
         assert cfg.database.stat().st_mode & 0o777 == 0o600
         receipt_db = sqlite3.connect(cfg.database)
@@ -109,6 +128,51 @@ def test_plan_and_capability_boundary():
         status, result = asyncio.run(service.apply(PAYLOAD, signature))
         assert status == 409 and result["error_code"] == "move_receipt_exists"
         assert len(catalogue.calls) == 1
+        verify_payload = verification_payload(operation_id)
+        parsed_operation, parsed_plan = verification_from_payload(verify_payload, cfg)
+        assert parsed_operation == operation_id and parsed_plan == plan
+        status, result = asyncio.run(service.verify(verify_payload, "sha256=wrong"))
+        assert status == 401 and result["error_code"] == "capability_invalid"
+        before_verify = cfg.database.read_bytes()
+        status, result = asyncio.run(service.verify(
+            verify_payload, capability_signature(verify_payload, SECRET)))
+        assert status == 200 and result == {
+            "schema": "video.move.verification.v1",
+            "operation_id": operation_id,
+            "status": "verified",
+            "destination_verified": True,
+            "library_verified": True,
+        }
+        assert cfg.database.read_bytes() == before_verify
+
+        mismatched = {**verify_payload, "provider_id": "124"}
+        status, result = asyncio.run(service.verify(
+            mismatched, capability_signature(mismatched, SECRET)))
+        assert status == 409 and result["error_code"] == "move_receipt_mismatch"
+        catalogue.root = "/media/Movies"
+        status, result = asyncio.run(service.verify(
+            verify_payload, capability_signature(verify_payload, SECRET)))
+        assert status == 409 and result["error_code"] == "destination_not_verified"
+        assert result["destination_verified"] is False
+        assert result["library_verified"] is True
+        catalogue.root = "/media/Documentaries"
+        visibility.visible = False
+        status, result = asyncio.run(service.verify(
+            verify_payload, capability_signature(verify_payload, SECRET)))
+        assert status == 409
+        assert result["error_code"] == "library_identity_not_verified"
+        assert result["destination_verified"] is True
+        assert result["library_verified"] is False
+        receipt_db = sqlite3.connect(cfg.database)
+        receipt_db.execute(
+            "UPDATE video_move_receipts SET status = 'rolled_back' WHERE operation_id = ?",
+            (operation_id,))
+        receipt_db.commit()
+        receipt_db.close()
+        visibility.visible = True
+        status, result = asyncio.run(service.verify(
+            verify_payload, capability_signature(verify_payload, SECRET)))
+        assert status == 409 and result["error_code"] == "move_not_committed"
     print("[PASS] exact capability is one-use and receipts remain path/title-free")
 
 
@@ -132,6 +196,16 @@ def test_http_surface():
             result = json.load(urlopen(request))
             assert result["schema"] == "video.move.result.v1"
             assert result["status"] == "committed"
+            verify_body = verification_payload(result["operation_id"])
+            encoded_verify = json.dumps(
+                verify_body, sort_keys=True, separators=(",", ":")).encode()
+            verified = json.load(urlopen(Request(
+                base + "/api/v1/video/move/verify", data=encoded_verify,
+                headers={"Content-Type": "application/json",
+                         "X-LM-Video-Capability": capability_signature(
+                             verify_body, SECRET)})))
+            assert verified["schema"] == "video.move.verification.v1"
+            assert verified["status"] == "verified"
             for method in ("PUT", "PATCH", "DELETE"):
                 try:
                     urlopen(Request(base + "/api/v1/video/move", data=b"{}",
@@ -143,7 +217,7 @@ def test_http_surface():
             server.shutdown()
             thread.join(timeout=2)
             server.server_close()
-    print("[PASS] loopback HTTP surface exposes health plus one signed POST only")
+    print("[PASS] loopback HTTP surface exposes health plus exact signed apply/verify POSTs")
 
 
 if __name__ == "__main__":

--- a/video_organization_service.py
+++ b/video_organization_service.py
@@ -22,13 +22,17 @@ from library_manager.video.organize import (
     OrganizationRefused,
     VideoMovePlan,
     execute_move,
+    verify_committed_move,
 )
 
 
 MAX_BODY = 64 * 1024
 REQUEST_SCHEMA = "video.move.request.v1"
 RESPONSE_SCHEMA = "video.move.result.v1"
+VERIFY_REQUEST_SCHEMA = "video.move.verify.request.v1"
+VERIFY_RESPONSE_SCHEMA = "video.move.verification.v1"
 _APPROVAL = re.compile(r"[A-Za-z0-9_.:-]{8,160}")
+_OPERATION = re.compile(r"vm_[a-f0-9]{32}")
 _RADARR_ID = re.compile(r"[1-9][0-9]{0,9}")
 _TMDB_ID = re.compile(r"[1-9][0-9]{0,11}")
 _IMDB_ID = re.compile(r"tt[0-9]{5,12}")
@@ -131,6 +135,24 @@ def plan_from_payload(payload: object, config: ServiceConfig) -> VideoMovePlan:
     )
 
 
+def verification_from_payload(payload: object, config: ServiceConfig
+                              ) -> tuple[str, VideoMovePlan]:
+    if not isinstance(payload, dict) or payload.get("schema") != VERIFY_REQUEST_SCHEMA:
+        raise RequestRefused("request_schema_invalid")
+    allowed = {"operation_id", "schema", "approval_ref", "subject_id", "provider",
+               "provider_id", "media_kind", "runtime_minutes", "source_root_id",
+               "destination_root_id", "destination_library_id"}
+    if set(payload) != allowed:
+        raise RequestRefused("request_fields_invalid")
+    operation_id = str(payload.get("operation_id") or "")
+    if not _OPERATION.fullmatch(operation_id):
+        raise RequestRefused("operation_identity_invalid")
+    move_payload = {key: value for key, value in payload.items()
+                    if key != "operation_id"}
+    move_payload["schema"] = REQUEST_SCHEMA
+    return operation_id, plan_from_payload(move_payload, config)
+
+
 class VideoOrganizationService:
     def __init__(self, config: ServiceConfig, *, catalogue, visibility,
                  idle_probe) -> None:
@@ -173,6 +195,43 @@ class VideoOrganizationService:
             503 if result["status"] == "manual_recovery" else 409)
         return status, {"schema": RESPONSE_SCHEMA, **result}
 
+    async def verify(self, payload: object, signature: str) -> tuple[int, dict]:
+        if not self.config.ready():
+            return 503, {"schema": VERIFY_RESPONSE_SCHEMA, "status": "unavailable",
+                         "error_code": "service_configuration_incomplete"}
+        if not isinstance(payload, dict) or not verify_capability(
+                payload, signature, self.config.capability_secret):
+            return 401, {"schema": VERIFY_RESPONSE_SCHEMA, "status": "refused",
+                         "error_code": "capability_invalid"}
+        try:
+            operation_id, plan = verification_from_payload(payload, self.config)
+        except RequestRefused as exc:
+            return 400, {"schema": VERIFY_RESPONSE_SCHEMA, "status": "refused",
+                         "error_code": str(exc)}
+        if not self.config.database.is_file():
+            return 409, {"schema": VERIFY_RESPONSE_SCHEMA, "status": "unverified",
+                         "error_code": "move_receipt_absent"}
+        conn: Optional[sqlite3.Connection] = None
+        try:
+            conn = sqlite3.connect(
+                self.config.database.resolve().as_uri() + "?mode=ro",
+                uri=True, timeout=60)
+            conn.row_factory = sqlite3.Row
+            result = await verify_committed_move(
+                operation_id, plan, conn=conn, catalogue=self.catalogue,
+                visibility=self.visibility)
+        except OrganizationRefused as exc:
+            return 409, {"schema": VERIFY_RESPONSE_SCHEMA, "status": "unverified",
+                         "error_code": str(exc)}
+        except Exception:
+            return 503, {"schema": VERIFY_RESPONSE_SCHEMA, "status": "unavailable",
+                         "error_code": "operation_unavailable"}
+        finally:
+            if conn is not None:
+                conn.close()
+        status = 200 if result["status"] == "verified" else 409
+        return status, {"schema": VERIFY_RESPONSE_SCHEMA, **result}
+
 
 def make_handler(service: VideoOrganizationService):
     class Handler(BaseHTTPRequestHandler):
@@ -197,13 +256,16 @@ def make_handler(service: VideoOrganizationService):
                              "status": "ready" if service.config.ready() else "unavailable"})
 
         def do_POST(self) -> None:  # noqa: N802
-            if self.path != "/api/v1/video/move":
+            if self.path not in {"/api/v1/video/move",
+                                 "/api/v1/video/move/verify"}:
                 self._send(404, {"schema": RESPONSE_SCHEMA,
                                  "status": "unavailable",
                                  "error_code": "route_unavailable"})
                 return
+            response_schema = (VERIFY_RESPONSE_SCHEMA
+                               if self.path.endswith("/verify") else RESPONSE_SCHEMA)
             if self.headers.get("Content-Type", "").split(";", 1)[0] != "application/json":
-                self._send(415, {"schema": RESPONSE_SCHEMA, "status": "refused",
+                self._send(415, {"schema": response_schema, "status": "refused",
                                  "error_code": "content_type_invalid"})
                 return
             try:
@@ -211,16 +273,18 @@ def make_handler(service: VideoOrganizationService):
             except ValueError:
                 length = -1
             if length <= 0 or length > MAX_BODY:
-                self._send(413, {"schema": RESPONSE_SCHEMA, "status": "refused",
+                self._send(413, {"schema": response_schema, "status": "refused",
                                  "error_code": "body_size_invalid"})
                 return
             try:
                 payload = json.loads(self.rfile.read(length))
             except (UnicodeDecodeError, json.JSONDecodeError):
-                self._send(400, {"schema": RESPONSE_SCHEMA, "status": "refused",
+                self._send(400, {"schema": response_schema, "status": "refused",
                                  "error_code": "json_invalid"})
                 return
-            status, result = asyncio.run(service.apply(
+            call = (service.verify if self.path.endswith("/verify")
+                    else service.apply)
+            status, result = asyncio.run(call(
                 payload, self.headers.get("X-LM-Video-Capability", "")))
             self._send(status, result)
 


### PR DESCRIPTION
## Summary

Adds the separate physical-read contract Gus #46 needs after Library Manager applies an approved video root move. The executor response is no longer the only proof: a second canonical HMAC-signed request binds the exact opaque operation, approval, catalogue/provider identity, configured roots, and destination library; the service proves those fields against the digest-only committed receipt and freshly re-reads Radarr and Jellyfin without a mutation verb.

Also repairs #307, which the required Docker acceptance exposed. The integration harness now uses Python sqlite3 already present in the production image, refuses to turn probe failures into zero, and keeps offline assertions within the deliberately disabled-provider profile.

Tracks #306 and #307. Per repository policy, both issues remain open until merged/deployed acceptance is confirmed.

## Safety boundaries

- verification opens the receipt database `mode=ro`; a byte-for-byte regression proves the check does not change it
- exact receipt digests, committed state, original destination/library proof flags, and fresh physical reads must all agree
- a different plan/operation, absent or non-committed receipt, Radarr drift, Jellyfin drift, malformed body, invalid capability, or adapter outage fails closed
- no title, path, raw provider id, credential, generic catalogue verb, or adapter exception is returned or added to receipts
- the read-only Flask Video dashboard remains separate and never receives this capability secret

## Verification

- full portable CI command set passed, including 318 naming checks and all apply/rollback, pre-sort, video, Plex, Music, provider, and API suites
- focused service coverage: absent receipt/no DB creation, invalid HMAC, one-use apply, exact binding, read-only DB bytes, success, mismatched plan, Radarr drift, Jellyfin drift, non-committed refusal, and live HTTP apply/verify routes
- focused Ruff passed for changed Python modules; `py_compile` passed for app/service/core
- `bash -n test-env/run-integration-tests.sh` passed
- `./test-env/run-integration-tests.sh --local --offline`: 11 passed, 0 failed; queue 1→0, numeric layer-4 count 0, SQLite quick-check `ok`, non-empty 82-book final inventory
- production image `sha256:318adfb2f3986957f402f1f5aa098f459dcef62302a4cd774ade0485e3e2a42b` imported beta.167, both verification schemas, and the verifier
- NTNB evidence lane validated every record type and passed 14/14 protocol/tool tests

## Documentation reviewed

- README Video Reconciliation boundary
- CHANGELOG beta.167
- version in `app.py`
- AGENTS and Release/PR Workflow

No UI changed, so existing browser screenshots remain current. No live media was moved; configured production move/rollback remains a Gus #46 acceptance gate.