### PR TITLE
docs: complete beta.168 release handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ All notable changes to Library Manager will be documented in this file.
 
 ### Safety
 - **Terminal authentication denials** — A Skaldleita `401` or `403` aborts the current
-  watch task and suppresses every further Skaldleita request for the process lifetime.
-  A rejected personal key is never retried with the shared credential. Only a restart
-  or an explicit credential replacement/removal clears the local denial; `429` remains
-  temporary and honors normal rate-limit handling.
+  watch task and suppresses further protected metadata/audio workflow traffic until
+  restart or explicit personal-key replacement/removal. A rejected personal key is
+  never retried with the shared credential. Settings key validation reports a rejection
+  without arming the workflow denial state; `429` remains temporary and honors normal
+  rate-limit handling.
 - **Coordinated old-client gate** — Skaldleita checks IP bans, blocked/minimum Library
   Manager versions, and request signatures before authorizing either shared or personal
   keys. This keeps quarantined or looping old clients denied even when they know the

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 > **beta.168** - **Safe no-signup Skaldleita access**
 > - Uses the bundled, per-IP-limited shared key when no personal Skaldleita key is configured.
 > - Signs every protected metadata, ISBN, fingerprint, narrator, voice, contribution, and audio-ID request with the full Library Manager version.
-> - Treats `401`/`403` as terminal and never downgrades a rejected personal key to the shared key; `429` remains temporary.
+> - Treats `401`/`403` as terminal for protected workflows until restart or explicit personal-key replacement/removal, and never downgrades a rejected personal key to the shared key; Settings validation can still report a rejection and `429` remains temporary.
 > - Skaldleita applies client blocks, minimum-version policy, and signature checks before either shared or personal key authorization.
 
 > **beta.161** - **#300: Verified apply-fix transfer receipts**

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -35,11 +35,13 @@ Library Manager continues to use Skaldleita for hosted metadata and audio identi
 ### Skaldleita access
 
 No signup is required for the default hosted service. If `bookdb_api_key` is empty,
-Library Manager selects its bundled shared key before each request; that tier is heavily
-rate-limited per source IP. A configured personal key is preferred and is never retried
-with the shared key after a rejection. Every protected Skaldleita route receives signed
-client/version headers, including metadata search, ISBN, fingerprint, narrator, voice,
-community contribution, and audio identification.
+Library Manager selects its bundled shared key before each request; that tier allows
+300 requests/hour per source IP. A configured personal key is preferred, allows 300
+requests/hour per key, and is never retried with the shared key after a rejection. Audio
+identification additionally allows 10 uploads/minute per source IP and 100 GPU jobs/hour
+per authenticated caller. Every protected Skaldleita route receives signed client/version
+headers, including metadata search, ISBN, fingerprint, narrator, voice, community
+contribution, and audio identification.
 
 The hosted service requires Library Manager `0.9.0-beta.168` or newer. Beta.168 is the
 first Docker/Unraid release that signs the real application version from its `python
@@ -49,11 +51,13 @@ denied with upgrade guidance.
 ![Optional personal key and no-signup shared access](images/skaldleita-shared-access-settings.png)
 
 Authentication responses are intentionally fail-closed: `401` and `403` stop the current
-task and suppress further Skaldleita traffic until Library Manager restarts or the user
-explicitly changes the credential. `429` is temporary and uses the server's
-`Retry-After` guidance. Server-side client blocks and minimum-version checks happen
-before key authorization, so an old or quarantined instance cannot bypass its denial by
-switching between personal and shared keys.
+task and suppress further protected metadata/audio workflow traffic until Library
+Manager restarts or the user explicitly replaces/removes the personal credential.
+Settings key validation reports a rejection without arming that workflow denial state.
+`429` is temporary and uses the server's `Retry-After` guidance. Server-side client
+blocks and minimum-version checks happen before key authorization, so an old or
+quarantined instance cannot bypass its denial by switching between personal and shared
+keys.
 
 Self-hosted compatible deployments can set `bookdb_url` in `config.json`; the default is
 `https://bookdb.deucebucket.com`.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -37,8 +37,11 @@ Metadata can come from Skaldleita, Audnexus, OpenLibrary, Google Books, and Hard
 
 No. Library Manager `0.9.0-beta.168` and newer use a bundled Skaldleita key when
 no personal key is saved. Shared access is limited to 300 requests/hour per
-source IP. A personal key is optional and currently has the same hourly
-allowance, but gives you a dedicated credential and email-based recovery.
+source IP. A personal key is optional and currently permits 300 requests/hour
+per key, giving you a dedicated credential and email-based recovery. Audio
+identification additionally allows 10 uploads/minute per source IP and 100 GPU
+jobs/hour per authenticated caller; the general 300/hour allowance is not the
+only audio limit.
 
 Skaldleita still enforces IP blocks, signed-client verification, and its minimum
 Library Manager version before authorizing either credential. A rejected

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -33,6 +33,17 @@ It can move a complete book folder or a loose media file into a generated destin
 
 Metadata can come from Skaldleita, Audnexus, OpenLibrary, Google Books, and Hardcover. Optional AI verification uses the configured Gemini, OpenRouter, Ollama, or OpenAI-compatible provider.
 
