### PR TITLE
fix: verify video moves on Jellyfin 10.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Library Manager will be documented in this file.
 
-## [Unreleased]
+## [0.9.0-beta.169] - 2026-08-26
 
 ### Fixed
 - **#312: Jellyfin 10.11 exact video visibility** — Independent video-move

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Library Manager will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **#312: Jellyfin 10.11 exact video visibility** — Independent video-move
+  verification no longer relies on the removed `AnyProviderIdEquals` query parameter.
+  It enumerates only the configured destination library in bounded 200-item pages,
+  matches TMDb/IMDb identity locally, requires exactly one match, and fails closed on
+  malformed, duplicate, oversized, truncated, or unavailable observations.
+
 ## [0.9.0-beta.168] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Smart Audiobook Library Organizer with Multi-Source Metadata & AI Verification**
 
-[![Version](https://img.shields.io/badge/version-0.9.0--beta.168-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.0--beta.169-blue.svg)](CHANGELOG.md)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/deucebucket/library-manager)
 [![License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE)
 
@@ -15,6 +15,14 @@
 ---
 
 ## Recent Changes (develop / beta)
+
+> **beta.169** - **Jellyfin 10.11 exact video verification**
+> - Replaces Jellyfin's removed provider-ID query with a bounded scan of only the
+>   configured destination library.
+> - Requires exactly one matching TMDb/IMDb identity and fails closed on duplicate,
+>   malformed, inconsistent, truncated, unavailable, or over-10,000-item results.
+> - Keeps the video-move receipt free of titles, paths, URLs, credentials, and household
+>   identity; no mutation contract changed.
 
 > **beta.168** - **Safe no-signup Skaldleita access**
 > - Uses the bundled, per-IP-limited shared key when no personal Skaldleita key is configured.

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ Features:
 - Multi-provider AI (Gemini, OpenRouter, Ollama, OpenAI-compatible APIs)
 """
 
-APP_VERSION = "0.9.0-beta.168"
+APP_VERSION = "0.9.0-beta.169"
 GITHUB_REPO = "deucebucket/library-manager"  # Your GitHub repo
 
 # Versioning Guide:

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -44,7 +44,7 @@ Library Manager automatically fixes messy audiobook folder names using real book
 - Verified watch-folder pre-sort for multi-book splits, multipart folder merges, and redundant nesting
 - Web dashboard
 
-The develop branch currently reports beta.168. Skaldleita works without signup through a heavily per-IP-limited shared key, while signed client/version policy keeps blocked or outdated instances denied before either shared or personal key authorization. The #292/#298 pre-sort and beta.161 #300 apply-fix flows retain exact, hash-verified transfer and rollback receipts. These controls improve auditability but are not a substitute for filesystem or hardware backups.
+The develop branch currently reports beta.169. Exact Jellyfin 10.11 video-move verification now scans only the configured destination library with a bounded exact-identity check instead of relying on a removed server-side provider filter. Skaldleita works without signup through a heavily per-IP-limited shared key, while signed client/version policy keeps blocked or outdated instances denied before either shared or personal key authorization. The #292/#298 pre-sort and beta.161 #300 apply-fix flows retain exact, hash-verified transfer and rollback receipts. These controls improve auditability but are not a substitute for filesystem or hardware backups.
 
 ![Verified pre-sort review](images/presort-review.png)
 

--- a/library_manager/video/adapters.py
+++ b/library_manager/video/adapters.py
@@ -15,6 +15,8 @@ from library_manager.video.organize import PlaybackObservation
 
 
 DEFAULT_TIMEOUT = (5, 900)
+JELLYFIN_PAGE_SIZE = 200
+JELLYFIN_MAX_LIBRARY_ITEMS = 10_000
 
 
 def _within(path: str, root: str) -> bool:
@@ -115,28 +117,51 @@ class JellyfinVisibilityAdapter:
             return False
 
         def verify() -> bool:
-            try:
-                response = self.session.get(
-                    f"{self.url}/Items",
-                    headers={"X-Emby-Token": self.api_key},
-                    params={"ParentId": library_ref, "Recursive": "true",
-                            "IncludeItemTypes": "Movie", "Fields": "ProviderIds",
-                            "AnyProviderIdEquals": f"{key}.{provider_id}",
-                            "Limit": 10},
-                    timeout=(5, 45))
-                response.raise_for_status()
-                payload = response.json()
-            except (requests.RequestException, ValueError):
-                return False
-            items = payload.get("Items") if isinstance(payload, dict) else None
-            if not isinstance(items, list):
-                return False
             matches = []
-            for item in items:
-                provider_ids = item.get("ProviderIds") if isinstance(item, dict) else None
-                if (isinstance(provider_ids, dict)
-                        and str(provider_ids.get(key) or "") == str(provider_id)):
-                    matches.append(item)
+            start = 0
+            expected_total = None
+            while start < JELLYFIN_MAX_LIBRARY_ITEMS:
+                try:
+                    response = self.session.get(
+                        f"{self.url}/Items",
+                        headers={"X-Emby-Token": self.api_key},
+                        params={"ParentId": library_ref, "Recursive": "true",
+                                "IncludeItemTypes": "Movie", "Fields": "ProviderIds",
+                                "StartIndex": start, "Limit": JELLYFIN_PAGE_SIZE},
+                        timeout=(5, 45))
+                    response.raise_for_status()
+                    payload = response.json()
+                except (requests.RequestException, ValueError):
+                    return False
+                items = payload.get("Items") if isinstance(payload, dict) else None
+                total = payload.get("TotalRecordCount") if isinstance(payload, dict) else None
+                if (not isinstance(items, list)
+                        or len(items) > JELLYFIN_PAGE_SIZE
+                        or not isinstance(total, int) or isinstance(total, bool)
+                        or total < 0 or total > JELLYFIN_MAX_LIBRARY_ITEMS
+                        or start > total
+                        or start + len(items) > total
+                        or (expected_total is not None and total != expected_total)
+                        or (not items and start < total)):
+                    return False
+                expected_total = total
+                for item in items:
+                    if not isinstance(item, dict):
+                        return False
+                    provider_ids = item.get("ProviderIds")
+                    if provider_ids is None:
+                        continue
+                    if not isinstance(provider_ids, dict):
+                        return False
+                    if str(provider_ids.get(key) or "") == str(provider_id):
+                        matches.append(item)
+                        if len(matches) > 1:
+                            return False
+                start += len(items)
+                if start >= total:
+                    break
+            else:
+                return False
             return len(matches) == 1
 
         return await asyncio.to_thread(verify)

--- a/test-env/test-video-adapters.py
+++ b/test-env/test-video-adapters.py
@@ -54,12 +54,14 @@ class RadarrSession:
 
 class JellyfinSession:
     def __init__(self, *, duplicate=False, malformed=False, malformed_identity=False,
-                 sessions=None, status=200):
+                 sessions=None, status=200, unrelated=0, total_override=None):
         self.duplicate = duplicate
         self.malformed = malformed
         self.malformed_identity = malformed_identity
         self.status = status
         self.sessions = sessions
+        self.unrelated = unrelated
+        self.total_override = total_override
         self.calls = []
 
     def get(self, url, **kwargs):
@@ -68,11 +70,19 @@ class JellyfinSession:
             return Response(self.sessions, self.status)
         if self.malformed:
             return Response({"Items": "not-a-list"}, self.status)
-        items = [{"Id": "one", "ProviderIds": (
-            [] if self.malformed_identity else {"Tmdb": "123"})}]
+        items = [
+            {"Id": f"unrelated-{index}", "ProviderIds": {"Tmdb": str(index + 1000)}}
+            for index in range(self.unrelated)
+        ]
+        items.append({"Id": "one", "ProviderIds": (
+            [] if self.malformed_identity else {"Tmdb": "123"})})
         if self.duplicate:
             items.append({"Id": "two", "ProviderIds": {"Tmdb": "123"}})
-        return Response({"Items": items}, self.status)
+        start = kwargs["params"]["StartIndex"]
+        limit = kwargs["params"]["Limit"]
+        total = len(items) if self.total_override is None else self.total_override
+        return Response({"Items": items[start:start + limit],
+                         "TotalRecordCount": total}, self.status)
 
 
 def test_radarr_move_and_readback():
@@ -101,8 +111,16 @@ def test_jellyfin_exact_library_identity():
     _, call = session.calls[0]
     assert call["headers"] == {"X-Emby-Token": "secret"}
     assert call["params"]["ParentId"] == "documentary-library"
-    assert call["params"]["AnyProviderIdEquals"] == "Tmdb.123"
+    assert "AnyProviderIdEquals" not in call["params"]
+    assert call["params"]["StartIndex"] == 0
+    assert call["params"]["Limit"] == 200
     assert call["params"]["IncludeItemTypes"] == "Movie"
+
+    paged_session = JellyfinSession(unrelated=200)
+    paged = JellyfinVisibilityAdapter(
+        "http://jellyfin.invalid", "secret", session=paged_session)
+    assert asyncio.run(paged.visible_in("tmdb", "123", "documentary-library"))
+    assert [call[1]["params"]["StartIndex"] for call in paged_session.calls] == [0, 200]
 
     duplicate = JellyfinVisibilityAdapter(
         "http://jellyfin.invalid", "secret", session=JellyfinSession(duplicate=True))
@@ -113,11 +131,24 @@ def test_jellyfin_exact_library_identity():
         session=JellyfinSession(malformed_identity=True))
     unavailable = JellyfinVisibilityAdapter(
         "http://jellyfin.invalid", "secret", session=JellyfinSession(status=503))
+    oversized = JellyfinVisibilityAdapter(
+        "http://jellyfin.invalid", "secret",
+        session=JellyfinSession(total_override=10_001))
+    inconsistent = JellyfinVisibilityAdapter(
+        "http://jellyfin.invalid", "secret",
+        session=JellyfinSession(total_override=0))
+    truncated = JellyfinVisibilityAdapter(
+        "http://jellyfin.invalid", "secret",
+        session=JellyfinSession(total_override=201))
     assert not asyncio.run(duplicate.visible_in("tmdb", "123", "documentary-library"))
     assert not asyncio.run(malformed.visible_in("tmdb", "123", "documentary-library"))
     assert not asyncio.run(malformed_identity.visible_in(
         "tmdb", "123", "documentary-library"))
     assert not asyncio.run(unavailable.visible_in("tmdb", "123", "documentary-library"))
+    assert not asyncio.run(oversized.visible_in("tmdb", "123", "documentary-library"))
+    assert not asyncio.run(inconsistent.visible_in(
+        "tmdb", "123", "documentary-library"))
+    assert not asyncio.run(truncated.visible_in("tmdb", "123", "documentary-library"))
     assert not asyncio.run(adapter.visible_in("tvdb", "123", "documentary-library"))
     print("[PASS] Jellyfin verification is exact-library, exact-provider, and fail-closed")
 


### PR DESCRIPTION
## Summary\n\nFixes #312. Jellyfin 10.11 removed/ignores the provider-id query used by the independent video-move verifier. The adapter now walks only the configured destination library in bounded 200-item pages, matches the exact TMDb/IMDb identity locally, and requires exactly one result.\n\n## Safety\n\n- 10,000-item hard ceiling\n- fail closed on duplicate, malformed, inconsistent, truncated, unavailable, or oversized observations\n- no title, path, URL, token, or household identity is persisted or logged\n- no mutation contract changed\n\n## Verification\n\n- `python3 test-env/test-video-adapters.py`\n- `python3 test-env/test-video-organization-service.py`\n- `.venv/bin/ruff check library_manager/video/adapters.py test-env/test-video-adapters.py`\n- `.venv/bin/python test-env/test-naming-issues.py` — 318/318\n- read-only live Jellyfin 10.11 probe: existing destination identity true, eligible source identities true and destination identities false\n\nThe prescribed repo-wide Ruff command still reports 193 pre-existing findings outside these files; focused changed-file Ruff is clean. No UI/config/package change, so screenshots, config examples, and Docker packaging are unchanged.