+### Do I need to register for a Skaldleita key?
+
+No. Library Manager `0.9.0-beta.168` and newer use a bundled Skaldleita key when
+no personal key is saved. Shared access is limited to 300 requests/hour per
+source IP. A personal key is optional and currently has the same hourly
+allowance, but gives you a dedicated credential and email-based recovery.
+
+Skaldleita still enforces IP blocks, signed-client verification, and its minimum
+Library Manager version before authorizing either credential. A rejected
+personal key is never retried with the shared key.
+
 ### What are the provider limits?
 
 Hosted provider limits vary by account and model; check the provider's current documentation. Library Manager also applies its own configurable request limiter (default 200/hour, Settings clamp 10–500/hour).

--- a/docs/How-It-Works.md
+++ b/docs/How-It-Works.md
@@ -44,8 +44,10 @@ Skaldleita requests select one credential before sending: a saved personal key,
 or the bundled shared key when no personal key exists. Every protected route is
 signed with the real Library Manager version. Server-side source blocks,
 minimum-version policy, and signature checks run before key authorization;
-`401`/`403` responses abort the current task and suppress further Skaldleita
-traffic for that process, while `429` remains recoverable after its retry delay.
+`401`/`403` responses abort the current task and suppress further protected
+metadata/audio workflow traffic until restart or explicit personal-key
+replacement/removal. Settings key validation reports rejection without arming
+that workflow state. `429` remains recoverable after its retry delay.
 
 ## Candidate checks
 

--- a/docs/How-It-Works.md
+++ b/docs/How-It-Works.md
@@ -40,6 +40,13 @@ Folder and filename hints remain a fallback for items that earlier layers cannot
 
 Metadata can come from Skaldleita/BookDB, Audnexus, OpenLibrary, Google Books, and Hardcover. AI choices are Gemini, OpenRouter, Ollama, and llama.cpp/OpenAI-compatible servers.
 
+Skaldleita requests select one credential before sending: a saved personal key,
+or the bundled shared key when no personal key exists. Every protected route is
+signed with the real Library Manager version. Server-side source blocks,
+minimum-version policy, and signature checks run before key authorization;
+`401`/`403` responses abort the current task and suppress further Skaldleita
+traffic for that process, while `429` remains recoverable after its retry delay.
+
 ## Candidate checks
 
 Results are compared with title, author, language, and series hints. Garbage title/author matches, placeholder authors, and third-party summary/derivative matches are rejected unless the source filename clearly indicates a summary. Uncertain or drastic changes are held for review according to safety settings.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -37,6 +37,11 @@ docker compose up -d
   - [OpenRouter](https://openrouter.ai) (multiple models available)
 - Or a reachable Ollama, llama.cpp, or OpenAI-compatible server (local providers can run without a hosted key)
 
+Skaldleita metadata and audio identification do not require signup in
+`0.9.0-beta.168` or newer. Library Manager uses its bundled, per-IP-limited
+shared credential when no personal Skaldleita key is saved. A personal key is
+optional and is never exposed in configuration examples or logs.
+
 ## First Run
 
 1. Open http://localhost:5757

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -37,10 +37,13 @@ docker compose up -d
   - [OpenRouter](https://openrouter.ai) (multiple models available)
 - Or a reachable Ollama, llama.cpp, or OpenAI-compatible server (local providers can run without a hosted key)
 
-Skaldleita metadata and audio identification do not require signup in
+The default hosted Skaldleita metadata/audio service does not require signup in
 `0.9.0-beta.168` or newer. Library Manager uses its bundled, per-IP-limited
-shared credential when no personal Skaldleita key is saved. A personal key is
-optional and is never exposed in configuration examples or logs.
+shared credential when no personal Skaldleita key is saved. A custom/self-hosted
+Skaldleita deployment must explicitly set `SKALDLEITA_LM_PUBLIC_KEY` to the
+matching bundled credential or shared access is disabled. Saved personal values
+live in `secrets.json`; Settings does not render them back to the browser and the
+application does not log them.
 
 ## First Run
 

--- a/docs/Release-and-PR-Workflow.md
+++ b/docs/Release-and-PR-Workflow.md
@@ -19,6 +19,7 @@ Documentation is part of every user-visible change. A pull request is not ready 
    - `docs/images/presort-review.png`
    - `docs/images/presort-committed-receipt.png`
    - `docs/images/presort-rollback-receipt.png`
+   - `docs/images/skaldleita-shared-access-settings.png`
 
 9. In the PR description, list documentation files reviewed, tests/browser flows run, screenshots, migration/rollback notes, and intentionally omitted uncertain claims.
 

--- a/docs/Release-and-PR-Workflow.md
+++ b/docs/Release-and-PR-Workflow.md
@@ -11,7 +11,12 @@ Documentation is part of every user-visible change. A pull request is not ready 
 5. Update `CHANGELOG.md`, `README.md`, `config.example.json`, and relevant docs when behavior, configuration, or version changes.
 6. Audit the GitHub wiki in an isolated wiki clone against the final branch. Remove obsolete claims, correct paths/ports/defaults/provider names, add verified behavior, and preserve useful navigation/history.
 7. Verify README/docs/wiki claims against source, templates, packaging, tests, or release notes. Do not publish provider quotas, performance percentages, database sizes, or future integrations without a current source.
-8. For UI changes, capture fresh screenshots from the final branch and include them in the PR. Receipt-related changes must include the History receipt list, committed receipt modal, and rollback/manual-recovery receipt views. Current references are:
+8. For coordinated Skaldleita contract/authentication changes, merge and deploy
+   the server first. Before publishing or merging the Library Manager client,
+   verify production `/health` reports `lm_public_access_configured: true` and
+   the intended `min_library_manager_version`, then exercise live signed success,
+   terminal `401`/`403`, and temporary `429` behavior from the final client branch.
+9. For UI changes, capture fresh screenshots from the final branch and include them in the PR. Receipt-related changes must include the History receipt list, committed receipt modal, and rollback/manual-recovery receipt views. Current references are:
 
    - `docs/images/transfer-receipts-history.png`
    - `docs/images/transfer-receipt-committed.png`
@@ -21,7 +26,7 @@ Documentation is part of every user-visible change. A pull request is not ready 
    - `docs/images/presort-rollback-receipt.png`
    - `docs/images/skaldleita-shared-access-settings.png`
 
-9. In the PR description, list documentation files reviewed, tests/browser flows run, screenshots, migration/rollback notes, and intentionally omitted uncertain claims.
+10. In the PR description, list documentation files reviewed, tests/browser flows run, screenshots, migration/rollback notes, and intentionally omitted uncertain claims.
 
 ## Documentation checklist
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -40,10 +40,13 @@ Use Library Manager `0.9.0-beta.168` or newer. Older Docker and Unraid builds ca
 report an invalid client version and are intentionally rejected before metadata
 matching begins. A `401` means the selected credential was rejected; a `403`
 means the client, version, signature, or source address was denied. Both are
-terminal for the current process so a broken instance cannot keep looping or
-downgrade from a rejected personal key to the shared key.
+terminal for protected metadata/audio workflows so a broken instance cannot
+keep looping or downgrade from a rejected personal key to the shared key.
+Settings validation reports a rejected saved key without arming that terminal
+workflow state.
 
-Correct the key or update Library Manager, then restart the app. A `429` is
+Update Library Manager and restart the app, or explicitly replace/remove the
+saved personal key in Settings to clear the workflow denial state. A `429` is
 temporary: wait for the displayed `Retry-After` interval instead of repeatedly
 clicking Search or restarting.
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -34,6 +34,19 @@ Use **History → Undo**. Undo is blocked if both sides exist or either path lea
 
 Check provider credentials, model ID, endpoint reachability, and Docker networking. The local request limiter defaults to 200/hour and clamps to 10–500/hour; wait for provider backoff/circuit-breaker recovery before repeatedly retrying.
 
+## Skaldleita denied this client
+
+Use Library Manager `0.9.0-beta.168` or newer. Older Docker and Unraid builds can
+report an invalid client version and are intentionally rejected before metadata
+matching begins. A `401` means the selected credential was rejected; a `403`
+means the client, version, signature, or source address was denied. Both are
+terminal for the current process so a broken instance cannot keep looping or
+downgrade from a rejected personal key to the shared key.
+
+Correct the key or update Library Manager, then restart the app. A `429` is
+temporary: wait for the displayed `Retry-After` interval instead of repeatedly
+clicking Search or restarting.
+
 ## Database locked or worker stuck
 
 Stop overlapping scans/process requests and allow the current worker to finish. Restart if the lock persists, then inspect the first error in the logs. Keep one active worker per data directory.


### PR DESCRIPTION
## Summary

- complete the maintained beta.168 guidance across README, changelog, Configuration, FAQ, Installation, How It Works, Troubleshooting, and release workflow
- document exact shared, personal, upload, and GPU quota scopes
- scope terminal 401/403 handling to protected metadata/audio workflows, including restart/key-change reset and the Settings-validation exception
- document the self-hosted public-key requirement and server-first cross-repository rollout gate
- register the fresh beta.168 Settings screenshot

## Release context

Follow-up documentation audit for merged PR #309 and deployed Skaldleita PR deucebucket/skaldleita#184. A separate GitHub wiki update is prepared from an isolated clone and will be published after this PR merges.

## Verification

- claims checked against merged develop at 0d7b9aa and the paired Skaldleita implementation
- production Skaldleita health confirms beta.168 minimum and bundled access configured
- Markdown diff checks pass in the repository and isolated wiki clone
- independent review agent re-review requested at exact head 61e367f

No runtime code, configuration defaults, or secrets changed.